### PR TITLE
Citrix packet marks

### DIFF
--- a/libnetcap/src/netcap_tcp.c
+++ b/libnetcap/src/netcap_tcp.c
@@ -601,7 +601,8 @@ static netcap_session_t* _netcap_get_or_create_sess ( int* created_flag,
                                       -1, -1,
                                       cli_intf, srv_intf );
 
-    sess->initial_mark = nfmark & 0x0000ff00;
+    // CITRIX - preserve the source and destination interfaces
+    sess->initial_mark = nfmark & 0x0000ffff;
     
     if ( netcap_nc_sesstable_add_tuple( !NC_SESSTABLE_LOCK, sess, IPPROTO_TCP,
                                         c_cli_addr, c_srv_addr,

--- a/libnetcap/src/netcap_tcp.c
+++ b/libnetcap/src/netcap_tcp.c
@@ -601,7 +601,13 @@ static netcap_session_t* _netcap_get_or_create_sess ( int* created_flag,
                                       -1, -1,
                                       cli_intf, srv_intf );
 
-    // CITRIX - preserve the source and destination interfaces
+    // NGFW-12726 For Citrix we need to preserve the source and destination
+    // interface id values in the packet mark. Previously we used 0x0000ff00
+    // which preserved only the source interface. A Jan 16 2014 commit
+    // indicates the mask was added because using the entire mark caused
+    // issues with bandwith control. The belief is that preserving src and
+    // dst should not cause a problem, so we now use a mask that preserves
+    // both but clears everything else.
     sess->initial_mark = nfmark & 0x0000ffff;
     
     if ( netcap_nc_sesstable_add_tuple( !NC_SESSTABLE_LOCK, sess, IPPROTO_TCP,

--- a/libnetcap/src/netcap_tcp_cli.c
+++ b/libnetcap/src/netcap_tcp_cli.c
@@ -245,7 +245,11 @@ int  _netcap_tcp_setsockopt_cli( int sock , u_int mark )
     if (setsockopt(sock,SOL_TCP,TCP_KEEPCNT,&nine,sizeof(nine)) < 0 )
         perrlog("setsockopt");
 
-    // we have to swap the src and dst interfaces on the client side
+    // NGFW-12726 For Citrix we want to set the source and destination
+    // interfaces in the packet mark for packets that are sent back to the
+    // client. We do this by setting our custom kernel extension
+    // IP_SENDNFMARK on the client socket and reversing the interfaces
+    // to reflect the traffic is flowing SERVER-to-CLIENT.
     u_char lo = (mark & 0x000000ff);
     u_char hi = ((mark & 0x0000ff00) >> 8);
     u_int fixer = mark & 0xffff0000;
@@ -258,7 +262,7 @@ int  _netcap_tcp_setsockopt_cli( int sock , u_int mark )
     };
 
     if ( setsockopt(sock,SOL_IP,IP_SENDNFMARK_VALUE(),&nfmark,sizeof(nfmark)) < 0 )
-        return perrlog( "setsockopt" );
+        perrlog( "setsockopt" );
 
     return 0;
 }

--- a/libnetcap/src/netcap_tcp_cli.c
+++ b/libnetcap/src/netcap_tcp_cli.c
@@ -245,9 +245,16 @@ int  _netcap_tcp_setsockopt_cli( int sock , u_int mark )
     if (setsockopt(sock,SOL_TCP,TCP_KEEPCNT,&nine,sizeof(nine)) < 0 )
         perrlog("setsockopt");
 
+    // we have to swap the src and dst interfaces on the client side
+    u_char lo = (mark & 0x000000ff);
+    u_char hi = ((mark & 0x0000ff00) >> 16);
+    u_int fixer = mark & 0xffff0000;
+    fixer |= (lo << 16);
+    fixer |= hi;
+
     struct ip_sendnfmark_opts nfmark = {
         .on = 1,
-        .mark = mark
+        .mark = fixer
     };
 
     if ( setsockopt(sock,SOL_IP,IP_SENDNFMARK_VALUE(),&nfmark,sizeof(nfmark)) < 0 )

--- a/libnetcap/src/netcap_tcp_cli.c
+++ b/libnetcap/src/netcap_tcp_cli.c
@@ -247,9 +247,9 @@ int  _netcap_tcp_setsockopt_cli( int sock , u_int mark )
 
     // we have to swap the src and dst interfaces on the client side
     u_char lo = (mark & 0x000000ff);
-    u_char hi = ((mark & 0x0000ff00) >> 16);
+    u_char hi = ((mark & 0x0000ff00) >> 8);
     u_int fixer = mark & 0xffff0000;
-    fixer |= (lo << 16);
+    fixer |= (lo << 8);
     fixer |= hi;
 
     struct ip_sendnfmark_opts nfmark = {

--- a/libnetcap/src/netcap_virtual_interface.c
+++ b/libnetcap/src/netcap_virtual_interface.c
@@ -136,11 +136,11 @@ int netcap_virtual_interface_send_pkt( netcap_pkt_t* pkt )
          * So we hack it by encoding the desired src interface mark into the source MAC address of the packet
          * In iptables we will set the nfmark and connmark based off the source MAC address
          *
-         * NGFW-12726 For Citrix we also need the destination interface which we put in another octet of the source MAC
-         * address. This also requires an update to the sync-settings interfaces_manager.py script to handle the fact
-         * that both interfaces are now encoded in the source MAC address. It's complicated by the fact that there is
-         * no way to mask the MAC address in the rule conditions, so we have create rules for every possible
-         * dst:src combination. Works fine with only a few interfaces configured, but gets ugly very fast.
+         * NGFW-12726 For Citrix we also need the destination interface which we now put in another octet of the source MAC
+         * address. This also required an update to the sync-settings interfaces_manager.py script to handle the fact
+         * that both interfaces are now encoded in the source MAC address. Since the stock iptables xt_mac.ko matcher
+         * module can only evaluate the entire address we also had to customize that to support a special syntax that
+         * allows rules that match by comparing individual bytes in the MAC address.
         */
         mac_src[5] = nfmark & 0x00FF;
         mac_src[4] = ((nfmark & 0xFF00) >> 8);


### PR DESCRIPTION
IMPORTANT: This should not be merged until the updated kernel with the patch to the xt_mac module is available, otherwise it will completely break things as these changes depend on that kernel enhancement.

These changes for Citrix preserve the src and dst interface marks on packets, and encode both the src and dst interface marks in the src MAC address for packets re-injected on the utun device.