### PR TITLE
NGFW-12669: uvm_login: Properly detect local login attempts

### DIFF
--- a/uvm/hier/usr/lib/python2.7/dist-packages/uvm_login.py
+++ b/uvm/hier/usr/lib/python2.7/dist-packages/uvm_login.py
@@ -86,7 +86,7 @@ def headerparserhandler(req):
 
     if None == username and is_local_process_uid_authorized(req):
         username = 'localadmin'
-        log_login(req, username, True, True, None)
+        log_login(req, username, True, None)
         save_session_user(sess, realm, username)
 
     #if sess.has_key('apache_realms'):
@@ -293,8 +293,21 @@ def send_login_event(client_addr, login, local, succeeded, reason):
     except Exception, e:
         apache.log_error('error: %s' % repr(e))
 
-def log_login(req, login, local, succeeded, reason):
+def log_login(req, login, succeeded, reason):
+    """ Send a login event to the admin login log
+
+    Arguments:
+        req -- http request
+        login -- the username attempting to log in
+        succeeded -- true if the login was successful, false otherwise
+        reason -- string conveys the reason the login failed, or None if the login succeeded
+    """
+    local = False
     (client_addr, client_port) = req.connection.remote_addr
+
+    if client_addr == "127.0.0.1" or client_addr == "::1":
+        local = True
+
     threading.Thread(target=lambda: send_login_event(client_addr, login, local, succeeded, reason)).start()
 
 def write_error_page(req, msg):

--- a/uvm/hier/usr/share/untangle/web/auth/index.py
+++ b/uvm/hier/usr/share/untangle/web/auth/index.py
@@ -172,14 +172,14 @@ def _reports_valid_login(req, realm, username, password, log=True):
         salt = pw_hash[len(pw_hash) - 8:]
         if raw_pw == md5.new(password + salt).digest():
             if log:
-                uvm_login.log_login(req, username, False, True, None)
+                uvm_login.log_login(req, username, True, None)
             return True
         else:
             if log:
-                uvm_login.log_login(req, username, False, False, 'P')
+                uvm_login.log_login(req, username, False, 'P')
             return False
     if log:
-        uvm_login.log_login(req, username, False, False, 'U')
+        uvm_login.log_login(req, username, False, 'U')
     return False
 
 def _admin_valid_login(req, realm, username, password, log=True):
@@ -197,14 +197,14 @@ def _admin_valid_login(req, realm, username, password, log=True):
         salt = pw_hash[len(pw_hash) - 8:]
         if raw_pw == md5.new(password + salt).digest():
             if log:
-                uvm_login.log_login(req, username, False, True, None)
+                uvm_login.log_login(req, username, True, None)
             return True
         else:
             if log:
-                uvm_login.log_login(req, username, False, False, 'P')
+                uvm_login.log_login(req, username, False, 'P')
             return False
     if log:
-        uvm_login.log_login(req, username, False, False, 'U')
+        uvm_login.log_login(req, username, False, 'U')
     return False
 
 def _write_login_form(req, title, host, error_msg):


### PR DESCRIPTION
Currently callers of log_login pass the 'local' parameter to indicate
whether a login attempt is coming from the local box or not.
Unfortunately, most callers are not actually setting the local parameter
correctly.  Now, log_login checks if the request is local itself, and
sets the local flag accordingly.