### PR TITLE
libmvutil: set pthread stack size on arm64

### DIFF
--- a/libmvutil/src/uthread.c
+++ b/libmvutil/src/uthread.c
@@ -13,6 +13,7 @@
 #define AMD64_STACK_SIZE 256*1024
 #define I386_STACK_SIZE 96*1024
 #define ARM_STACK_SIZE 256*1024
+#define ARM64_STACK_SIZE 256*1024
 
 uthread_attr_t uthread_attr;
 
@@ -61,6 +62,10 @@ int uthread_init (void)
     }
     else if ( strstr(utsn.machine,"arm") != NULL) {
         if ( pthread_attr_setstacksize( &small_detached_attr, ARM_STACK_SIZE ) < 0 )
+            return perrlog("pthread_attr_setstacksize");
+    }
+    else if ( strstr(utsn.machine,"aarch64") != NULL) {
+        if ( pthread_attr_setstacksize( &small_detached_attr, ARM64_STACK_SIZE ) < 0 )
             return perrlog("pthread_attr_setstacksize");
     }
     else {


### PR DESCRIPTION
Use the same setting as amd64 and arm32 for now, I have not quantified if this is the best value.
This removes the unknown arch warning on this architecture.