### PR TITLE
Pytest adblocker

### DIFF
--- a/ad-blocker/hier/usr/lib/python3.5/dist-packages/tests/test_ad_blocker.py
+++ b/ad-blocker/hier/usr/lib/python3.5/dist-packages/tests/test_ad_blocker.py
@@ -64,12 +64,30 @@ class AdBlockerTests(unittest.TestCase):
         return "ad-blocker"
 
     @staticmethod
-    def initial_setup(self):
+    def initial_setup(garbage=None):
         global app
-        if (uvmContext.appManager().isInstantiated(self.module_name())):
-            raise Exception('app %s already instantiated' % self.module_name())
-        app = uvmContext.appManager().instantiate(self.module_name(), default_policy_id)
+        name = AdBlockerTests.module_name()
+        if app or uvmContext.appManager().isInstantiated(name):
+            AdBlockerTests.final_tear_down()
+        app = uvmContext.appManager().instantiate(name, default_policy_id)
         app.start() # must be called since ad blocker doesn't auto-start
+
+    @staticmethod
+    def final_tear_down(garbage=None):
+        global app
+        name = AdBlockerTests.module_name()
+        if app or uvmContext.appManager().isInstantiated(name):
+            app = uvmContext.appManager().appInstances(name, default_policy_id)["list"][0]
+            uvmContext.appManager().destroy( app.getAppSettings()["id"] )
+        app = None
+
+    @classmethod
+    def setup_class(cls):
+        cls.initial_setup()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.final_tear_down()
 
     def setUp(self):
         pass
@@ -179,12 +197,5 @@ class AdBlockerTests(unittest.TestCase):
         print("Yesterday: \"%s\"" % (yesterday_str))
         assert((today_str in result) or (yesterday_str in result))
 
-    @staticmethod
-    def final_tear_down(self):
-        global app
-        if app != None:
-            uvmContext.appManager().destroy( app.getAppSettings()["id"] )
-        app = None
-        
 
 test_registry.register_module("ad-blocker", AdBlockerTests)

--- a/ad-blocker/hier/usr/lib/python3.5/dist-packages/tests/test_ad_blocker.py
+++ b/ad-blocker/hier/usr/lib/python3.5/dist-packages/tests/test_ad_blocker.py
@@ -63,6 +63,15 @@ class AdBlockerTests(unittest.TestCase):
     def module_name():
         return "ad-blocker"
 
+    @classmethod
+    def get_app(cls):
+        return uvmContext.appManager().appInstances(cls.module_name(),
+                                                    default_policy_id)["list"][0]
+
+    @classmethod
+    def get_app_id(cls):
+        return cls.get_app().getAppSettings()["id"]
+
     @staticmethod
     def initial_setup(garbage=None):
         global app
@@ -77,8 +86,7 @@ class AdBlockerTests(unittest.TestCase):
         global app
         name = AdBlockerTests.module_name()
         if app or uvmContext.appManager().isInstantiated(name):
-            app = uvmContext.appManager().appInstances(name, default_policy_id)["list"][0]
-            uvmContext.appManager().destroy( app.getAppSettings()["id"] )
+            uvmContext.appManager().destroy(AdBlockerTests.get_app_id())
         app = None
 
     @classmethod
@@ -88,9 +96,6 @@ class AdBlockerTests(unittest.TestCase):
     @classmethod
     def teardown_class(cls):
         cls.final_tear_down()
-
-    def setUp(self):
-        pass
 
     # verify client is online
     def test_010_clientIsOnline(self):

--- a/uvm/hier/usr/lib/python3.5/dist-packages/tests/__init__.py
+++ b/uvm/hier/usr/lib/python3.5/dist-packages/tests/__init__.py
@@ -1,2 +1,3 @@
 """x"""
 import tests.global_functions
+import tests.common

--- a/uvm/hier/usr/lib/python3.5/dist-packages/tests/common.py
+++ b/uvm/hier/usr/lib/python3.5/dist-packages/tests/common.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest import TestCase
+
+import runtests
+from tests.global_functions import uvmContext
+
+
+class NGFWTestCase(TestCase):
+
+    # overload the next 2 in subclasses if needed
+    force_start = False
+
+    _app = None
+    default_policy_id = 1
+
+    # once we switch to pytest this should be converted to a class variable
+    @staticmethod
+    def module_name():
+        """Return module name; to be implemented in subclasses."""
+        return "ad-blocker"
+
+    @staticmethod
+    def skip_instantiated():
+        return getattr(runtests, 'skip_instantiated', True)
+
+    @classmethod
+    def get_app(cls):
+        return uvmContext.appManager().appInstances(cls.module_name(),
+                                                    cls.default_policy_id)["list"][0]
+
+    @classmethod
+    def get_app_id(cls):
+        return cls.get_app().getAppSettings()["id"]
+
+    @classmethod
+    def initial_setup(cls, unused=None):
+        name = cls.module_name()
+        if cls._app or uvmContext.appManager().isInstantiated(name):
+            if cls.skip_instantiated():
+                pytest.skip('app %s already instantiated' % cls.module_name())
+            else:
+                cls.final_tear_down()
+        cls._app = uvmContext.appManager().instantiate(name, cls.default_policy_id)
+        if cls.force_start:
+            cls._app.start()
+
+    @classmethod
+    def final_tear_down(cls, unused=None):
+        name = cls.module_name()
+        if cls._app or uvmContext.appManager().isInstantiated(name):
+            uvmContext.appManager().destroy(cls.get_app_id())
+        cls._app = None
+
+    @classmethod
+    def setup_class(cls):
+        cls.initial_setup()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.final_tear_down()

--- a/uvm/hier/usr/lib/python3.5/dist-packages/tests/conftest.py
+++ b/uvm/hier/usr/lib/python3.5/dist-packages/tests/conftest.py
@@ -1,0 +1,13 @@
+import datetime
+import pytest
+
+import runtests
+
+
+def pytest_addoption(parser):
+    parser.addoption("--runtests-host", type=foo, default="192.168.122.122", help="client IP")
+def foo(host):
+    runtests.remote_control.client_ip = host
+    return host
+
+runtests.test_start_time = datetime.datetime.now()

--- a/uvm/hier/usr/lib/python3.5/dist-packages/tests/conftest.py
+++ b/uvm/hier/usr/lib/python3.5/dist-packages/tests/conftest.py
@@ -6,8 +6,14 @@ import runtests
 
 def pytest_addoption(parser):
     parser.addoption("--runtests-host", type=foo, default="192.168.122.122", help="client IP")
+    parser.addoption("--skip-instantiated", type=bar, default=True, help="skip tests if app is already instantiated")
+
 def foo(host):
     runtests.remote_control.client_ip = host
     return host
+
+def bar(skip_instantiated):
+    runtests.skip_instantiated = skip_instantiated in ['true', 'True', '1', 't', 'y', 'yes']
+    return runtests.skip_instantiated
 
 runtests.test_start_time = datetime.datetime.now()


### PR DESCRIPTION
This is meant as a PoC implementing minimal changes to unit tests for one particular app (adblocker in this case). The main goal is to introduce pytest-3 compatibility, while also retaining legacy runtests functionality.

With this PR, both runs produce equivalent results:

```
# pytest-3 --capture=fd -m ad_blocker --runtests-host 192.168.122.230 /usr/lib/python3.5/dist-packages/tests/
===================================================================================================================================================== test session starts =====================================================================================================================================================
platform linux -- Python 3.5.3, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /usr/lib/python3.5/dist-packages/tests, inifile: 
collected 940 items 

../usr/lib/python3.5/dist-packages/tests/test_ad_blocker.py ..........F....
[...]
==================================================================================================================================================== 925 tests deselected =====================================================================================================================================================
==================================================================================================================================== 1 failed, 14 passed, 925 deselected in 45.58 seconds =====================================================================================================================================
```

vs.

```
runtests -h 192.168.122.230 -t ad-blocker -v -v -v -l /tmp/log ; head -20 /tmp/log
Loading tests from /usr/lib/python3.5/dist-packages/
[...]
== testing ad-blocker ==
[...]
== testing ad-blocker [42.5s] ==

Tests complete. [42.5 seconds]
14 passed, 0 skipped, 1 failed

Total          :   15
Passed         :   14
Skipped        :    0
Passed/Skipped :   14 [ 93.33%]
Failed         :    1 [  6.67%]
```

There are *many* other improvements I could have made (global app variable, regactoring, staticmethods signatures, etc) but I tried to aim for the smallest diff possible in order to ease up review. If this PR is validated, further changes will be made in a pure pytest-style after the official switch from runtests to pytest.

One (maybe) controversial change is the behavior change in initial_setup(): instead of skipping tests if the app is already loaded, it will instead destroy and recreate it. I believe it makes more sense this way, but I'm open to input as to why the previous behavior should instead be chosen.