### PR TITLE
NGFW-12733: untangle-vm.preinst: Add swap on vm with < 2GB ram

### DIFF
--- a/debian/untangle-vm.preinst
+++ b/debian/untangle-vm.preinst
@@ -24,6 +24,32 @@ if [ -f /var/run/uvm.pid ] ; then
         echo "Stopped  untangle-vm  $?"
 
 	if dpkg --compare-versions "$oldVersion" le 15.0~ ; then
+
+          # if we are upgrading a vm install to 15.0 and it doesn't
+          # have swap, has 2GB or less of memory, and 2GB or more
+          # of free disk space, add a 2GB swap file.  Depending on
+          # what apps a user has installed we may be tight on memory
+          # with only 2GB and adding a swap file can help
+          mem=`free -b | awk '/Mem:/ { print $2 }'`
+          disk=`df --output=avail / | awk ' /^[0-9]/ { print $1 }'`
+          if grep -q hypervisor /proc/cpuinfo && \
+             free -m | egrep -q '^Swap:\s+0\s.*' && \
+             [ $mem -le 2101301248 ] && \
+             [ $disk -gt 2097152 ] ; then
+
+            echo "mem: $mem"
+            echo "disk: $disk"
+            echo "Creating swap..."
+
+            fallocate -l 2G /swapfile
+            mkswap /swapfile
+            chmod 600 /swapfile
+            swapon /swapfile
+
+            /bin/sed -e '/^\/swapfile/d' -i /etc/fstab
+            /bin/echo -e '/swapfile\tnone\tswap\tsw\t0\t0' >> /etc/fstab
+          fi
+
 	  # reboot to new 4.9.0-11 kernel (NGFW-12661)
 	  #
           # we defer this to the postinst, because during preinst


### PR DESCRIPTION
In the past, ovas specified 2GB of ram.  Users who are still running
vms with 2GB of ram may run into memory pressure depending on what
apps they have installed.  This may even impair their ability to
upgrade.  To mitigate this, try to create and enable swap.

If we are upgrading to 15.0, and the box is a vm, and the box has
2GB of ram or less, and the box has 2GB or more of free disk space,
then create and enable a 2GB swap file before we start the upgrade
process.

NGFW-12733