### PR TITLE
NGFW-12733 Tweak 2 gb

### DIFF
--- a/debian/untangle-vm.preinst
+++ b/debian/untangle-vm.preinst
@@ -34,7 +34,7 @@ if [ -f /var/run/uvm.pid ] ; then
           disk=`df --output=avail / | awk ' /^[0-9]/ { print $1 }'`
           if grep -q hypervisor /proc/cpuinfo && \
              free -m | egrep -q '^Swap:\s+0\s.*' && \
-             [ $mem -le 2101301248 ] && \
+             [ $mem -le 2106716160 ] && \
              [ $disk -gt 2097152 ] ; then
 
             echo "mem: $mem"


### PR DESCRIPTION
2GB of ram is reported differently on the 3.16 kernel than it is
on 4.9.  For users who have upgraded from 13.2 and may still be on
3.16, bump up the memory check.

NGFW-12733