### PR TITLE
Ngfw 12878 duplicate web filter events

### DIFF
--- a/http-casing/src/com/untangle/app/http/RequestLine.java
+++ b/http-casing/src/com/untangle/app/http/RequestLine.java
@@ -118,7 +118,7 @@ public class RequestLine implements Serializable
      * Set the requestId
      * @param newValue
      */
-    public void setRequestId( long newValue ) { this.requestId = requestId; }
+    public void setRequestId( long newValue ) { this.requestId = newValue; }
 
     /**
      * Request method.

--- a/threat-prevention/hier/usr/share/untangle/lib/threat-prevention/reports/web-all-web-events.json
+++ b/threat-prevention/hier/usr/share/untangle/lib/threat-prevention/reports/web-all-web-events.json
@@ -2,7 +2,6 @@
     "category": "Threat Prevention",
     "readOnly": true,
     "type": "EVENT_LIST",
-    "conditions": [],
     "defaultColumns": ["time_stamp","client_country","server_country","hostname","username","host","uri","c_client_addr","s_server_addr","s_server_port","threat_prevention_blocked","threat_prevention_flagged","threat_prevention_rule_id","threat_prevention_reputation","threat_prevention_categories"],
     "conditions": [
         {

--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
@@ -296,6 +296,7 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
             evt = new HttpRequestEvent(requestLine, domain, null, 0);
             requestLine.setHttpRequestEvent(evt);
             this.app.logEvent(evt);
+            sess.globalAttach(AppSession.KEY_HTTPS_SNI_HTTP_REQUEST_EVENT, evt);
             logger.info("Creating new HttpRequestEvent: " + evt.toString());
         } else {
             logger.info("Using existing HttpRequestEvent: " + evt.toString());

--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
@@ -243,9 +243,9 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
         if (requestLine == null) {
             requestLine = new RequestLine(sess.sessionEvent(), HttpMethod.GET, new byte[] { '/' });
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_REQUEST_LINE, requestLine);
-            logger.info("Creating new requestLine: " + requestLine.toString());
+            logger.debug("Creating new requestLine: " + requestLine.toString());
         } else {
-            logger.info("Using existing requestLine: " + requestLine.toString());
+            logger.debug("Using existing requestLine: " + requestLine.toString());
         }
 
         URI fakeUri;
@@ -274,19 +274,34 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
         }
         requestLine.setRequestUri(fakeUri); // URI is unknown
 
+        /**
+         * Similar to the RequestLine logic above, this session may already have a requestlinetoken associated with it,
+         * we do not want to add multiple requestlinetokens for each individual app.
+         * 
+         * This logic should be consolidated/removed.
+         */
+
         RequestLineToken rlt = null;
 
         rlt = (RequestLineToken) sess.globalAttachment(AppSession.KEY_HTTPS_SNI_REQUEST_TOKEN);
         if (rlt == null) {
             rlt = new RequestLineToken(requestLine, "HTTP/1.1");
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_REQUEST_TOKEN, rlt);
-            logger.info("Creating new requestLineToken: " + rlt.toString());
+            logger.debug("Creating new requestLineToken: " + rlt.toString());
         } else {
-            logger.info("Using existing requestLine: " + rlt.toString());
+            logger.debug("Using existing requestLine: " + rlt.toString());
         }
 
         /**
          * Log this HTTPS hit to the http_events table
+         * 
+         * 
+         * Similar to the RequestLine and RequestLineToken logic above, 
+         * we do not want to create an additional HttpRequestEvent in the http_events
+         * table when a request comes through the SNI logic.
+         * 
+         * This logic should be consolidated/removed.
+         * 
          */
         HttpRequestEvent evt = null;
         
@@ -297,9 +312,9 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
             requestLine.setHttpRequestEvent(evt);
             this.app.logEvent(evt);
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_HTTP_REQUEST_EVENT, evt);
-            logger.info("Creating new HttpRequestEvent: " + evt.toString());
+            logger.debug("Creating new HttpRequestEvent: " + evt.toString());
         } else {
-            logger.info("Using existing HttpRequestEvent: " + evt.toString());
+            logger.debug("Using existing HttpRequestEvent: " + evt.toString());
         }
 
         // attach the hostname we extracted to the session

--- a/uvm/api/com/untangle/uvm/vnet/SessionAttachments.java
+++ b/uvm/api/com/untangle/uvm/vnet/SessionAttachments.java
@@ -62,12 +62,15 @@ public interface SessionAttachments
     public static final String KEY_CAPTIVE_PORTAL_SSL_ENGINE = "captive-portal-ssl-engine"; /* CaptureSSLEngine */
     public static final String KEY_CAPTIVE_PORTAL_SESSION_CAPTURE = "captive-portal-session-capture"; /* String */
 
+    public static final String KEY_THREAT_PREVENTION_SSL_ENGINE = "threat-prevention-ssl-engine"; /* ThreatPreventionSSLEngine */
     public static final String KEY_THREAT_PREVENTION_CLIENT_REPUTATION = "ip-reputation-client-reputation"; /* Integer */
     public static final String KEY_THREAT_PREVENTION_CLIENT_CATEGORIES = "ip-reputation-client-categories"; /* Integer */
     public static final String KEY_THREAT_PREVENTION_SERVER_REPUTATION = "ip-reputation-server-reputation"; /* Integer */
     public static final String KEY_THREAT_PREVENTION_SERVER_CATEGORIES = "ip-reputation-server-categories"; /* Integer */
 
     public static final String KEY_HTTPS_SNI_REQUEST_LINE = "https-sni-request-line"; /* RequestLine */
+    public static final String KEY_HTTPS_SNI_REQUEST_TOKEN = "https-sni-request-line-token"; /* RequestLineToken */
+    public static final String KEY_HTTPS_SNI_HTTP_REQUEST_EVENT = "https-sni-http-request-event"; /* HttpRequestEvent */
 
     /**
      * Attaches the given object to this session.

--- a/uvm/api/com/untangle/uvm/vnet/SessionAttachments.java
+++ b/uvm/api/com/untangle/uvm/vnet/SessionAttachments.java
@@ -67,6 +67,8 @@ public interface SessionAttachments
     public static final String KEY_THREAT_PREVENTION_SERVER_REPUTATION = "ip-reputation-server-reputation"; /* Integer */
     public static final String KEY_THREAT_PREVENTION_SERVER_CATEGORIES = "ip-reputation-server-categories"; /* Integer */
 
+    public static final String KEY_HTTPS_SNI_REQUEST_LINE = "https-sni-request-line"; /* RequestLine */
+
     /**
      * Attaches the given object to this session.
      *

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
@@ -297,6 +297,7 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             evt = new HttpRequestEvent(requestLine, domain, null, 0);
             requestLine.setHttpRequestEvent(evt);
             this.app.logEvent(evt);
+            sess.globalAttach(AppSession.KEY_HTTPS_SNI_HTTP_REQUEST_EVENT, evt);
             logger.info("Creating new HttpRequestEvent: " + evt.toString());
         } else {
             logger.info("Using existing HttpRequestEvent: " + evt.toString());

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
@@ -275,14 +275,32 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             return;
         }
         requestLine.setRequestUri(fakeUri); // URI is unknown
-        RequestLineToken rlt = new RequestLineToken(requestLine, "HTTP/1.1");
+        RequestLineToken rlt = null;
+
+        rlt = (RequestLineToken) sess.globalAttachment(AppSession.KEY_HTTPS_SNI_REQUEST_TOKEN);
+        if (rlt == null) {
+            rlt = new RequestLineToken(requestLine, "HTTP/1.1");
+            sess.globalAttach(AppSession.KEY_HTTPS_SNI_REQUEST_TOKEN, rlt);
+            logger.info("Creating new requestLineToken: " + rlt.toString());
+        } else {
+            logger.info("Using existing requestLine: " + rlt.toString());
+        }
 
         /**
          * Log this HTTPS hit to the http_events table
          */
-        HttpRequestEvent evt = new HttpRequestEvent(requestLine, domain, null, 0);
-        requestLine.setHttpRequestEvent(evt);
-        this.app.logEvent(evt);
+        HttpRequestEvent evt = null;
+        
+        evt = (HttpRequestEvent) sess.globalAttachment(AppSession.KEY_HTTPS_SNI_HTTP_REQUEST_EVENT);
+
+        if (evt == null) {
+            evt = new HttpRequestEvent(requestLine, domain, null, 0);
+            requestLine.setHttpRequestEvent(evt);
+            this.app.logEvent(evt);
+            logger.info("Creating new HttpRequestEvent: " + evt.toString());
+        } else {
+            logger.info("Using existing HttpRequestEvent: " + evt.toString());
+        }
 
         // attach the hostname we extracted to the session
         sess.globalAttach(AppSession.KEY_HTTP_HOSTNAME, domain);

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
@@ -245,9 +245,9 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
         if (requestLine == null) {
             requestLine = new RequestLine(sess.sessionEvent(), HttpMethod.GET, new byte[] { '/' });
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_REQUEST_LINE, requestLine);
-            logger.info("Creating new requestLine: " + requestLine.toString());
+            logger.debug("Creating new requestLine: " + requestLine.toString());
         } else {
-            logger.info("Using existing requestLine: " + requestLine.toString());
+            logger.debug("Using existing requestLine: " + requestLine.toString());
         }
 
         URI fakeUri;
@@ -275,19 +275,35 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             return;
         }
         requestLine.setRequestUri(fakeUri); // URI is unknown
+
+        /**
+         * Similar to the RequestLine logic above, this session may already have a requestlinetoken associated with it,
+         * we do not want to add multiple requestlinetokens for each individual app.
+         * 
+         * This logic should be consolidated/removed.
+         */
+
         RequestLineToken rlt = null;
 
         rlt = (RequestLineToken) sess.globalAttachment(AppSession.KEY_HTTPS_SNI_REQUEST_TOKEN);
         if (rlt == null) {
             rlt = new RequestLineToken(requestLine, "HTTP/1.1");
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_REQUEST_TOKEN, rlt);
-            logger.info("Creating new requestLineToken: " + rlt.toString());
+            logger.debug("Creating new requestLineToken: " + rlt.toString());
         } else {
-            logger.info("Using existing requestLine: " + rlt.toString());
+            logger.debug("Using existing requestLine: " + rlt.toString());
         }
 
         /**
          * Log this HTTPS hit to the http_events table
+         * 
+         * 
+         * Similar to the RequestLine and RequestLineToken logic above, 
+         * we do not want to create an additional HttpRequestEvent in the http_events
+         * table when a request comes through the SNI logic.
+         * 
+         * This logic should be consolidated/removed.
+         * 
          */
         HttpRequestEvent evt = null;
         
@@ -298,9 +314,9 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             requestLine.setHttpRequestEvent(evt);
             this.app.logEvent(evt);
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_HTTP_REQUEST_EVENT, evt);
-            logger.info("Creating new HttpRequestEvent: " + evt.toString());
+            logger.debug("Creating new HttpRequestEvent: " + evt.toString());
         } else {
-            logger.info("Using existing HttpRequestEvent: " + evt.toString());
+            logger.debug("Using existing HttpRequestEvent: " + evt.toString());
         }
 
         // attach the hostname we extracted to the session


### PR DESCRIPTION
This PR contains some temporary fixes prior to 15.0 until NGFW-12885 is implemented.

We were creating double the amount of events in the http_events table due to our current HTTPS SNI implementation between Web Filter and Threat Prevention. This was causing a doubling up of events for every HTTPS request that went through the Threat Prevention and Web Filter applications. Our temporary fix is to use the session globals to store the RequestLine, RequestLineToken, and HttpRequestEvent objects in the session globals for a given Session ID. This will allow the applications to function properly, while also cutting down on the amount of events generated.