### PR TITLE
NGFW-12844: VTypes: ipOrUrl: Allow domains up to 63 characters

### DIFF
--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -16,7 +16,7 @@ Ext.define('Ung.overrides.form.field.VTypes', {
         openvpnName: /^[A-Za-z0-9]([-.0-9A-Za-z]*[0-9A-Za-z])?$/,
         positiveInteger: /^[0-9]+$/,
         domainNameRe: /^[a-zA-Z0-9\-_.]+$/,
-        urlAddrRe: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/
+        urlAddrRe: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}(:[0-9]{1,5})?(\/.*)?$/
     },
 
     isSinglePortValid: function(val) {


### PR DESCRIPTION
According to ietf rfc1034 [0] node labels have a maximum length
of 63 octets.  Prior to this change, urls with tlds greater than
5 were being truncated.

[0] https://tools.ietf.org/html/rfc1034

NGFW-12844