### PR TITLE
Hide RADIUS column on certificates table

### DIFF
--- a/uvm/servlets/admin/config/administration/MainController.js
+++ b/uvm/servlets/admin/config/administration/MainController.js
@@ -81,6 +81,9 @@ Ext.define('Ung.config.administration.MainController', {
     loadAdmin: function () {
         var me = this, v = me.getView(),vm = me.getViewModel();
 
+        // set expert mode used to show/hide RADIUS section
+        vm.set('expertMode', Rpc.directData('rpc.isExpertMode'));
+
         v.setLoading(true);
         Ext.Deferred.sequence([
             Rpc.asyncPromise('rpc.adminManager.getSettings'),

--- a/uvm/servlets/admin/config/administration/view/Certificates.js
+++ b/uvm/servlets/admin/config/administration/view/Certificates.js
@@ -180,6 +180,9 @@ Ext.define('Ung.config.administration.view.Certificates', {
                 xtype: 'checkcolumn',
                 width: 80,
                 dataIndex: 'radiusServer',
+                bind: {
+                    hidden: '{!expertMode}'
+                },
                 listeners: {
                     // don't allow uncheck - they must pick a different cert
                     beforecheckchange: function (el, rowIndex, checked) {


### PR DESCRIPTION
Fix to hide the RADIUS checkbox column on the certificate selection
table if the expert mode flag is not set.