### PR TITLE
MFW-847: OpenVpnSettings: Set default keepalive settings to '2 10'

### DIFF
--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnSettings.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnSettings.java
@@ -27,8 +27,8 @@ public class OpenVpnSettings implements java.io.Serializable, JSONString
         NONE, LOCAL_DIRECTORY, RADIUS, ACTIVE_DIRECTORY, ANY_DIRCON
     };
 
-    private static final int DEFAULT_PING_TIME    = 10;
-    private static final int DEFAULT_PING_TIMEOUT = 60;
+    private static final int DEFAULT_PING_TIME    = 2;
+    private static final int DEFAULT_PING_TIMEOUT = 10;
     private static final int DEFAULT_VERBOSITY    = 1;
     static final int MANAGEMENT_PORT              = 1195;
 


### PR DESCRIPTION
With 'keepalive 10 60' it takes 60 seconds for a client to determine
that a vpn connection has been lost before it does a soft restart to
try to reconnect.  On clients that might be sending all traffic through
the vpn (like an Untangle SDWAN router) that means clients behind the
router might not be able to send out any traffic for 60 seconds, which
seems like a long time.  A 10 second timeout with pings every 2 seconds
seems a bit more reasonable as far as making clients more responsive to
vpn connection drops, but not so drastic as to cause spurious restarts
on a spotty connection.

MFW-847