### PR TITLE
Ngfw 12914 local radius server

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-radius-logfile
+++ b/uvm/hier/usr/share/untangle/bin/ut-radius-logfile
@@ -1,0 +1,6 @@
+#!/bin/dash
+
+# Grab most recent output from the Freeradius log file
+tail -n 1024 /var/log/freeradius/radius.log | /usr/bin/tac
+
+exit 0

--- a/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
+++ b/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
@@ -544,8 +544,8 @@ public class LocalDirectoryImpl implements LocalDirectory
                 fw.write("\tsyslog_facility = daemon\n");
                 fw.write("\tstripped_names = no\n");
                 fw.write("\tauth = yes\n");
-                fw.write("\tauth_badpass = yes\n");
-                fw.write("\tauth_goodpass = yes\n");
+                fw.write("\tauth_badpass = no\n");
+                fw.write("\tauth_goodpass = no\n");
                 fw.write("\tmsg_goodpass = \"UT_RADIUS_GOOD\"\n");
                 fw.write("\tmsg_badpass = \"UT_RADIUS_FAIL\"\n");
                 fw.write("\tmsg_denied = \"Access Denied\"\n");

--- a/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
+++ b/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
@@ -35,6 +35,7 @@ public class LocalDirectoryImpl implements LocalDirectory
     private final static String XAUTH_SECRETS_FILE = "/etc/xauth.secrets";
     private final static String IPSEC_RELOAD_SECRETS = "/usr/sbin/ipsec rereadsecrets";
 
+    private final static String FREERADIUS_LOGFILE_SCRIPT = System.getProperty("uvm.home") + "/bin/ut-radius-logfile";
     private final static String FREERADIUS_LOCAL_SECRETS = "/etc/freeradius/3.0/mods-config/files/untangle.local";
     private final static String FREERADIUS_AUTHORIZE = "/etc/freeradius/3.0/mods-config/files/authorize";
     private final static String FREERADIUS_RADIUSD = "/etc/freeradius/3.0/radiusd.conf";
@@ -56,6 +57,17 @@ public class LocalDirectoryImpl implements LocalDirectory
 
         // install a callback for network settings changes
         UvmContextFactory.context().hookManager().registerCallback(com.untangle.uvm.HookManager.NETWORK_SETTINGS_CHANGE, networkSaveHookCallback);
+    }
+
+    /**
+     * Gets the contents of the radius server log file
+     *
+     * @return The contents of the radius server log file
+     */
+    public String getRadiusLogFile()
+    {
+        logger.debug("getRadiusLogFile()");
+        return UvmContextFactory.context().execManager().execOutput(FREERADIUS_LOGFILE_SCRIPT);
     }
 
     /**
@@ -546,8 +558,8 @@ public class LocalDirectoryImpl implements LocalDirectory
                 fw.write("\tauth = yes\n");
                 fw.write("\tauth_badpass = no\n");
                 fw.write("\tauth_goodpass = no\n");
-                fw.write("\tmsg_goodpass = \"UT_RADIUS_GOOD\"\n");
-                fw.write("\tmsg_badpass = \"UT_RADIUS_FAIL\"\n");
+                fw.write("\tmsg_goodpass = \"RADIUS_ACCEPT\"\n");
+                fw.write("\tmsg_badpass = \"RADIUS_REJECT\"\n");
                 fw.write("\tmsg_denied = \"Access Denied\"\n");
                 fw.write("}\n");
                 fw.write("checkrad = ${sbindir}/checkrad\n");

--- a/uvm/servlets/admin/config/local-directory/MainController.js
+++ b/uvm/servlets/admin/config/local-directory/MainController.js
@@ -6,7 +6,8 @@ Ext.define('Ung.config.local-directory.MainController', {
     control: {
         '#': {
             beforerender: 'loadSettings'
-        }
+        },
+        '#radius-log': { afterrender: 'refreshRadiusLogFile' }
     },
 
     loadSettings: function () {
@@ -121,6 +122,23 @@ Ext.define('Ung.config.local-directory.MainController', {
 
     configureCertificate: function (btn) {
         Ung.app.redirectTo("#config/administration/certificates");
+    },
+
+    refreshRadiusLogFile: function (cmp) {
+        var v = cmp.isXType('button') ? cmp.up('panel') : cmp;
+        var target = v.down('textarea');
+
+        target.setValue('');
+
+        v.setLoading(true);
+        Rpc.asyncData('rpc.UvmContext.localDirectory.getRadiusLogFile')
+        .then(function(result){
+            if(Util.isDestroyed(v, target)){
+                return;
+            }
+            target.setValue(result);
+            v.setLoading(false);
+        });
     },
 
     statics:{

--- a/uvm/servlets/admin/config/local-directory/view/Radius.js
+++ b/uvm/servlets/admin/config/local-directory/view/Radius.js
@@ -41,6 +41,31 @@ Ext.define('Ung.config.local-directory.view.Radius', {
             },
             handler: 'configureCertificate'
         }]
+    }, {
+        xtype: 'fieldset',
+        padding: '10 20',
+        itemId: 'radius-log',
+        width: '80%',
+        title: 'RADIUS Server Log'.t(),
+        items: [{
+            xtype: 'button',
+            iconCls: 'fa fa-refresh',
+            text: 'Refresh',
+            target: 'radiusLogFile',
+            handler: 'refreshRadiusLogFile'
+        }, {
+            xtype: 'textarea',
+            itemId: 'radiusLogFile',
+            spellcheck: false,
+            padding: '5 0',
+            border: true,
+            width: '100%',
+            height: 500,
+            bind: '{radiusLogFile}',
+            fieldStyle: {
+                'fontFamily'   : 'courier new',
+                'fontSize'     : '12px'
+            }
+        }]
     }]
-
 });


### PR DESCRIPTION
I think this is ready for testing. One critical thing... don't forget to add an access rule to allow RADIUS traffic (UDP port 1812) from the wireless access point to the Untangle. We'll likely do this automatically in a future release, but since for now this is expert-mode only, the rule creation is manual.

In my environment, I have my access point connected to the LAN, so I created an access rule to allow all UDP 1812 traffic from non-WAN's.

My UT = 192.168.20.1
My WAP = 192.168.20.222
My clients = 192.168.20.100 - 192.168.20.200

Configure your access point to do WPA/WPA2 Enterprise, and provide the IP address and shared secret configured on the untangle. That should be it. Once configured, clients should be able to connect to the WiFi by providing a username/password configured in the local directory on the untangle.
