### PR TITLE
NGFW-12877: threat-prevention: Handle "Host" headers with appended port

### DIFF
--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionDecisionEngine.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionDecisionEngine.java
@@ -239,6 +239,7 @@ public class ThreatPreventionDecisionEngine
          * this stores the corresponding reason for the flag/block
          */
         URI requestUri = null;
+        int pos;
 
         try {
             requestUri = new URI(CONSECUTIVE_SLASHES_URI_PATTERN.matcher(requestLine.getRequestUri().normalize().toString()).replaceAll("/"));
@@ -265,6 +266,17 @@ public class ThreatPreventionDecisionEngine
         }
 
         uri = CONSECUTIVE_SLASHES_PATH_PATTERN.matcher(uri).replaceAll("/");
+
+        /*
+         * We have seen a case where the host in the "Host"
+         * header actually has a port number appended to it
+         * bctid doesn't work with the port appended to the
+         * host, so strip it here if it exists (NGFW-12877)
+         */
+        pos = host.indexOf(':');
+        if (pos > 0) {
+            host = host.substring(0, pos);
+        }
 
         Boolean match = false;
         if(addressQuery(clientIp, sess.getServerAddr(), host + uri, sess)){


### PR DESCRIPTION
We have seen a case where the host specified in the "Host" header
had the port appended.  bctid doesn't handle requests with the
port specified in the url.

Example:

This request would get its reputation reported correctly:

wget ws.trackmytime.com

But this one would not:

wget --header="Host: ws.trackmytime.com:80" ws.trackmytime.com

Since we know bctid can't handle the port, strip it from the host
if it exits, before we send the reputation request to bctid.

NGFW-12877