### PR TITLE
buildtools: prioritizing openjdk11 over openjdk8

### DIFF
--- a/buildtools/buildtools.rb
+++ b/buildtools/buildtools.rb
@@ -3,6 +3,7 @@
 
 arch = `dpkg-architecture -qDEB_TARGET_ARCH_CPU`.strip()
 openjdk8 = "java-8-openjdk-#{arch}"
+openjdk11 = "java-11-openjdk-#{arch}"
 
 jvm = case arch
       when "armel"
@@ -11,7 +12,7 @@ jvm = case arch
       when "armhf"
         File.exist?("/usr/lib/jvm/#{openjdk8}") ? openjdk8 : "jdk-7-oracle-arm-vfp-hflt"
       else
-        File.exist?("/usr/lib/jvm/#{openjdk8}") ? openjdk8 : "java-11-openjdk-#{arch}"
+        File.exist?("/usr/lib/jvm/#{openjdk11}") ? openjdk11 : openjdk8
       end
 warn "JVM = #{jvm}"
 ENV['JAVA_HOME'] = "/usr/lib/jvm/#{jvm}"


### PR DESCRIPTION
Wondering if this should apply to armhf and armel as well, or if we should remove openjdk8 during the upgrade?