### PR TITLE
ARM64 CPU detection for uvm

### DIFF
--- a/uvm/hier/usr/share/untangle/conf/untangle-vm.conf
+++ b/uvm/hier/usr/share/untangle/conf/untangle-vm.conf
@@ -92,7 +92,7 @@ if platform.machine() == 'x86_64':
     java_opts += " -Xss228k"
 elif platform.machine() == 'i686':
     java_opts += " -Xss128k"
-elif platform.machine().startswith('arm'):
+elif platform.machine().startswith('arm') or platform.machine() == 'aarch64':
     java_opts += " -Xss256k"
 else:
     java_opts += " -Xss128k"

--- a/uvm/impl/com/untangle/uvm/MetricManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/MetricManagerImpl.java
@@ -222,7 +222,9 @@ public class MetricManagerImpl implements MetricManager
                         } catch (NumberFormatException exn) {
                             logger.warn("could not parse cpu speed: " + v);
                         }
-                    }
+                    } else if (n.equals("CPU part") && "0xd03".equals(matcher.group(2))) {
+		    	cpuModel = "ARM Cortex A53";
+		    }
                 }
             }
         } finally {


### PR DESCRIPTION
These patches add recognition of ARM64 CPUs, i.e set the JVM options.

Since /proc/cpuinfo does provide a human readable processor name on arm I've added detection for the Cortex-A53, it should be possible to add other cores (A7, A72 etc.) and/or the SoC as well.

This is enough to build and boot and configure Untangle, there is still a crash issue with nfq_get_ct_info that needs to be fixed before it is fully usable. 