### PR TITLE
NGFW-12688 sanitize csv

### DIFF
--- a/reports/hier/usr/share/untangle/bin/reports-create-csv.sh
+++ b/reports/hier/usr/share/untangle/bin/reports-create-csv.sh
@@ -53,6 +53,9 @@ psql -U postgres -d uvm -t -c "SELECT tablename FROM pg_catalog.pg_tables WHERE 
         echo "Creating csv: ${tablename}.csv ..." 
         # psql -U postgres -d uvm -A -F"," -c "select * from reports.${tablename}" > $TMPDIR/$DIR/${tablename}.csv
         psql -U postgres -d uvm -A -F"," -c "\copy reports.${tablename} to '${TMPDIR}/${DIR}/${tablename}.csv' csv header" 
+
+        # escape -, ", @, +, and = with a leading single quote to prevent formula injection
+        sed -ri "s/(^|,)([-\"@+=])/\1'\2/g" ${TMPDIR}/${DIR}/${tablename}.csv
     done
                                                                                                                                                 
 cd $TMPDIR

--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -1094,7 +1094,11 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
                         }
                         String oStr = "";
                         if (o != null)
-                            oStr = o.toString().replaceAll(",","");
+                            /**
+                             * remove any commas in the string, and escape leading -, ", @, +, and =
+                             * with a single quote to prevent formula injections
+                             */
+                            oStr = o.toString().replaceAll(",","").replaceAll("(^|,)([-\"@+=])","$1'$2");
                     
                         if (writtenColumnCount != 0)
                             resp.getWriter().write(",");


### PR DESCRIPTION
Leading -, ", + , @, and = in exported csv files need to be escaped with a single quote to
prevent formula injection