### PR TITLE
Fix to make generated certs compliant with new Apple requirements

### DIFF
--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
@@ -248,7 +248,7 @@ class SslInspectorManager
                 }
 
                 else {
-                    logger.info("Loading existing MitM certificate " + certPathFile);
+                    logger.debug("Loading existing MitM certificate " + certPathFile);
                 }
             }
 

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
@@ -184,8 +184,9 @@ class SslInspectorManager
      * certificate with a CN that matches the CN in the cert received on the
      * server side of the casing. We load these certs from a common shared
      * directory so they can be re-used by all instances once they have been
-     * created. If the cert file doesn't yet exist we call the
-     * generateFakeCertificate() function to create it.
+     * created. If the cert file does not yet exist, or is invalid or more than
+     * one year old, we call the generateFakeCertificate() function to create
+     * it.
      * 
      * @param baseCert
      *        The certificate received from the actual server
@@ -230,17 +231,24 @@ class SslInspectorManager
             // being generated multiple times when several threads all attempt
             // to create a certificate that doesn't yet exist.
             synchronized (keyStorePath) {
-                // see if the cert file already exists
+                long currStamp = (System.currentTimeMillis() / 86400000);
+                long certStamp = 0;
+
                 File tester = new File(certPathFile);
 
-                // file not found so call the external script to generate a new cert
-                if ((tester.exists() == false) || (tester.length() == 0)) {
-                    logger.info("Creating new certificate for " + certHostName + " in " + certFileName);
+                // if the file exists get the last modified time converted to days
+                if (tester.exists() == true) {
+                    certStamp = (tester.lastModified() / 86400000);
+                }
+
+                // if file not found, invalid, or stale we call the external script to generate a new cert
+                if ((tester.exists() == false) || (tester.length() == 0) || ((currStamp - certStamp) > 365)) {
+                    logger.info("Creating new MitM certificate for " + certHostName + " in " + certFileName);
                     generateFakeCertificate(baseCert, certFileName);
                 }
 
                 else {
-                    logger.debug("Loading existing certificate " + certPathFile);
+                    logger.info("Loading existing MitM certificate " + certPathFile);
                 }
             }
 

--- a/uvm/hier/usr/share/untangle/bin/ut-certgen
+++ b/uvm/hier/usr/share/untangle/bin/ut-certgen
@@ -7,6 +7,13 @@ TEMP="/dev/shm"
 
 UT_ROOT_PATH="@PREFIX@/usr/share/untangle/settings/untangle-certificates"
 
+# Start with the current epoch time
+# Subtract one day to avoid not-yet-valid errors from minor clock differences
+# Put the adjusted date in YYMMDDHHMMSSZ format required by openssl
+CURRDATE=`date +%s`
+PREVDATE=$(($CURRDATE-86400))
+CERTDATE=`date --date=@$PREVDATE +%y%m%d%H%M%S`'Z'
+
 # Since we call this script to generate mitm certificates on the fly we must
 # use a random source that will not block.  All the security articles I found
 # indicate /dev/urandom has plenty of entropy given what we're doing here.
@@ -115,7 +122,7 @@ case $1 in
             echo "APACHE: Error generating certificate signing request"
             exit 5
         fi
-        $OPENSSL_TOOL ca -batch -config $OPENSSL_CONF -extensions v3_host -startdate 100102030405Z -enddate 380102030405Z -out $TEMP/server.crt -outdir $TEMP -infiles $UT_ROOT_PATH/apache.csr
+        $OPENSSL_TOOL ca -batch -config $OPENSSL_CONF -extensions v3_host -startdate $CERTDATE -days 820 -out $TEMP/server.crt -outdir $TEMP -infiles $UT_ROOT_PATH/apache.csr
         if [ $? != 0 ]; then
             echo "APACHE: Error generating signed certificate"
             exit 6
@@ -136,7 +143,7 @@ case $1 in
             echo "SERVER: Error generating certificate signing request"
             exit 8
         fi
-        $OPENSSL_TOOL ca -batch -config $OPENSSL_CONF -extensions v3_host -startdate 100102030405Z -enddate 380102030405Z -out $TEMP/server.crt -outdir $TEMP -infiles $UT_ROOT_PATH/$4.csr
+        $OPENSSL_TOOL ca -batch -config $OPENSSL_CONF -extensions v3_host -startdate $CERTDATE -days 820 -out $TEMP/server.crt -outdir $TEMP -infiles $UT_ROOT_PATH/$4.csr
         if [ $? != 0 ]; then
             echo "SERVER: Error generating signed certificate"
             exit 9
@@ -158,7 +165,7 @@ case $1 in
             echo "MITM: Error generating certificate signing request"
             exit 11
         fi
-        $OPENSSL_TOOL ca -batch -config $OPENSSL_CONF -extensions v3_fake -startdate 100102030405Z -enddate 380102030405Z -out $TEMP/server.crt -outdir $TEMP -infiles $TEMP/server.csr
+        $OPENSSL_TOOL ca -batch -config $OPENSSL_CONF -extensions v3_fake -startdate $CERTDATE -days 820 -out $TEMP/server.crt -outdir $TEMP -infiles $TEMP/server.csr
         if [ $? != 0 ]; then
             echo "MITM: Error generating signed certificate"
             exit 12


### PR DESCRIPTION
The latest versions of iOS and macOS are enforcing strict requirements
on TLS certs. Ours seem to meet all of them except we use hard coded
start and end dates that result in a validity period of 28 years.
I updated the ut-certgen script so it will use current_time minus
one day as the start date which will prevent issues with minor clock
differences causing cert-not-yet-valid errors. I used a validity
period of 820 days to compensate for our one day start adjustment
plus a little extra room to be safe. I also updated the SSL Inspector
manager to look at the file modification time on MitM certs we cache
to improve performance, and force them to be recreated when they are
more than one year old.

@changelog