### PR TITLE
NGFW-13045: openvpn: Stop client process for removed remote servers

### DIFF
--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
@@ -922,6 +922,9 @@ public class OpenVpnAppImpl extends AppBase
 
             if (found == true) continue;
 
+            logger.info("Stopping client OpenVPN proecess for openvpn@" + serverName + ".service");
+            UvmContextFactory.context().execManager().exec("systemctl stop openvpn@" + serverName + ".service");
+
             // no matching server so get rid of the config file and keys
             logger.info("Cleanup removing: " + target);
 


### PR DESCRIPTION
When we remove a remote server configuration from an openvpn client,
make sure we actually stop the openvpn process when we are cleaning
up.

NGFW-13045