### PR TITLE
NGFW-12740: IPS: Remove minimumMemory requirement

### DIFF
--- a/intrusion-prevention/hier/usr/share/untangle/lib/intrusion-prevention/appProperties.json
+++ b/intrusion-prevention/hier/usr/share/untangle/lib/intrusion-prevention/appProperties.json
@@ -10,7 +10,6 @@
             "javaClass": "java.util.LinkedList",
             "list": ["i386","amd64"]
         },
-        "minimumMemory": 1600000000,
         "daemon": "suricata"
 
 }


### PR DESCRIPTION
This is legacy behaviour from snort.  Now we do not require as much
memory with Suricata and we have rules to control how we use the
signature based on the amount of memory.

NGFW-12750