### PR TITLE
Vendor1 session tuple

### DIFF
--- a/uvm/api/com/untangle/uvm/app/AppBase.java
+++ b/uvm/api/com/untangle/uvm/app/AppBase.java
@@ -416,7 +416,7 @@ public abstract class AppBase implements App
         List<SessionTuple> sessions = new LinkedList<>();
 
         for (AppSession sess : liveAppSessions()) {
-            SessionTuple tuple = new SessionTuple(sess.getProtocol(), sess.getClientAddr(), sess.getServerAddr(), sess.getClientPort(), sess.getServerPort());
+            SessionTuple tuple = new SessionTuple(sess.getProtocol(), sess.getClientAddr(), sess.getServerAddr(), sess.getClientPort(), sess.getServerPort(), sess.getClientIntf(), sess.getServerIntf());
             sessions.add(tuple);
         }
 

--- a/uvm/api/com/untangle/uvm/app/AppBase.java
+++ b/uvm/api/com/untangle/uvm/app/AppBase.java
@@ -416,7 +416,7 @@ public abstract class AppBase implements App
         List<SessionTuple> sessions = new LinkedList<>();
 
         for (AppSession sess : liveAppSessions()) {
-            SessionTuple tuple = new SessionTuple(sess.getProtocol(), sess.getClientAddr(), sess.getServerAddr(), sess.getClientPort(), sess.getServerPort(), sess.getClientIntf(), sess.getServerIntf());
+            SessionTuple tuple = new SessionTuple(sess.getProtocol(), sess.getClientAddr(), sess.getServerAddr(), sess.getClientPort(), sess.getServerPort(), sess.getClientIntf());
             sessions.add(tuple);
         }
 

--- a/uvm/api/com/untangle/uvm/app/SessionTuple.java
+++ b/uvm/api/com/untangle/uvm/app/SessionTuple.java
@@ -20,6 +20,8 @@ public class SessionTuple
     private int clientPort = 0;
     private InetAddress serverAddr;
     private int serverPort = 0;
+    private int srcInterface = 0;
+    private int dstInterface = 0;
 
     /**
      * Constructor
@@ -28,14 +30,18 @@ public class SessionTuple
      * @param serverAddr The server address
      * @param clientPort The client port
      * @param serverPort The server port
+     * @param srcInterface The source interface
+     * @param dstInterface the destination interface
      */
-    public SessionTuple( short protocol, InetAddress clientAddr, InetAddress serverAddr, int clientPort, int serverPort )
+    public SessionTuple( short protocol, InetAddress clientAddr, InetAddress serverAddr, int clientPort, int serverPort, int srcInterface, int dstInterface )
     {
         this.protocol = protocol;
         this.clientAddr = clientAddr;
         this.clientPort = clientPort;
         this.serverAddr = serverAddr;
         this.serverPort = serverPort;
+        this.srcInterface = srcInterface;
+        this.dstInterface = dstInterface;
     }
 
     /**
@@ -49,6 +55,8 @@ public class SessionTuple
         this.clientPort = tuple.getClientPort();
         this.serverAddr = tuple.getServerAddr();
         this.serverPort = tuple.getServerPort();
+        this.srcInterface = tuple.getSrcInterface();
+        this.dstInterface = tuple.getDstInterface();
     }
 
     /**
@@ -106,12 +114,36 @@ public class SessionTuple
      * @return the server port.
      */
     public int getServerPort() { return this.serverPort; }
-    
+
     /**
      * Set the server port
      * @param serverPort The server port
      */
     public void setServerPort( int serverPort ) { this.serverPort = serverPort; }
+
+    /**
+     * Get the source interface
+     * @return the source interface
+     */
+    public int getSrcInterface() { return this.srcInterface; }
+
+    /**
+     * Set the source interface
+     * @param srcInterface The source interface
+     */
+    public void setSrcInterface(int srcInterface) { this.srcInterface = srcInterface; }
+
+    /**
+     * Get the destination interface
+     * @return The destination interface
+     */
+    public int getDstInterface() { return this.dstInterface; }
+
+    /**
+     * Set the destination interface
+     * @param dstInterface The destination interface
+     */
+    public void setDstInterface(int dstInterface) { this.dstInterface = dstInterface; }
 
     /**
      * Get the hash code
@@ -121,9 +153,9 @@ public class SessionTuple
     public int hashCode()
     {
         if ( clientAddr == null || serverAddr == null )
-            return protocol + clientPort + serverPort;
+            return protocol + clientPort + serverPort + srcInterface + dstInterface;
         else
-            return protocol + clientAddr.hashCode() + clientPort + serverAddr.hashCode() + serverPort;
+            return protocol + clientAddr.hashCode() + clientPort + serverAddr.hashCode() + serverPort + srcInterface + dstInterface;
     }
 
     /**
@@ -145,6 +177,8 @@ public class SessionTuple
             return false;
         if ( ! ( t.serverAddr == null ? this.serverAddr == null : t.serverAddr.equals(this.serverAddr) ) )
             return false;
+        if ( t.srcInterface != this.srcInterface || t.dstInterface != this.dstInterface )
+            return false;
         return true;
     }
 
@@ -156,6 +190,8 @@ public class SessionTuple
     public String toString()
     {
         String str = "[Tuple ";
+        str += "{" + Integer.toString(srcInterface) + "|" + Integer.toString(dstInterface) + "} ";
+
         switch ( protocol ) {
         case PROTO_UDP:
             str += "UDP ";

--- a/uvm/api/com/untangle/uvm/app/SessionTuple.java
+++ b/uvm/api/com/untangle/uvm/app/SessionTuple.java
@@ -21,7 +21,6 @@ public class SessionTuple
     private InetAddress serverAddr;
     private int serverPort = 0;
     private int srcInterface = 0;
-    private int dstInterface = 0;
 
     /**
      * Constructor
@@ -31,9 +30,8 @@ public class SessionTuple
      * @param clientPort The client port
      * @param serverPort The server port
      * @param srcInterface The source interface
-     * @param dstInterface the destination interface
      */
-    public SessionTuple( short protocol, InetAddress clientAddr, InetAddress serverAddr, int clientPort, int serverPort, int srcInterface, int dstInterface )
+    public SessionTuple( short protocol, InetAddress clientAddr, InetAddress serverAddr, int clientPort, int serverPort, int srcInterface )
     {
         this.protocol = protocol;
         this.clientAddr = clientAddr;
@@ -41,7 +39,6 @@ public class SessionTuple
         this.serverAddr = serverAddr;
         this.serverPort = serverPort;
         this.srcInterface = srcInterface;
-        this.dstInterface = dstInterface;
     }
 
     /**
@@ -56,7 +53,6 @@ public class SessionTuple
         this.serverAddr = tuple.getServerAddr();
         this.serverPort = tuple.getServerPort();
         this.srcInterface = tuple.getSrcInterface();
-        this.dstInterface = tuple.getDstInterface();
     }
 
     /**
@@ -134,18 +130,6 @@ public class SessionTuple
     public void setSrcInterface(int srcInterface) { this.srcInterface = srcInterface; }
 
     /**
-     * Get the destination interface
-     * @return The destination interface
-     */
-    public int getDstInterface() { return this.dstInterface; }
-
-    /**
-     * Set the destination interface
-     * @param dstInterface The destination interface
-     */
-    public void setDstInterface(int dstInterface) { this.dstInterface = dstInterface; }
-
-    /**
      * Get the hash code
      * @return The hash code
      */
@@ -153,9 +137,9 @@ public class SessionTuple
     public int hashCode()
     {
         if ( clientAddr == null || serverAddr == null )
-            return protocol + clientPort + serverPort + srcInterface + dstInterface;
+            return protocol + clientPort + serverPort + srcInterface;
         else
-            return protocol + clientAddr.hashCode() + clientPort + serverAddr.hashCode() + serverPort + srcInterface + dstInterface;
+            return protocol + clientAddr.hashCode() + clientPort + serverAddr.hashCode() + serverPort + srcInterface;
     }
 
     /**
@@ -177,7 +161,7 @@ public class SessionTuple
             return false;
         if ( ! ( t.serverAddr == null ? this.serverAddr == null : t.serverAddr.equals(this.serverAddr) ) )
             return false;
-        if ( t.srcInterface != this.srcInterface || t.dstInterface != this.dstInterface )
+        if ( t.srcInterface != this.srcInterface )
             return false;
         return true;
     }
@@ -190,7 +174,7 @@ public class SessionTuple
     public String toString()
     {
         String str = "[Tuple ";
-        str += "{" + Integer.toString(srcInterface) + "|" + Integer.toString(dstInterface) + "} ";
+        str += "{" + Integer.toString(srcInterface) + "} ";
 
         switch ( protocol ) {
         case PROTO_UDP:

--- a/uvm/impl/com/untangle/uvm/ConntrackMonitorImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConntrackMonitorImpl.java
@@ -250,7 +250,7 @@ public class ConntrackMonitorImpl
                 for (Conntrack conntrack : dumpEntries) {
                     try {
                         long sessionId = 0;
-                        SessionTuple tuple = new SessionTuple(conntrack.getProtocol(), conntrack.getPreNatClient(), conntrack.getPreNatServer(), conntrack.getPreNatClientPort(), conntrack.getPreNatServerPort());
+                        SessionTuple tuple = new SessionTuple(conntrack.getProtocol(), conntrack.getPreNatClient(), conntrack.getPreNatServer(), conntrack.getPreNatClientPort(), conntrack.getPreNatServerPort(), conntrack.getClientIntf(), conntrack.getServerIntf());
                         /**
                          * Lookup the session from the previous conntrack
                          * entries

--- a/uvm/impl/com/untangle/uvm/ConntrackMonitorImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConntrackMonitorImpl.java
@@ -250,7 +250,7 @@ public class ConntrackMonitorImpl
                 for (Conntrack conntrack : dumpEntries) {
                     try {
                         long sessionId = 0;
-                        SessionTuple tuple = new SessionTuple(conntrack.getProtocol(), conntrack.getPreNatClient(), conntrack.getPreNatServer(), conntrack.getPreNatClientPort(), conntrack.getPreNatServerPort(), conntrack.getClientIntf(), conntrack.getServerIntf());
+                        SessionTuple tuple = new SessionTuple(conntrack.getProtocol(), conntrack.getPreNatClient(), conntrack.getPreNatServer(), conntrack.getPreNatClientPort(), conntrack.getPreNatServerPort(), conntrack.getClientIntf());
                         /**
                          * Lookup the session from the previous conntrack
                          * entries

--- a/uvm/impl/com/untangle/uvm/NetcapConntrackHook.java
+++ b/uvm/impl/com/untangle/uvm/NetcapConntrackHook.java
@@ -96,8 +96,7 @@ public class NetcapConntrackHook implements NetcapCallback
                                                            ct.getPreNatServer(),
                                                            ct.getPreNatClientPort(),
                                                            ct.getPreNatServerPort(),
-                                                           clientIntf,
-                                                           serverIntf );
+                                                           clientIntf );
 
             boolean logEvent = UvmContextFactory.context().networkManager().getNetworkSettings().getLogBypassedSessions();
             

--- a/uvm/impl/com/untangle/uvm/NetcapConntrackHook.java
+++ b/uvm/impl/com/untangle/uvm/NetcapConntrackHook.java
@@ -95,7 +95,9 @@ public class NetcapConntrackHook implements NetcapCallback
                                                            ct.getPreNatClient(),
                                                            ct.getPreNatServer(),
                                                            ct.getPreNatClientPort(),
-                                                           ct.getPreNatServerPort() );
+                                                           ct.getPreNatServerPort(),
+                                                           clientIntf,
+                                                           serverIntf );
 
             boolean logEvent = UvmContextFactory.context().networkManager().getNetworkSettings().getLogBypassedSessions();
             

--- a/uvm/impl/com/untangle/uvm/NetcapHook.java
+++ b/uvm/impl/com/untangle/uvm/NetcapHook.java
@@ -144,13 +144,17 @@ public abstract class NetcapHook implements Runnable
                                            netcapSession.clientSide().client().host(),
                                            netcapSession.clientSide().server().host(),
                                            netcapSession.clientSide().client().port(),
-                                           netcapSession.clientSide().server().port());
+                                           netcapSession.clientSide().server().port(),
+                                           netcapSession.clientSide().interfaceId(),
+                                           netcapSession.serverSide().interfaceId());
             sessionGlobalState.setClientSideTuple( clientSide );
             serverSide = new SessionTuple( sessionGlobalState.getProtocol(),
                                            netcapSession.serverSide().client().host(),
                                            netcapSession.serverSide().server().host(),
                                            netcapSession.serverSide().client().port(),
-                                           netcapSession.serverSide().server().port());
+                                           netcapSession.serverSide().server().port(),
+                                           netcapSession.serverSide().interfaceId(),
+                                           netcapSession.clientSide().interfaceId());
             sessionGlobalState.setServerSideTuple( clientSide );
 
             
@@ -367,7 +371,9 @@ public abstract class NetcapHook implements Runnable
                                                sessionEvent.getSClientAddr(),
                                                sessionEvent.getSServerAddr(),
                                                sessionEvent.getSClientPort(),
-                                               sessionEvent.getSServerPort());
+                                               sessionEvent.getSServerPort(),
+                                               sessionEvent.getServerIntf(),
+                                               sessionEvent.getClientIntf());
 
             /* Connect to the client */
             clientActionCompleted = connectClientIfNecessary();

--- a/uvm/impl/com/untangle/uvm/NetcapHook.java
+++ b/uvm/impl/com/untangle/uvm/NetcapHook.java
@@ -145,15 +145,13 @@ public abstract class NetcapHook implements Runnable
                                            netcapSession.clientSide().server().host(),
                                            netcapSession.clientSide().client().port(),
                                            netcapSession.clientSide().server().port(),
-                                           netcapSession.clientSide().interfaceId(),
-                                           netcapSession.serverSide().interfaceId());
+                                           netcapSession.clientSide().interfaceId());
             sessionGlobalState.setClientSideTuple( clientSide );
             serverSide = new SessionTuple( sessionGlobalState.getProtocol(),
                                            netcapSession.serverSide().client().host(),
                                            netcapSession.serverSide().server().host(),
                                            netcapSession.serverSide().client().port(),
                                            netcapSession.serverSide().server().port(),
-                                           netcapSession.serverSide().interfaceId(),
                                            netcapSession.clientSide().interfaceId());
             sessionGlobalState.setServerSideTuple( clientSide );
 
@@ -372,7 +370,6 @@ public abstract class NetcapHook implements Runnable
                                                sessionEvent.getSServerAddr(),
                                                sessionEvent.getSClientPort(),
                                                sessionEvent.getSServerPort(),
-                                               sessionEvent.getServerIntf(),
                                                sessionEvent.getClientIntf());
 
             /* Connect to the client */

--- a/uvm/impl/com/untangle/uvm/PipelineFoundryImpl.java
+++ b/uvm/impl/com/untangle/uvm/PipelineFoundryImpl.java
@@ -285,7 +285,9 @@ public class PipelineFoundryImpl implements PipelineFoundry
         int index = 0;
         List<PipelineConnectorImpl> pipelineConnectors = null;
         try{
-            SessionTuple sessionTuple = new SessionTuple(protocol, InetAddress.getByName(clientIp), InetAddress.getByName(serverIp), clientPort, serverPort);
+            // TODO - For now we just use zero for src and dst interfaces since they
+            // don't currently factor into any traffic processing decisions.
+            SessionTuple sessionTuple = new SessionTuple(protocol, InetAddress.getByName(clientIp), InetAddress.getByName(serverIp), clientPort, serverPort, 0, 0);
             pipelineConnectors = weld( 0L, sessionTuple, policyId, true );
             result = new JSONArray();
             for(PipelineConnectorImpl pci : pipelineConnectors){

--- a/uvm/impl/com/untangle/uvm/PipelineFoundryImpl.java
+++ b/uvm/impl/com/untangle/uvm/PipelineFoundryImpl.java
@@ -287,7 +287,7 @@ public class PipelineFoundryImpl implements PipelineFoundry
         try{
             // TODO - For now we just use zero for src and dst interfaces since they
             // don't currently factor into any traffic processing decisions.
-            SessionTuple sessionTuple = new SessionTuple(protocol, InetAddress.getByName(clientIp), InetAddress.getByName(serverIp), clientPort, serverPort, 0, 0);
+            SessionTuple sessionTuple = new SessionTuple(protocol, InetAddress.getByName(clientIp), InetAddress.getByName(serverIp), clientPort, serverPort, 0);
             pipelineConnectors = weld( 0L, sessionTuple, policyId, true );
             result = new JSONArray();
             for(PipelineConnectorImpl pci : pipelineConnectors){

--- a/uvm/impl/com/untangle/uvm/SessionMonitorImpl.java
+++ b/uvm/impl/com/untangle/uvm/SessionMonitorImpl.java
@@ -385,7 +385,7 @@ public class SessionMonitorImpl implements SessionMonitor
             logger.warn("Unknown protocol: " + protocolStr);
             protocol = 0;
         }
-        return new SessionTuple( protocol, preNatClient, preNatServer, preNatClientPort, preNatServerPort, clientIntf, serverIntf );
+        return new SessionTuple( protocol, preNatClient, preNatServer, preNatClientPort, preNatServerPort, clientIntf );
     }
 
     /**
@@ -409,8 +409,7 @@ public class SessionMonitorImpl implements SessionMonitor
                                      session.getPreNatServer(),
                                      session.getPreNatClientPort(),
                                      session.getPreNatServerPort(),
-                                     session.getClientIntf(),
-                                     session.getServerIntf() );
+                                     session.getClientIntf() );
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/SessionMonitorImpl.java
+++ b/uvm/impl/com/untangle/uvm/SessionMonitorImpl.java
@@ -131,8 +131,8 @@ public class SessionMonitorImpl implements SessionMonitor
                     session.setCreationTime(sessionState.getCreationTime());
                     session.setPipeline(sessionState.getPipelineDescription());
                     session.setBypassed(Boolean.FALSE);
-                    session.setClientIntf(new Integer(sessionState.getClientIntf()));
-                    session.setServerIntf(new Integer(sessionState.getServerIntf()));
+                    session.setClientIntf(sessionState.getClientIntf());
+                    session.setServerIntf(sessionState.getServerIntf());
                     session.setHostname(sessionState.getSessionEvent().getHostname());
                     session.setUsername(sessionState.getSessionEvent().getUsername());
 
@@ -385,7 +385,7 @@ public class SessionMonitorImpl implements SessionMonitor
             logger.warn("Unknown protocol: " + protocolStr);
             protocol = 0;
         }
-        return new SessionTuple( protocol, preNatClient, preNatServer, preNatClientPort, preNatServerPort );
+        return new SessionTuple( protocol, preNatClient, preNatServer, preNatClientPort, preNatServerPort, clientIntf, serverIntf );
     }
 
     /**
@@ -408,7 +408,9 @@ public class SessionMonitorImpl implements SessionMonitor
                                      session.getPreNatClient(),
                                      session.getPreNatServer(),
                                      session.getPreNatClientPort(),
-                                     session.getPreNatServerPort() );
+                                     session.getPreNatServerPort(),
+                                     session.getClientIntf(),
+                                     session.getServerIntf() );
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/SessionTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/SessionTableImpl.java
@@ -115,7 +115,10 @@ public class SessionTableImpl
                                                               session.netcapSession().clientSide().client().host(),
                                                               session.netcapSession().clientSide().server().host(),
                                                               session.netcapSession().clientSide().client().port(),
-                                                              session.netcapSession().clientSide().server().port());
+                                                              session.netcapSession().clientSide().server().port(),
+                                                              session.netcapSession().clientSide().interfaceId(),
+                                                              session.netcapSession().serverSide().interfaceId()
+                                                              );
 // THIS IS FOR ECLIPSE - @formatter:on
 
             sessionTableByTuple.put(tupleKey, session);
@@ -147,7 +150,10 @@ public class SessionTableImpl
                                                       session.netcapSession().clientSide().client().host(),
                                                       session.netcapSession().clientSide().server().host(),
                                                       session.netcapSession().clientSide().client().port(),
-                                                      session.netcapSession().clientSide().server().port());
+                                                      session.netcapSession().clientSide().server().port(),
+                                                      session.netcapSession().clientSide().interfaceId(),
+                                                      session.netcapSession().serverSide().interfaceId()
+                                                      );
 // THIS IS FOR ECLIPSE - @formatter:on
 
             if (sessionTableByTuple.remove(tupleKey) == null) {
@@ -188,7 +194,7 @@ public class SessionTableImpl
      */
     protected synchronized SessionGlobalState remove(short protocol, int clientIntf, int serverIntf, InetAddress clientAddr, InetAddress serverAddr, int clientPort, int serverPort)
     {
-        SessionTuple tupleKey = new SessionTuple(protocol, clientAddr, serverAddr, clientPort, serverPort);
+        SessionTuple tupleKey = new SessionTuple(protocol, clientAddr, serverAddr, clientPort, serverPort, clientIntf, serverIntf);
         SessionGlobalState session = sessionTableByTuple.get(tupleKey);
         if (session == null) {
             return null;

--- a/uvm/impl/com/untangle/uvm/SessionTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/SessionTableImpl.java
@@ -116,8 +116,7 @@ public class SessionTableImpl
                                                               session.netcapSession().clientSide().server().host(),
                                                               session.netcapSession().clientSide().client().port(),
                                                               session.netcapSession().clientSide().server().port(),
-                                                              session.netcapSession().clientSide().interfaceId(),
-                                                              session.netcapSession().serverSide().interfaceId()
+                                                              session.netcapSession().clientSide().interfaceId()
                                                               );
 // THIS IS FOR ECLIPSE - @formatter:on
 
@@ -151,8 +150,7 @@ public class SessionTableImpl
                                                       session.netcapSession().clientSide().server().host(),
                                                       session.netcapSession().clientSide().client().port(),
                                                       session.netcapSession().clientSide().server().port(),
-                                                      session.netcapSession().clientSide().interfaceId(),
-                                                      session.netcapSession().serverSide().interfaceId()
+                                                      session.netcapSession().clientSide().interfaceId()
                                                       );
 // THIS IS FOR ECLIPSE - @formatter:on
 
@@ -194,7 +192,7 @@ public class SessionTableImpl
      */
     protected synchronized SessionGlobalState remove(short protocol, int clientIntf, int serverIntf, InetAddress clientAddr, InetAddress serverAddr, int clientPort, int serverPort)
     {
-        SessionTuple tupleKey = new SessionTuple(protocol, clientAddr, serverAddr, clientPort, serverPort, clientIntf, serverIntf);
+        SessionTuple tupleKey = new SessionTuple(protocol, clientAddr, serverAddr, clientPort, serverPort, clientIntf);
         SessionGlobalState session = sessionTableByTuple.get(tupleKey);
         if (session == null) {
             return null;


### PR DESCRIPTION
I don't know of any way to test this outside the actual environment where this issue was discovered, so my recommendation is to do a normal regression test to make sure this doesn't introduce new problems with normal traffic processing, and then create a release that can be provided to anyone who needs this functionality.

Here are the details:

I enhanced the uvm to include the source interface in the SessionTuple we use when caching sessions that are being processed. This should resolve an issue where we can't properly handle two identical sessions on different VLAN's.

Historically we have cached active sessions based on a 5-tuple:
proto+src_addr+src_port+dst_addr+dst_port

Before this change, creating an identical session on a second VLAN would not work, because the uvm would see the traffic as belonging to an existing session, and treat the new session initiation as an invalid SYN for an existing session.

With this change we now cache active sessions based on a 6-tuple:
proto+src_addr+src_port+dst_addr+dst_port+src_interface

Since each VLAN is assigned a unique interface ID value, this is the functional equivalent of adding the source VLAN tag as part of the session caching model, allowing us to now track identical sessions that differ only by the VLAN tag.
