### PR TITLE
NGFW-12761: ut-upgrade: Run apt-get clean after upgrade

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -110,6 +110,10 @@ def autoremove():
     log("apt-get autoremove %s" % AUTOREMOVE_OPTS)
     return cmd_to_log("apt-get autoremove %s" % AUTOREMOVE_OPTS)
 
+def clean():
+    log("apt-get clean")
+    return cmd_to_log("apt-get clean")
+
 log_date( os.path.basename( sys.argv[0]) )
 
 log("")
@@ -134,6 +138,11 @@ log_date("")
 log("")
 
 autoremove()
+
+log_date("")
+log("")
+
+clean()
 
 log_date("")
 log("")


### PR DESCRIPTION
It'll clean up any debs we have laying around in /var/cache/apt/archives

NGFW-12761