### PR TITLE
NGFW-12384: intrusion-prevention: Use ping with specified payload for icmp test

### DIFF
--- a/intrusion-prevention/hier/usr/lib/python3.5/dist-packages/tests/test_intrusion_prevention.py
+++ b/intrusion-prevention/hier/usr/lib/python3.5/dist-packages/tests/test_intrusion_prevention.py
@@ -188,7 +188,10 @@ class IntrusionPreventionTests(NGFWTestCase):
         self.do_wait_for_daemon_ready()
 
         startTime = datetime.datetime.now()
-        remote_control.run_command("nmap -sP " + wan_ip + " >/dev/null 2>&1",host=global_functions.iperf_server)
+
+        # Ensure the icmp request includes the string ISSPNGRQ in it so we are sure to trigger a detected scan event
+        # see sid: 2100465 "GPL SCAN ISS Pinger"
+        remote_control.run_command("ping -c 1 -p 495353504e475251 " + wan_ip + " >/dev/null 2>&1",host=global_functions.iperf_server)
 
         app.forceUpdateStats()
         events = global_functions.get_events('Intrusion Prevention','All Events',None,5)

--- a/uvm/js/common/reports/view/GraphReport.js
+++ b/uvm/js/common/reports/view/GraphReport.js
@@ -600,7 +600,7 @@ Ext.define('Ung.view.reports.GraphReport', {
                     if (seriesRenderer) {
                         seriesName = seriesRenderer(parseInt(colVal, 10));
                     } else {
-                        seriesName = colVal !== undefined ? TableConfig.getDisplayValue(colVal, table, colField, rowRecord) : 'None'.t();
+                        seriesName = !colVal ? 'None'.t() : TableConfig.getDisplayValue(colVal, table, colField, rowRecord);
                     }
 
                     var tableColumn = null;


### PR DESCRIPTION
If 'nmap -sP' is run by an unprivileged user, it only uses TCP SYN
packets to 443 and 80 to ping the target.  These are not detected
by suricata as a network scan.  If run as root, 'nmap -sP' will
use ARP requests to ping the target.  These are also not detected
by suricata as a network scan.  If 'nmap -sP -PE --send-ip' is run
as root then nmap will actually send an icmp echo request that suricata
detects as a network scan.  However, we currently don't have a method
in our test framework of requesting that the remote nmap call be run
as root.  Instead we will use ping with 'ISSPNGRQ' specified in the
data section to trigger suricata sid: 2100465 "GPL SCAN ISS Pinger".

NGFW-12384