### PR TITLE
NGFW-12864: tunnel-vpn: Store last traffic check time per tunnel

### DIFF
--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnMonitor.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnMonitor.java
@@ -53,7 +53,6 @@ class TunnelVpnMonitor implements Runnable
 
     private Thread thread = null;
     private volatile boolean isAlive = false;
-    private volatile long lastTrafficCheck = 0;
     private volatile long cycleCount = 0;
 
     /**
@@ -404,8 +403,8 @@ class TunnelVpnMonitor implements Runnable
          * If not time to write a traffic stats record just return
          */
         long currentTime = System.currentTimeMillis();
-        if (currentTime < (lastTrafficCheck + TRAFFIC_CHECK_INTERVAL)) return (status);
-        lastTrafficCheck = currentTime;
+        if (currentTime < (status.getLastTrafficCheck() + TRAFFIC_CHECK_INTERVAL)) return (status);
+        status.setLastTrafficCheck(currentTime);
 
         /*
          * The stats for each the tunnel will be cleared if the connection dies

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnTunnelStatus.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnTunnelStatus.java
@@ -30,6 +30,7 @@ public class TunnelVpnTunnelStatus implements JSONString, Serializable
     private long recvTotal = 0;
     private long recvLast = 0;
     private int tunnelId = 0;
+    private long lastTrafficCheck = 0;
 
     protected long restartCount = 0;
     protected long restartStamp = 0;
@@ -80,6 +81,9 @@ public class TunnelVpnTunnelStatus implements JSONString, Serializable
 
         public int getTunnelId() { return(tunnelId); }
         public void setTunnelId(int argValue) { this.tunnelId = argValue; }
+
+        public long getLastTrafficCheck() { return(lastTrafficCheck); }
+        public void setLastTrafficCheck(long argValue) { this.lastTrafficCheck = argValue; }
 
         public long getElapsedTime()
         {


### PR DESCRIPTION
Previously, we were storing the last traffic check time globally.
This works fine with a single tunnel, but breaks tunnel statistics
if there are multiple tunnel vpns.  In the case of multiple tunnels,
if it was time to update statistics, the first iteration through the
loop would set the lastTrafficCheck global when it generated a
statistic for the first tunnel.  On subsequent iterations through
the loop, for subsequent tunnels, the check of lastTrafficCheck
would always fail and we would therefore never generate a statistic
event for those tunnels.

Now we store the lastTrafficCheck value in the per tunnel status
so that we properly detect when it is time to generate a statistic
for each tunnel.

NGFW-12864