### PR TITLE
[buildtools Enforce reading JS files as ASCII

### DIFF
--- a/buildtools/target.rb
+++ b/buildtools/target.rb
@@ -349,7 +349,7 @@ class JsBuilder < Target
   def all
     info "[jsbuild ] #{@name}: #{@path} -> #{@relativeDestPath}"
     # read all deps into memory, as an array of content
-    data = @deps.map { |d| File.open(d).read() }
+    data = @deps.map { |d| File.open(d, "r:ASCII").read() }
 
     # start pipe'ing operations on that array
     data = remove_comment(data)


### PR DESCRIPTION
C is the default locale on all the buildbot slaves instances, and also
in the more recent docker images used TravisCI; by also forcing ASCII
during the build, we expose potential failures during developer builds
where utf8-based locales are more common.