### PR TITLE
Ngfw 10097 capture prikey

### DIFF
--- a/captive-portal/hier/usr/lib/python2.7/tests/captive_portal_tests.py
+++ b/captive-portal/hier/usr/lib/python2.7/tests/captive_portal_tests.py
@@ -56,20 +56,20 @@ def createCaptureNonWanNicRule():
     };
 
 def createLocalDirectoryUser():
-    return {'javaClass': 'java.util.LinkedList', 
+    return {'javaClass': 'java.util.LinkedList',
         'list': [{
-            'username': localUserName, 
-            'firstName': '[firstName]', 
-            'lastName': '[lastName]', 
-            'javaClass': 'com.untangle.uvm.LocalDirectoryUser', 
-            'expirationTime': 0, 
-            'passwordBase64Hash': base64.b64encode('passwd'), 
+            'username': localUserName,
+            'firstName': '[firstName]',
+            'lastName': '[lastName]',
+            'javaClass': 'com.untangle.uvm.LocalDirectoryUser',
+            'expirationTime': 0,
+            'passwordBase64Hash': base64.b64encode('passwd'),
             'email': 'test20@example.com'
             },]
     }
 
 def removeLocalDirectoryUser():
-    return {'javaClass': 'java.util.LinkedList', 
+    return {'javaClass': 'java.util.LinkedList',
         'list': []
     }
 
@@ -87,11 +87,11 @@ def createDirectoryConnectorSettings():
             "superuserPass": AD_PASSWORD
        },
         "radiusSettings": {
-            "port": 1812, 
-            "enabled": False, 
-            "authenticationMethod": "PAP", 
-            "javaClass": "com.untangle.node.directory_connector.RadiusSettings", 
-            "server": radiusHost, 
+            "port": 1812,
+            "enabled": False,
+            "authenticationMethod": "PAP",
+            "javaClass": "com.untangle.node.directory_connector.RadiusSettings",
+            "server": radiusHost,
             "sharedSecret": "mysharedsecret"
         },
         "googleSettings": {
@@ -107,21 +107,21 @@ def createDirectoryConnectorSettings():
 def createRadiusSettings():
     return {
         "activeDirectorySettings": {
-            "enabled": False, 
-            "superuserPass": "passwd", 
-            "LDAPPort": "389", 
-            "OUFilter": "", 
-            "domain": "adtest.metaloft.com", 
-            "javaClass": "com.untangle.node.directory_connector.ActiveDirectorySettings", 
-            "LDAPHost": AD_HOST, 
+            "enabled": False,
+            "superuserPass": "passwd",
+            "LDAPPort": "389",
+            "OUFilter": "",
+            "domain": "adtest.metaloft.com",
+            "javaClass": "com.untangle.node.directory_connector.ActiveDirectorySettings",
+            "LDAPHost": AD_HOST,
             "superuser": AD_ADMIN
-        }, 
+        },
         "radiusSettings": {
-            "port": 1812, 
-            "enabled": True, 
-            "authenticationMethod": "PAP", 
-            "javaClass": "com.untangle.node.directory_connector.RadiusSettings", 
-            "server": radiusHost, 
+            "port": 1812,
+            "enabled": True,
+            "authenticationMethod": "PAP",
+            "javaClass": "com.untangle.node.directory_connector.RadiusSettings",
+            "server": radiusHost,
             "sharedSecret": "chakas"
         },
         "googleSettings": {
@@ -144,7 +144,7 @@ def findNameInHostTable (hostname='test'):
             break
     remote_control.runCommand("pkill netcat")
     return foundTestSession
-    
+
 def timeOfClientOff (timediff=60):
     # Check the time differential betwen the Untangle and client is less than 1 min.
     client_time = int(remote_control.runCommand("date +%s",stdout=True))
@@ -196,9 +196,9 @@ class CaptivePortalTests(unittest2.TestCase):
         # Create local directory user 'test20'
         uvmContext.localDirectory().setUsers(createLocalDirectoryUser())
         # Get the IP address of test.untangle.com
-        test_untangle_com_ip = socket.gethostbyname("test.untangle.com")   
+        test_untangle_com_ip = socket.gethostbyname("test.untangle.com")
         captureIP = system_properties.findInterfaceIPbyIP(remote_control.clientIP)
-        
+
         # remove previous temp files
         remote_control.runCommand("rm -f /tmp/capture_test_*")
 
@@ -229,18 +229,18 @@ class CaptivePortalTests(unittest2.TestCase):
                                             'captive_portal_blocked', True )
         assert( found )
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_021b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_021b.out")
         assert (search == 0)
-        
+
     def test_022_webFilterAffinityCheck(self):
         global node, nodeData, nodeWeb
         nodeData['captureRules']['list'] = []
         nodeData['captureRules']['list'].append(createCaptureNonWanNicRule())
         node.setSettings(nodeData)
- 
+
         newRule = { "blocked": True, "description": "test.untangle.com", "flagged": True, "javaClass": "com.untangle.uvm.node.GenericRule", "string": "test.untangle.com" }
         rules_orig = nodeWeb.getBlockedUrls()
         rules = copy.deepcopy(rules_orig)
@@ -254,7 +254,7 @@ class CaptivePortalTests(unittest2.TestCase):
         assert (search == 0)
 
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         nodeWeb.setBlockedUrls(rules_orig)
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_022b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
@@ -285,9 +285,9 @@ class CaptivePortalTests(unittest2.TestCase):
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_023a.out")
         assert (search == 0)
-        
+
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_023b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_023b.out")
@@ -317,7 +317,7 @@ class CaptivePortalTests(unittest2.TestCase):
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_024a.out")
         assert (search == 0)
-        
+
         # Wait for captive timeout
         time.sleep(20)
         node.runCleanup() # run the periodic cleanup task to remove expired users
@@ -351,9 +351,9 @@ class CaptivePortalTests(unittest2.TestCase):
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_025a.out")
         assert (search == 0)
-        
+
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_025b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_025b.out")
@@ -376,7 +376,7 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'username and password' /tmp/capture_test_030.out")
         assert (search == 0)
 
-        # check if local directory login and password 
+        # check if local directory login and password
         appid = str(node.getNodeSettings()["id"])
         # print 'appid is %s' % appid  # debug line
         result = remote_control.runCommand("wget -O /tmp/capture_test_030a.out  \'http://" + captureIP + "/capture/handler.py/authpost?username=" + localUserName + "&password=passwd&nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\'")
@@ -384,16 +384,16 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_030a.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(localUserName)
-        assert(foundUsername)        
+        assert(foundUsername)
 
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_030b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_030b.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(localUserName)
-        assert(not foundUsername)        
+        assert(not foundUsername)
 
     def test_031_loginAny(self):
         global node, nodeData
@@ -412,7 +412,7 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'username and password' /tmp/capture_test_030.out")
         assert (search == 0)
 
-        # check if local directory login and password 
+        # check if local directory login and password
         appid = str(node.getNodeSettings()["id"])
         # print 'appid is %s' % appid  # debug line
         result = remote_control.runCommand("wget -O /tmp/capture_test_030a.out  \'http://" + captureIP + "/capture/handler.py/authpost?username=" + localUserName + "&password=passwd&nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\'")
@@ -420,16 +420,16 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_030a.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(localUserName)
-        assert(foundUsername)        
+        assert(foundUsername)
 
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_030b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_030b.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(localUserName)
-        assert(not foundUsername)        
+        assert(not foundUsername)
 
     def test_032_loginGoogle(self):
         if platform.machine().startswith('arm'):
@@ -443,7 +443,7 @@ class CaptivePortalTests(unittest2.TestCase):
         print "username: %s\n " % str(googleUserName)
         if googlePassword != None:
             print "password: %s\n" % (len(googlePassword)*"*")
-        
+
         # account not found if message returned
         if googleUserName == "message":
             raise unittest2.SkipTest(googlePassword)
@@ -457,14 +457,14 @@ class CaptivePortalTests(unittest2.TestCase):
 
         # Configure Directory Connector
         nodeAD.setSettings(createDirectoryConnectorSettings())
-        
+
         # check that basic captive page is shown
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_032.out http://test.untangle.com/")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'username and password' /tmp/capture_test_032.out")
         assert (search == 0)
 
-        # check if local directory login and password 
+        # check if local directory login and password
         appid = str(node.getNodeSettings()["id"])
         # print 'appid is %s' % appid  # debug line
         result = remote_control.runCommand("wget -O /tmp/capture_test_032a.out  \'http://" + captureIP + "/capture/handler.py/authpost?username=" + googleUserName + "&password=" + googlePassword + "&nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\'")
@@ -472,16 +472,16 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_032a.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(googleUserName)
-        assert(foundUsername)        
+        assert(foundUsername)
 
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_030b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_030b.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(googleUserName)
-        assert(not foundUsername)        
+        assert(not foundUsername)
 
     def test_033_loginFacebook(self):
         if platform.machine().startswith('arm'):
@@ -491,7 +491,7 @@ class CaptivePortalTests(unittest2.TestCase):
         print "username: %s\n " % str(facebookUserName)
         if facebookPassword != None:
             print "password: %s\n" % (len(facebookPassword)*"*")
-        
+
         # account not found if message returned
         if facebookUserName == "message":
             raise unittest2.SkipTest(facebookPassword)
@@ -505,14 +505,14 @@ class CaptivePortalTests(unittest2.TestCase):
 
         # Configure Directory Connector
         nodeAD.setSettings(createDirectoryConnectorSettings())
-        
+
         # check that basic captive page is shown
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_032.out http://test.untangle.com/")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'username and password' /tmp/capture_test_032.out")
         assert (search == 0)
 
-        # check if local directory login and password 
+        # check if local directory login and password
         appid = str(node.getNodeSettings()["id"])
         # print 'appid is %s' % appid  # debug line
         result = remote_control.runCommand("wget -O /tmp/capture_test_032a.out  \'http://" + captureIP + "/capture/handler.py/authpost?username=" + facebookUserName + "&password=" + facebookPassword + "&nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\'")
@@ -520,17 +520,17 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_032a.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(facebookUserName)
-        assert(foundUsername)        
+        assert(foundUsername)
 
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_030b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_030b.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(facebookUserName)
-        assert(not foundUsername)        
-        
+        assert(not foundUsername)
+
     def test_035_loginActiveDirectory(self):
         global nodeData, node, nodeDataAD, nodeAD, captureIP
         if (adResult != 0):
@@ -554,7 +554,7 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'username and password' /tmp/capture_test_035.out")
         assert (search == 0)
 
-        # check if AD login and password 
+        # check if AD login and password
         appid = str(node.getNodeSettings()["id"])
         # print 'appid is %s' % appid  # debug line
         result = remote_control.runCommand("wget -O /tmp/capture_test_035a.out  \'http://" + captureIP + "/capture/handler.py/authpost?username=" + adUserName + "&password=passwd&nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\'")
@@ -562,27 +562,27 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_035a.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(adUserName)
-        assert(foundUsername)        
+        assert(foundUsername)
 
-        # logout 
+        # logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_035b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_035b.out")
         assert (search == 0)
-        # try second time to login, 
+        # try second time to login,
         result = remote_control.runCommand("wget -O /tmp/capture_test_035c.out  \'http://" + captureIP + "/capture/handler.py/authpost?username=" + adUserName + "&password=passwd&nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\'")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_035c.out")
         assert (search == 0)
 
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_035d.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_035d.out")
         assert (search == 0)
         foundUsername = findNameInHostTable(adUserName)
-        assert(not foundUsername)        
+        assert(not foundUsername)
 
         # check extend ascii in login and password bug 10860
         result = remote_control.runCommand("wget -O /tmp/capture_test_035e.out  \'http://" + captureIP + "/capture/handler.py/authpost?username=britishguy&password=passwd%C2%A3&nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\'")
@@ -596,7 +596,7 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_035f.out")
         assert (search == 0)
 
-        
+
     def test_040_loginRadius(self):
         global nodeData, node, nodeDataRD, nodeDataAD, nodeAD, captureIP
         if (radiusResult != 0):
@@ -627,7 +627,7 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'username' /tmp/capture_test_040.out")
         assert (search == 0)
 
-        # check if RADIUS login and password 
+        # check if RADIUS login and password
         appid = str(node.getNodeSettings()["id"])
         # print 'appid is %s' % appid  # debug line
         result = remote_control.runCommand("wget -O /tmp/capture_test_040a.out  \'http://" + captureIP + "/capture/handler.py/authpost?username=normal&password=passwd&nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\'",stdout=True)
@@ -635,7 +635,7 @@ class CaptivePortalTests(unittest2.TestCase):
         assert (search == 0)
 
         # logout user to clean up test.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_040b.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_040b.out")
@@ -649,7 +649,7 @@ class CaptivePortalTests(unittest2.TestCase):
         assert (search == 0)
 
         # logout user to clean up test a second time.
-        # wget http://<internal IP>/capture/logout  
+        # wget http://<internal IP>/capture/logout
         result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_040d.out http://" + captureIP + "/capture/logout")
         assert (result == 0)
         search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_040d.out")
@@ -684,7 +684,7 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'username and password' " + capture_file_name)
         assert (search == 0)
 
-        # check if local directory login and password 
+        # check if local directory login and password
         appid = str(node.getNodeSettings()["id"])
 
         # connect and auth to get cookie
@@ -710,7 +710,7 @@ class CaptivePortalTests(unittest2.TestCase):
         assert (search == 0)
 
         foundUsername = findNameInHostTable(localUserName)
-        assert(foundUsername)        
+        assert(foundUsername)
 
         # Wait for captive timeout
         time.sleep(20)
@@ -725,7 +725,7 @@ class CaptivePortalTests(unittest2.TestCase):
             raise unittest2.SkipTest('Skipping a time consuming test')
         if timeOfClientOff():
             raise unittest2.SkipTest('Client time different than Untangle server')
-            
+
         # variable for local test
         capture_file_name = "/tmp/capture_test_051.out"
         cookie_file_name = "/tmp/capture_test_051_cookie.txt"
@@ -748,7 +748,7 @@ class CaptivePortalTests(unittest2.TestCase):
         search = remote_control.runCommand("grep -q 'username and password' " + capture_file_name)
         assert (search == 0)
 
-        # check if local directory login and password 
+        # check if local directory login and password
         appid = str(node.getNodeSettings()["id"])
 
         # connect and auth to get cookie
@@ -794,7 +794,7 @@ class CaptivePortalTests(unittest2.TestCase):
         nodeData['userTimeout'] = 3600
         node.setSettings(nodeData)
 
-        # # check if local directory login and password 
+        # # check if local directory login and password
         appid = str(node.getNodeSettings()["id"])
 
         result = remote_control.runCommand("wget -O " + capture_file_name + "  \'http://" + captureIP + "/capture/handler.py/index?nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\' --load-cookies " + savedCookieFileName)
@@ -804,7 +804,44 @@ class CaptivePortalTests(unittest2.TestCase):
         assert (search == 1)
 
         foundUsername = findNameInHostTable(localUserName)
-        assert(foundUsername == False)        
+        assert(foundUsername == False)
+
+    def test_060_loginLocalDirectoryMacMode(self):
+        global node, nodeData
+
+        # Create Internal NIC capture rule with basic login page
+        nodeData['captureRules']['list'] = []
+        nodeData['captureRules']['list'].append(createCaptureNonWanNicRule())
+        nodeData['authenticationType']="LOCAL_DIRECTORY"
+        nodeData['pageType'] = "BASIC_LOGIN"
+        nodeData['userTimeout'] = 3600  # default
+        nodeData['useMacAddress'] = True
+        node.setSettings(nodeData)
+
+        # check that basic captive page is shown
+        result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_060.out http://test.untangle.com/")
+        assert (result == 0)
+        search = remote_control.runCommand("grep -q 'username and password' /tmp/capture_test_060.out")
+        assert (search == 0)
+
+        # check if local directory login and password
+        appid = str(node.getNodeSettings()["id"])
+        # print 'appid is %s' % appid  # debug line
+        result = remote_control.runCommand("wget -O /tmp/capture_test_060a.out  \'http://" + captureIP + "/capture/handler.py/authpost?username=" + localUserName + "&password=passwd&nonce=9abd7f2eb5ecd82b&method=GET&appid=" + appid + "&host=test.untangle.com&uri=/\'")
+        assert (result == 0)
+        search = remote_control.runCommand("grep -q 'Hi!' /tmp/capture_test_060a.out")
+        assert (search == 0)
+        foundUsername = findNameInHostTable(localUserName)
+        assert(foundUsername)
+
+        # logout user to clean up test.
+        # wget http://<internal IP>/capture/logout
+        result = remote_control.runCommand("wget -4 -t 2 --timeout=5 -O /tmp/capture_test_060b.out http://" + captureIP + "/capture/logout")
+        assert (result == 0)
+        search = remote_control.runCommand("grep -q 'logged out' /tmp/capture_test_060b.out")
+        assert (search == 0)
+        foundUsername = findNameInHostTable(localUserName)
+        assert(not foundUsername)
 
     @staticmethod
     def finalTearDown(self):

--- a/captive-portal/hier/usr/share/untangle/web/webui/script/untangle-node-captive-portal/settings.js
+++ b/captive-portal/hier/usr/share/untangle/web/webui/script/untangle-node-captive-portal/settings.js
@@ -88,6 +88,8 @@ Ext.define('Webui.untangle-node-captive-portal.settings', {
             },{
                 name: "userMacAddress"
             },{
+                name: "macLogin",
+            },{
                 name: "userName"
             },{
                 name: "sessionCreation"
@@ -106,6 +108,11 @@ Ext.define('Webui.untangle-node-captive-portal.settings', {
                 header: i18n._("MAC Address"),
                 dataIndex:'userMacAddress',
                 width: 200
+            },{
+                header: i18n._("Login Key"),
+                dataIndex: 'macLogin',
+                width: 120,
+                renderer: function(value) { return (value ? "MAC Address" : "IP Address"); }
             },{
                 header: i18n._("User Name"),
                 dataIndex:'userName',

--- a/captive-portal/hier/usr/share/untangle/web/webui/script/untangle-node-captive-portal/settings.js
+++ b/captive-portal/hier/usr/share/untangle/web/webui/script/untangle-node-captive-portal/settings.js
@@ -134,10 +134,21 @@ Ext.define('Webui.untangle-node-captive-portal.settings', {
                 iconCls: 'icon-delete-row',
                 tooltip: i18n._("Click to logout"),
                 handler: Ext.bind(function(view, rowIndex, colIndex, item, e, record) {
-                    this.getRpcNode().userAdminLogout(Ext.bind(function(result, exception) {
-                        if(Ung.Util.handleException(exception)) return;
-                        this.gridCaptiveStatus.reload();
-                    },this), record.get("userNetAddress"));
+
+                    var netaddr = record.get("userNetAddress");
+                    var macaddr = record.get("userMacAddress");
+
+                    if ( (this.settings.useMacAddress == true) && (macaddr != null) && (macaddr.length > 12) ) {
+                        this.getRpcNode().userAdminMacLogout(Ext.bind(function(result, exception) {
+                            if(Ung.Util.handleException(exception)) return;
+                            this.gridCaptiveStatus.reload();
+                        },this), macaddr);
+                    } else {
+                        this.getRpcNode().userAdminNetLogout(Ext.bind(function(result, exception) {
+                            if(Ung.Util.handleException(exception)) return;
+                            this.gridCaptiveStatus.reload();
+                        },this), netaddr);
+                    }
                 }, this)
             }]
         });

--- a/captive-portal/hier/usr/share/untangle/web/webui/script/untangle-node-captive-portal/settings.js
+++ b/captive-portal/hier/usr/share/untangle/web/webui/script/untangle-node-captive-portal/settings.js
@@ -83,8 +83,10 @@ Ext.define('Webui.untangle-node-captive-portal.settings', {
             dataFn: this.getRpcNode().getActiveUsers,
             recordJavaClass: "com.untangle.node.captive_portal.CaptureUserEntry",
             fields: [{
-                name: "userAddress",
+                name: "userNetAddress",
                 sortType: 'asIp'
+            },{
+                name: "userMacAddress"
             },{
                 name: "userName"
             },{
@@ -98,8 +100,12 @@ Ext.define('Webui.untangle-node-captive-portal.settings', {
             }],
             columns: [{
                 header: i18n._("IP Address"),
-                dataIndex:'userAddress',
+                dataIndex:'userNetAddress',
                 width: 150
+            },{
+                header: i18n._("MAC Address"),
+                dataIndex:'userMacAddress',
+                width: 200
             },{
                 header: i18n._("User Name"),
                 dataIndex:'userName',
@@ -131,7 +137,7 @@ Ext.define('Webui.untangle-node-captive-portal.settings', {
                     this.getRpcNode().userAdminLogout(Ext.bind(function(result, exception) {
                         if(Ung.Util.handleException(exception)) return;
                         this.gridCaptiveStatus.reload();
-                    },this), record.get("userAddress"));
+                    },this), record.get("userNetAddress"));
                 }, this)
             }]
         });
@@ -578,6 +584,17 @@ Ext.define('Webui.untangle-node-captive-portal.settings', {
                     listeners: {
                         "change": Ext.bind(function(elem, checked) {
                             this.settings.sessionCookiesEnabled = checked;
+                        }, this)
+                    }
+                },{
+                    xtype: "checkbox",
+                    boxLabel: i18n._("Track logins using MAC address"),
+                    tooltip: i18n._("This will allow client authentication to be tracked by MAC address instead of IP address."),
+                    hideLabel: true,
+                    checked: this.settings.useMacAddress,
+                    listeners: {
+                        "change": Ext.bind(function(elem, checked) {
+                            this.settings.useMacAddress = checked;
                         }, this)
                     }
                 },{

--- a/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalApp.java
+++ b/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalApp.java
@@ -119,8 +119,9 @@ public class CaptivePortalApp extends NodeBase
 // THIS IS FOR ECLIPSE - @formatter:on
 
     /**
-     * The UI components seem to automagically call getSettings and setSettings to handle the load and save stuff, so
-     * these functions just call our getCaptivePortalSettings and setCaptivePortalSettings functions.
+     * The UI components seem to automagically call getSettings and setSettings
+     * to handle the load and save stuff, so these functions just call our
+     * getCaptivePortalSettings and setCaptivePortalSettings functions.
      */
 
     public CaptivePortalSettings getSettings()
@@ -607,7 +608,6 @@ public class CaptivePortalApp extends NodeBase
 
     public int userAdminMacLogout(String macaddr)
     {
-
         CaptivePortalUserEntry user = captureUserTable.searchByMacAddress(macaddr);
 
         if (user == null) {
@@ -618,8 +618,8 @@ public class CaptivePortalApp extends NodeBase
         // remove from the user table
         captureUserTable.removeActiveMacUser(macaddr);
 
-        // call the session cleanup function passing the address of the
-        // user we just logged out to clean up any outstanding sessions
+        // call the session cleanup function passing the address from the MAC
+        // entry of the user we just logged out to clean up any outstanding sessions
         HostTableEntry entry = UvmContextFactory.context().hostTable().findHostTableEntry(macaddr);
         validateAllSessions(entry.getAddress());
 
@@ -772,12 +772,31 @@ public class CaptivePortalApp extends NodeBase
             long currentTime = System.currentTimeMillis();
 
             /**
-             * Insert all the non-expired users into the table. Since the untangle-vm has likely been down, don't check
-             * idle timeout
+             * Insert all the non-expired users into the table. Since the
+             * untangle-vm has likely been down, don't check idle timeout
              */
             for (CaptivePortalUserEntry user : users) {
                 long userTrigger = (user.getSessionCreation() + (userTimeout * 1000));
-                if (currentTime > userTrigger) continue;
+
+                /**
+                 * If we aren't loading this expired user we need to clear our
+                 * username and authenticated fields in the HostTable
+                 */
+                if (currentTime > userTrigger) {
+                    HostTableEntry entry;
+
+                    if (user.getMacLogin()) {
+                        entry = UvmContextFactory.context().hostTable().findHostTableEntry(user.getUserMacAddress());
+                    } else {
+                        entry = UvmContextFactory.context().hostTable().getHostTableEntry(user.getUserNetAddress());
+                    }
+
+                    if (entry != null) {
+                        entry.setUsernameCapture(null);
+                        entry.setCaptivePortalAuthenticated(false);
+                    }
+                    continue;
+                }
 
                 captureUserTable.insertActiveUser(user);
                 usersLoaded++;
@@ -796,8 +815,8 @@ public class CaptivePortalApp extends NodeBase
     }
 
     /**
-     * This method saves the current user state in a file in conf/ This is so we preserve user login state on
-     * untangle-vm or server reboots
+     * This method saves the current user state in a file in conf/ This is so we
+     * preserve user login state on untangle-vm or server reboots
      */
     private void saveUserState()
     {
@@ -853,8 +872,8 @@ public class CaptivePortalApp extends NodeBase
             tempStream.close();
 
             /*
-             * make sure we have a valid zip file and check the contents to see if there is either a custom.html or
-             * custom.py script
+             * make sure we have a valid zip file and check the contents to see
+             * if there is either a custom.html or custom.py script
              */
             try {
                 int checker = 0;
@@ -887,8 +906,9 @@ public class CaptivePortalApp extends NodeBase
             }
 
             /*
-             * We seem to have a good ZIP archive and it contains the files we expect so clean up any existing custom
-             * page that may already exist and extract the file into our custom directory
+             * We seem to have a good ZIP archive and it contains the files we
+             * expect so clean up any existing custom page that may already
+             * exist and extract the file into our custom directory
              */
             UvmContextFactory.context().execManager().exec(CAPTURE_CUSTOM_REMOVE_SCRIPT + " " + customPath);
             UvmContextFactory.context().execManager().exec(CAPTURE_CUSTOM_CREATE_SCRIPT + " " + customPath);
@@ -900,7 +920,7 @@ public class CaptivePortalApp extends NodeBase
 
         private ExecManagerResult handleFileRemove() throws Exception
         {
-            // use our existing remove and create scripts to wipe any existing custom page 
+            // use our existing remove and create scripts to wipe any existing custom page
             UvmContextFactory.context().execManager().exec(CAPTURE_CUSTOM_REMOVE_SCRIPT + " " + customPath);
             UvmContextFactory.context().execManager().exec(CAPTURE_CUSTOM_CREATE_SCRIPT + " " + customPath);
             return new ExecManagerResult(0, "The custom captive portal page has been removed");
@@ -915,11 +935,12 @@ public class CaptivePortalApp extends NodeBase
         }
 
         /**
-         * This hook is called when a host is removed from the host table. If the user is logged into captive portal the
-         * host table entry should never be removed.
+         * This hook is called when a host is removed from the host table. If
+         * the user is logged into captive portal the host table entry should
+         * never be removed.
          * 
-         * However it is removed if the MAC address changes (a different host) or something drastic occurs. In this case
-         * we should log the host out.
+         * However it is removed if the MAC address changes (a different host)
+         * or something drastic occurs. In this case we should log the host out.
          */
         public void callback(Object o)
         {

--- a/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalApp.java
+++ b/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalApp.java
@@ -84,8 +84,8 @@ public class CaptivePortalApp extends NodeBase
     private final String settingsFile = (System.getProperty("uvm.settings.dir") + "/untangle-node-captive-portal/settings_" + getNodeSettings().getId().toString()) + ".js";
     private final String customPath = (System.getProperty("uvm.web.dir") + "/capture/custom_" + getNodeSettings().getId().toString());
 
-    protected CaptivePortalUserTable captureUserTable = new CaptivePortalUserTable();
     protected CaptivePortalUserCookieTable captureUserCookieTable = new CaptivePortalUserCookieTable();
+    protected CaptivePortalUserTable captureUserTable;
     private CaptivePortalSettings captureSettings;
     private CaptivePortalTimer captureTimer;
     private Timer timer;
@@ -97,6 +97,7 @@ public class CaptivePortalApp extends NodeBase
     {
         super( nodeSettings, nodeProperties );
 
+        captureUserTable = new CaptivePortalUserTable(this);
         replacementGenerator = new CaptivePortalReplacementGenerator(getNodeSettings(),this);
 
         UvmContextFactory.context().servletFileManager().registerUploadHandler(new CustomPageUploadHandler());
@@ -330,7 +331,7 @@ public class CaptivePortalApp extends NodeBase
     }
 
     @Override
-    protected void preStart( boolean isPermanentTransition )
+    protected void preStart(boolean isPermanentTransition)
     {
         // load user state from file (if exists)
         loadUserState();
@@ -343,26 +344,26 @@ public class CaptivePortalApp extends NodeBase
     }
 
     @Override
-    protected void postStart( boolean isPermanentTransition )
+    protected void postStart(boolean isPermanentTransition)
     {
         logger.debug("Creating session cleanup timer task");
         captureTimer = new CaptivePortalTimer(this);
         timer = new Timer();
         timer.schedule(captureTimer, CLEANUP_INTERVAL, CLEANUP_INTERVAL);
 
-        UvmContextFactory.context().hookManager().registerCallback( com.untangle.uvm.HookManager.HOST_TABLE_REMOVE, this.hostRemovedCallback );
+        UvmContextFactory.context().hookManager().registerCallback(com.untangle.uvm.HookManager.HOST_TABLE_REMOVE, this.hostRemovedCallback);
     }
 
     @Override
-    protected void preStop( boolean isPermanentTransition )
+    protected void preStop(boolean isPermanentTransition)
     {
         // stop the session cleanup timer thread
         logger.debug("Destroying session cleanup timer task");
         timer.cancel();
 
         // unregister hook
-        UvmContextFactory.context().hookManager().unregisterCallback( com.untangle.uvm.HookManager.HOST_TABLE_REMOVE, this.hostRemovedCallback );
-        
+        UvmContextFactory.context().hookManager().unregisterCallback(com.untangle.uvm.HookManager.HOST_TABLE_REMOVE, this.hostRemovedCallback);
+
         // shutdown any active sessions
         killAllSessions();
 
@@ -375,7 +376,7 @@ public class CaptivePortalApp extends NodeBase
     }
 
     @Override
-    protected void postStop( boolean isPermanentTransition )
+    protected void postStop(boolean isPermanentTransition)
     {
     }
 
@@ -440,11 +441,11 @@ public class CaptivePortalApp extends NodeBase
             // when concurrent logins are disabled and we have an active entry for the user
             // we check the address and ignore the match if they are the same since it's
             // not really a concurrent login but a duplicate login from the same client
-            if ((entry != null) && (address.equals(entry.getUserAddress()) == false)) {
-                CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address, username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.FAILED);
+            if ((entry != null) && (address.equals(entry.getUserNetAddress()) == false)) {
+                CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address.getHostAddress().toString(), username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.FAILED);
                 logEvent(event);
                 incrementBlinger(BlingerType.AUTHFAIL, 1);
-                logger.info("Authenticate duplicate " + username + " " + address);
+                logger.info("Authenticate duplicate " + username + " " + address.getHostAddress().toString());
                 return (2);
             }
         }
@@ -537,38 +538,38 @@ public class CaptivePortalApp extends NodeBase
         }
 
         if (!isAuthenticated) {
-            CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address, username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.FAILED);
+            CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address.getHostAddress().toString(), username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.FAILED);
             logEvent(event);
             incrementBlinger(BlingerType.AUTHFAIL, 1);
-            logger.info("Authenticate failure " + username + " " + address);
+            logger.info("Authenticate failure " + username + " " + address.getHostAddress().toString());
             return (1);
         }
 
         captureUserTable.insertActiveUser(address, username, false);
 
-        CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address, username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.LOGIN);
+        CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address.getHostAddress().toString(), username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.LOGIN);
         logEvent(event);
         incrementBlinger(BlingerType.AUTHGOOD, 1);
-        logger.info("Authenticate success " + username + " " + address);
+        logger.info("Authenticate success " + username + " " + address.getHostAddress().toString());
         return (0);
     }
 
     public int userActivate(InetAddress address, String username, String agree, boolean anonymous)
     {
         if (agree.equals("agree") == false) {
-            CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address, username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.FAILED);
+            CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address.getHostAddress().toString(), username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.FAILED);
             logEvent(event);
             incrementBlinger(BlingerType.AUTHFAIL, 1);
-            logger.info("Activate failure " + address);
+            logger.info("Activate failure " + address.getHostAddress().toString());
             return (1);
         }
 
         captureUserTable.insertActiveUser(address, username, anonymous);
 
-        CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address, username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.LOGIN);
+        CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address.getHostAddress().toString(), username, captureSettings.getAuthenticationType(), CaptivePortalUserEvent.EventType.LOGIN);
         logEvent(event);
         incrementBlinger(BlingerType.AUTHGOOD, 1);
-        logger.info("Activate success " + address);
+        logger.info("Activate success " + address.getHostAddress().toString());
 
         if (captureSettings.getSessionCookiesEnabled()) {
             captureUserCookieTable.removeActiveUser(address);
@@ -586,10 +587,10 @@ public class CaptivePortalApp extends NodeBase
     {
         captureUserTable.insertActiveUser(address, username, false);
 
-        CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address, username, CaptivePortalSettings.AuthenticationType.CUSTOM, CaptivePortalUserEvent.EventType.LOGIN);
+        CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, address.getHostAddress().toString(), username, CaptivePortalSettings.AuthenticationType.CUSTOM, CaptivePortalUserEvent.EventType.LOGIN);
         logEvent(event);
         incrementBlinger(BlingerType.AUTHGOOD, 1);
-        logger.info("Login success " + address);
+        logger.info("Login success " + address.getHostAddress().toString());
         return (0);
     }
 
@@ -608,7 +609,7 @@ public class CaptivePortalApp extends NodeBase
         CaptivePortalUserEntry user = captureUserTable.searchByAddress(address);
 
         if (user == null) {
-            logger.info("Logout failure: " + address);
+            logger.info("Logout failure: " + address.getHostAddress().toString());
             return (1);
         }
 
@@ -619,9 +620,9 @@ public class CaptivePortalApp extends NodeBase
         // user we just logged out to clean up any outstanding sessions
         validateAllSessions(address);
 
-        CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, user.getUserAddress(), user.getUserName(), captureSettings.getAuthenticationType(), reason);
+        CaptivePortalUserEvent event = new CaptivePortalUserEvent(policyId, user.getUserNetAddress().getHostAddress().toString(), user.getUserName(), captureSettings.getAuthenticationType(), reason);
         logEvent(event);
-        logger.info("Logout success: " + address);
+        logger.info("Logout success: " + address.getHostAddress().toString());
 
         if (captureSettings.getSessionCookiesEnabled() && ((reason == CaptivePortalUserEvent.EventType.USER_LOGOUT) || (reason == CaptivePortalUserEvent.EventType.ADMIN_LOGOUT))) {
             captureUserCookieTable.insertInactiveUser(user);
@@ -885,22 +886,21 @@ public class CaptivePortalApp extends NodeBase
         }
 
         /**
-         * This hook is called when a host is removed from the host table.
-         * If the user is logged into captive portal the host table entry should never be removed.
-         *
-         * However it is removed if the MAC address changes (a different host) or something drastic occurs.
-         * In this case we should log the host out.
+         * This hook is called when a host is removed from the host table. If
+         * the user is logged into captive portal the host table entry should
+         * never be removed.
+         * 
+         * However it is removed if the MAC address changes (a different host)
+         * or something drastic occurs. In this case we should log the host out.
          */
-        public void callback( Object o )
+        public void callback(Object o)
         {
-            if ( !(o instanceof InetAddress) ) {
-                logger.warn( "Invalid argument: " + o );
-                    return;
+            if (!(o instanceof InetAddress)) {
+                logger.warn("Invalid argument: " + o);
+                return;
             }
             InetAddress addr = (InetAddress) o;
-            if ( isClientAuthenticated( addr ) )
-                userLogout( addr, CaptivePortalUserEvent.EventType.HOST_CHANGE );
+            if (isClientAuthenticated(addr)) userLogout(addr, CaptivePortalUserEvent.EventType.HOST_CHANGE);
         }
     }
-
 }

--- a/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalSettings.java
+++ b/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalSettings.java
@@ -36,6 +36,7 @@ public class CaptivePortalSettings implements Serializable
     private boolean areConcurrentLoginsEnabled = true;
     private boolean alwaysUseSecureCapture = false;
     private boolean sessionCookiesEnabled = false;
+    private boolean useMacAddress = false;
     private int sessionCookiesTimeout = 3600 * 24;
     private PageType pageType = PageType.BASIC_MESSAGE;
     private String customFileName = "";
@@ -127,6 +128,16 @@ public class CaptivePortalSettings implements Serializable
     public void setUserTimeout(int newValue)
     {
         this.userTimeout = newValue;
+    }
+
+    public boolean getUseMacAddress()
+    {
+        return this.useMacAddress;
+    }
+
+    public void setUseMacAddress(boolean newValue)
+    {
+        this.useMacAddress = newValue;
     }
 
     public boolean getConcurrentLoginsEnabled()

--- a/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalTimer.java
+++ b/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalTimer.java
@@ -31,7 +31,7 @@ public class CaptivePortalTimer extends TimerTask
             int counter = 0;
 
             for (CaptivePortalUserTable.StaleUser item : staleUsers) {
-                node.userLogout(item.address, item.reason);
+                node.userLogout(item.netaddr, item.reason);
                 counter++;
             }
 

--- a/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserCookieTable.java
+++ b/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserCookieTable.java
@@ -34,7 +34,7 @@ public class CaptivePortalUserCookieTable
 
     public CaptivePortalUserEntry insertInactiveUser( CaptivePortalUserEntry local )
     {
-        userTable.put(local.getUserAddress(), local);
+        userTable.put(local.getUserNetAddress(), local);
 
         return (local);
     }

--- a/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserEntry.java
+++ b/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserEntry.java
@@ -10,7 +10,8 @@ import java.net.InetAddress;
 @SuppressWarnings("serial")
 public class CaptivePortalUserEntry implements Serializable
 {
-    private InetAddress userAddress;
+    private InetAddress userNetAddress;
+    private String userMacAddress;
     private String userName;
     private Boolean isAnonymous;
     private long sessionCreation;
@@ -19,18 +20,22 @@ public class CaptivePortalUserEntry implements Serializable
 
     public CaptivePortalUserEntry() {}
     
-    public CaptivePortalUserEntry(InetAddress userAddress, String userName, Boolean isAnonymous)
+    public CaptivePortalUserEntry(InetAddress userNetAddress, String userMacAddress, String userName, Boolean isAnonymous)
     {
-        this.userAddress = userAddress;
+        this.userNetAddress = userNetAddress;
+        this.userMacAddress = userMacAddress;
         this.userName = userName;
         this.isAnonymous = isAnonymous;
         sessionCreation = System.currentTimeMillis();
         sessionActivity = sessionCreation;
     }
 
-    public InetAddress getUserAddress() { return userAddress; }
-    public void setUserAddress( InetAddress newValue ) { this.userAddress = newValue; }
-    
+    public InetAddress getUserNetAddress() { return userNetAddress; }
+    public void setUserNetAddress( InetAddress newValue ) { this.userNetAddress = newValue; }
+
+    public String getUserMacAddress() { return userMacAddress; }
+    public void setUserMacAddress( String newValue ) { this.userMacAddress = newValue; }
+
     public String getUserName() { return userName; }
     public void setUserName( String newValue ) { this.userName = newValue; }
 
@@ -50,5 +55,11 @@ public class CaptivePortalUserEntry implements Serializable
     {
         sessionActivity = System.currentTimeMillis();
         sessionCounter++;
+    }
+    
+    public String toString()
+    {
+        String local = ("ADDR:" + userNetAddress.getHostAddress().toString() + " MAC:" + userMacAddress + " NAME:" + userName); 
+        return(local);
     }
 }

--- a/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserEntry.java
+++ b/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserEntry.java
@@ -14,18 +14,20 @@ public class CaptivePortalUserEntry implements Serializable
     private String userMacAddress;
     private String userName;
     private Boolean isAnonymous;
+    private Boolean isMacLogin;
     private long sessionCreation;
     private long sessionActivity;
     private long sessionCounter;
 
     public CaptivePortalUserEntry() {}
-    
+
     public CaptivePortalUserEntry(InetAddress userNetAddress, String userMacAddress, String userName, Boolean isAnonymous)
     {
         this.userNetAddress = userNetAddress;
         this.userMacAddress = userMacAddress;
         this.userName = userName;
         this.isAnonymous = isAnonymous;
+        this.isMacLogin = false;
         sessionCreation = System.currentTimeMillis();
         sessionActivity = sessionCreation;
     }
@@ -38,6 +40,9 @@ public class CaptivePortalUserEntry implements Serializable
 
     public String getUserName() { return userName; }
     public void setUserName( String newValue ) { this.userName = newValue; }
+
+    public Boolean getMacLogin() { return isMacLogin; }
+    public void setMacLogin( Boolean newValue ) { this.isMacLogin = newValue; }
 
     public Boolean getAnonymous() { return isAnonymous; }
     public void setAnonymous( Boolean newValue ) { this.isAnonymous = newValue; }
@@ -56,10 +61,10 @@ public class CaptivePortalUserEntry implements Serializable
         sessionActivity = System.currentTimeMillis();
         sessionCounter++;
     }
-    
+
     public String toString()
     {
-        String local = ("ADDR:" + userNetAddress.getHostAddress().toString() + " MAC:" + userMacAddress + " NAME:" + userName); 
+        String local = ("ADDR:" + userNetAddress.getHostAddress().toString() + " MAC:" + userMacAddress + " NAME:" + userName);
         return(local);
     }
 }

--- a/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserEvent.java
+++ b/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserEvent.java
@@ -3,8 +3,6 @@
  */
 package com.untangle.node.captive_portal;
 
-import java.net.InetAddress;
-
 import com.untangle.node.captive_portal.CaptivePortalSettings.AuthenticationType;
 import com.untangle.uvm.logging.LogEvent;
 import com.untangle.uvm.util.I18nUtil;
@@ -17,7 +15,7 @@ public class CaptivePortalUserEvent extends LogEvent
         LOGIN, FAILED, TIMEOUT, INACTIVE, USER_LOGOUT, ADMIN_LOGOUT, HOST_CHANGE
     };
 
-    private InetAddress clientAddr;
+    private String clientAddr;
     private String loginName;
     private String authenticationTypeValue;
     private String eventValue;
@@ -27,7 +25,7 @@ public class CaptivePortalUserEvent extends LogEvent
     {
     }
 
-    public CaptivePortalUserEvent(Integer policyId, InetAddress clientAddr, String loginName, AuthenticationType type, EventType event)
+    public CaptivePortalUserEvent(Integer policyId, String clientAddr, String loginName, AuthenticationType type, EventType event)
     {
         setPolicyId(policyId);
         setClientAddr(clientAddr);
@@ -36,8 +34,8 @@ public class CaptivePortalUserEvent extends LogEvent
         setEvent(event);
     }
 
-    public InetAddress getClientAddr() { return clientAddr; }
-    public void setClientAddr(InetAddress clientAddr) { this.clientAddr = clientAddr; }
+    public String getClientAddr() { return clientAddr; }
+    public void setClientAddr(String clientAddr) { this.clientAddr = clientAddr; }
 
     public String getLoginName() { return loginName; }
     public void setLoginName(String loginName) { this.loginName = loginName; }
@@ -72,7 +70,7 @@ public class CaptivePortalUserEvent extends LogEvent
         pstmt.setString(++i, getLoginName());
         pstmt.setString(++i, getEvent().toString());
         pstmt.setString(++i, getAuthenticationTypeValue());
-        pstmt.setString(++i, getClientAddr().getHostAddress().toString());
+        pstmt.setString(++i, getClientAddr());
 
         pstmt.addBatch();
         return;
@@ -95,5 +93,4 @@ public class CaptivePortalUserEvent extends LogEvent
         String summary = "Captive Portal: " + I18nUtil.marktr("User") + " " + getLoginName() + " " + action;
         return summary;
     }
-
 }

--- a/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserTable.java
+++ b/captive-portal/src/com/untangle/node/captive_portal/CaptivePortalUserTable.java
@@ -60,7 +60,7 @@ public class CaptivePortalUserTable
     {
         String macaddr = null;
 
-        // do not pass the create flag here since it is passed in object insert call 
+        // do not pass the create flag here since it is passed in object insert call
         HostTableEntry entry = UvmContextFactory.context().hostTable().getHostTableEntry(netaddr);
         if (entry != null) macaddr = entry.getMacAddress();
 
@@ -72,9 +72,11 @@ public class CaptivePortalUserTable
     {
         if ((ownerApp.getSettings().getUseMacAddress()) && (local.getUserMacAddress() != null)) {
             logger.debug("INSERT MAC TABLE: " + local.toString());
+            local.setMacLogin(Boolean.TRUE);
             macAddrTable.put(local.getUserMacAddress(), local);
         } else {
             logger.debug("INSERT NET TABLE: " + local.toString());
+            local.setMacLogin(Boolean.FALSE);
             netAddrTable.put(local.getUserNetAddress(), local);
         }
 
@@ -124,7 +126,7 @@ public class CaptivePortalUserTable
         if (user == null) return (false);
 
         // clear the capture username from the host table entry and turn
-        // of the captive portal flag so it knows we are all done 
+        // of the captive portal flag so it knows we are all done
         entry.setUsernameCapture(null);
         entry.setCaptivePortalAuthenticated(false);
         return (true);

--- a/uvm/api/com/untangle/uvm/HostTable.java
+++ b/uvm/api/com/untangle/uvm/HostTable.java
@@ -30,6 +30,11 @@ public interface HostTable
     HostTableEntry getHostTableEntry( InetAddress addr, boolean create );
 
     /**
+     * Search for a HostTableEntry with specified MAC address 
+     */
+    HostTableEntry findHostTableEntry( String macaddr );
+
+    /**
      * return the "license size" (the number of hosts applicable to licensing)
      */
     int getCurrentActiveSize();
@@ -140,4 +145,3 @@ public interface HostTable
      */
     HostTableEntry removeHostTableEntry( InetAddress addr );
 }
-

--- a/uvm/impl/com/untangle/uvm/HostTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/HostTableImpl.java
@@ -124,6 +124,20 @@ public class HostTableImpl implements HostTable
 
         return entry;
     }
+
+    public HostTableEntry findHostTableEntry( String macaddr )
+    {
+        LinkedList<HostTableEntry> list = new LinkedList<HostTableEntry>(UvmContextFactory.context().hostTable().getHosts());
+
+        //  look for an entry with matching MAC address
+        for (Iterator<HostTableEntry> i = list.iterator(); i.hasNext(); ) {
+            HostTableEntry entry = i.next();
+            if (entry.getMacAddress() == null) continue;
+            if (entry.getMacAddress().equals(macaddr)) return(entry);
+        }
+
+        return(null);
+    }
     
     public void setHostTableEntry( InetAddress addr, HostTableEntry entry )
     {
@@ -865,5 +879,4 @@ public class HostTableImpl implements HostTable
             saveHosts();
         }
     }
-    
 }


### PR DESCRIPTION
This branch includes changes to track captive portal users by MAC address. The feature is disabled by default (legacy behavior) but can be enabled by turning on the corresponding checkbox in settings on the Authentication tab. 

When enabled, the application will attempt to index and track authenticated users based on the MAC address. If no MAC address is available for a user, they will be tracked by IP address.
