### PR TITLE
Ngfw 12983 ipsec tunnel reconnect

### DIFF
--- a/ipsec-vpn/js/view/IpsecTunnels.js
+++ b/ipsec-vpn/js/view/IpsecTunnels.js
@@ -52,8 +52,7 @@ Ext.define('Ung.apps.ipsecvpn.view.IpsecTunnels', {
         'description': '',
         'secret': '',
         'localInterface': 0,
-        'pingAddress': '',
-        'pingInterval': 0
+        'pingAddress': ''
         },
 
     bind: '{tunnelList}',
@@ -387,24 +386,6 @@ Ext.define('Ung.apps.ipsecvpn.view.IpsecTunnels', {
             xtype: 'displayfield',
             margin: '0 0 0 10',
             value: 'An IP address on the remote network to ping for connectivity verification. Leave blank to disable.'.t()
-        }]
-    }, {
-        xtype: 'container',
-        layout: 'column',
-        margin: '0 0 5 0',
-        items: [{
-            xtype:'numberfield',
-            bind: '{record.pingInterval}',
-            fieldLabel: 'Ping Interval'.t(),
-            labelWidth: 120,
-            allowBlank: false,
-            allowDecimals: false,
-            minValue: 0,
-            maxValue: 30
-        }, {
-            xtype: 'displayfield',
-            margin: '0 0 0 10',
-            value: 'How often to ping the configured ping address address. Enter 0 to disable.'.t()
         }]
     }, {
         xtype: 'container',

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
@@ -380,12 +380,13 @@ public class IpsecVpnApp extends AppBase
     {
         logger.debug("postStart()");
 
-        // our DataTimer class expects to be called once every minute
+        // our DataTimer class expects to run every sixty (60) seconds
         dataTimer = new Timer();
         dataTimer.schedule(new IpsecVpnDataTimer(this), 60000, 60000);
 
+        // our PingTimer class expects to run every twenty (20) seconds
         pingTimer = new Timer();
-        pingTimer.schedule(new IpsecVpnPingTimer(this), 5000, 5000);
+        pingTimer.schedule(new IpsecVpnPingTimer(this), 20000, 20000);
     }
 
     /**

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
@@ -75,7 +75,8 @@ public class IpsecVpnApp extends AppBase
     }
 
     protected IpsecVpnSettings settings;
-    protected Timer timer;
+    protected Timer dataTimer;
+    protected Timer pingTimer;
 
     private String activeCertificate = UvmContextFactory.context().systemManager().getSettings().getIpsecCertificate();
 
@@ -370,7 +371,7 @@ public class IpsecVpnApp extends AppBase
     }
 
     /**
-     * After the app is started, we create our monitoring timer task.
+     * After the app is started, we create our timer tasks
      * 
      * @param isPermanentTransition
      */
@@ -379,9 +380,12 @@ public class IpsecVpnApp extends AppBase
     {
         logger.debug("postStart()");
 
-        // our timer class expects to be called once every minute
-        timer = new Timer();
-        timer.schedule(new IpsecVpnTimer(this), 60000, 60000);
+        // our DataTimer class expects to be called once every minute
+        dataTimer = new Timer();
+        dataTimer.schedule(new IpsecVpnDataTimer(this), 60000, 60000);
+
+        pingTimer = new Timer();
+        pingTimer.schedule(new IpsecVpnPingTimer(this), 5000, 5000);
     }
 
     /**
@@ -399,7 +403,8 @@ public class IpsecVpnApp extends AppBase
 
         UvmContextFactory.context().hookManager().unregisterCallback(com.untangle.uvm.HookManager.UVM_SETTINGS_CHANGE, this.ipsecVpnHookCallback);
 
-        timer.cancel();
+        dataTimer.cancel();
+        pingTimer.cancel();
 
         int counter = 0;
 

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnDataTimer.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnDataTimer.java
@@ -13,7 +13,7 @@ import java.net.InetAddress;
 import org.apache.log4j.Logger;
 
 /**
- * This is our DataTimer class that is called periodically to capture and record
+ * This is our DataTimer class that runs periodically to capture and record
  * tunnel traffic statistics for reporting purposes.
  * 
  * @author mahotz
@@ -32,7 +32,6 @@ public class IpsecVpnDataTimer extends TimerTask
     class TunnelWatcher
     {
         String tunnelName;
-        int tunnelId;
         long cycleMark;
         long outLast;
         long inLast;
@@ -42,13 +41,10 @@ public class IpsecVpnDataTimer extends TimerTask
          * 
          * @param tunnelName
          *        The name of the tunnel
-         * @param tunnelId
-         *        The ID of the tunnel
          */
-        public TunnelWatcher(String tunnelName, int tunnelId)
+        public TunnelWatcher(String tunnelName)
         {
             this.tunnelName = tunnelName;
-            this.tunnelId = tunnelId;
             cycleMark = 0;
             outLast = 0;
             inLast = 0;
@@ -100,13 +96,13 @@ public class IpsecVpnDataTimer extends TimerTask
             watcher = watchTable.get(status.getWorkName());
 
             if (watcher == null) {
-                logger.debug("Creating new watch table entry for " + status.getWorkName());
-                watcher = new TunnelWatcher(status.getWorkName(), Integer.parseInt(status.getId()));
+                logger.debug("Creating new data table entry for " + status.getWorkName());
+                watcher = new TunnelWatcher(status.getWorkName());
                 watchTable.put(status.getWorkName(), watcher);
             }
 
             else {
-                logger.debug("Found existing watch table entry for " + status.getWorkName());
+                logger.debug("Found existing data table entry for " + status.getWorkName());
             }
 
             // update the cycle mark for all watcher objects that match an enabled IPsec
@@ -129,7 +125,7 @@ public class IpsecVpnDataTimer extends TimerTask
             // means we didn't find an enabled IPsec tunnel so we remove the entry
             // using the iterator remove function since the Java docs say it's safe
             if (watcher.cycleMark != cycleCounter) {
-                logger.debug("Removing stale watchTable entry for " + watcher.tunnelName);
+                logger.debug("Removing stale data table entry for " + watcher.tunnelName);
                 ksi.remove();
             }
         }

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnDataTimer.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnDataTimer.java
@@ -1,0 +1,236 @@
+/**
+ * $Id: IpsecVpnDataTimer.java 37267 2014-02-26 23:42:19Z dmorris $
+ */
+
+package com.untangle.app.ipsec_vpn;
+
+import java.util.LinkedList;
+import java.util.TimerTask;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.net.InetAddress;
+
+import org.apache.log4j.Logger;
+
+/**
+ * This is our DataTimer class that is called periodically to capture and record
+ * tunnel traffic statistics for reporting purposes.
+ * 
+ * @author mahotz
+ * 
+ */
+
+public class IpsecVpnDataTimer extends TimerTask
+{
+
+    /**
+     * Define an object we can use to keep track of each IPsec tunnel.
+     * 
+     * @author mahotz
+     * 
+     */
+    class TunnelWatcher
+    {
+        String tunnelName;
+        int tunnelId;
+        long cycleMark;
+        long outLast;
+        long inLast;
+
+        /**
+         * Constructor
+         * 
+         * @param tunnelName
+         *        The name of the tunnel
+         * @param tunnelId
+         *        The ID of the tunnel
+         */
+        public TunnelWatcher(String tunnelName, int tunnelId)
+        {
+            this.tunnelName = tunnelName;
+            this.tunnelId = tunnelId;
+            cycleMark = 0;
+            outLast = 0;
+            inLast = 0;
+        }
+    }
+
+    private final String TUNNEL_STATUS_SCRIPT = System.getProperty("uvm.home") + "/bin/ipsec-tunnel-status";
+    private final Logger logger = Logger.getLogger(getClass());
+    private final IpsecVpnApp app;
+
+    private Hashtable<String, TunnelWatcher> watchTable = new Hashtable<>();
+    private long cycleCounter = 0;
+
+    /**
+     * Constructor
+     * 
+     * @param app
+     *        The application instance that created us
+     */
+    public IpsecVpnDataTimer(IpsecVpnApp app)
+    {
+        this.app = app;
+    }
+
+    /**
+     * This is the timer run function
+     */
+    public void run()
+    {
+        ProcessAllTunnels();
+    }
+
+    /**
+     * Function to process all tunnels
+     */
+    private void ProcessAllTunnels()
+    {
+        LinkedList<ConnectionStatusRecord> statusList = app.getTunnelStatus();
+        TunnelWatcher watcher;
+        cycleCounter += 1;
+        String key;
+        int x;
+
+        // start by adding or updating watchTable with all enabled IPsec tunnels
+        for (x = 0; x < statusList.size(); x++) {
+            ConnectionStatusRecord status = statusList.get(x);
+
+            // see if there is an existing entry in the watch table
+            watcher = watchTable.get(status.getWorkName());
+
+            if (watcher == null) {
+                logger.debug("Creating new watch table entry for " + status.getWorkName());
+                watcher = new TunnelWatcher(status.getWorkName(), Integer.parseInt(status.getId()));
+                watchTable.put(status.getWorkName(), watcher);
+            }
+
+            else {
+                logger.debug("Found existing watch table entry for " + status.getWorkName());
+            }
+
+            // update the cycle mark for all watcher objects that match an enabled IPsec
+            // tunnel.  we'll use this later to remove any stale watcher entries
+            watcher.cycleMark = cycleCounter;
+
+            // if the tunnel is active grab the traffic stats
+            if (status.getMode().toLowerCase().equals("active")) {
+                GrabTunnelStatistics(watcher);
+            }
+        }
+
+        Iterator<String> ksi = watchTable.keySet().iterator();
+
+        while (ksi.hasNext()) {
+            key = ksi.next();
+            watcher = watchTable.get(key);
+
+            // if the cycle mark on this object doesn't match the cycle counter it
+            // means we didn't find an enabled IPsec tunnel so we remove the entry
+            // using the iterator remove function since the Java docs say it's safe
+            if (watcher.cycleMark != cycleCounter) {
+                logger.debug("Removing stale watchTable entry for " + watcher.tunnelName);
+                ksi.remove();
+            }
+        }
+    }
+
+    /**
+     * Function to capture and record the traffic statistics for each active
+     * tunnel.
+     * 
+     * @param watcher
+     *        The TunnelWatcher for the tunnel to be checked
+     */
+    private void GrabTunnelStatistics(TunnelWatcher watcher)
+    {
+        long outValue = 0;
+        long inValue = 0;
+        long outBytes = 0;
+        long inBytes = 0;
+        int top, wid, len;
+        String result;
+
+// THIS IS FOR ECLIPSE - @formatter:off
+
+        /*
+         * the script should return the tunnel status in the following format:
+         * | TUNNNEL:tunnel_name LOCAL:1.2.3.4 REMOTE:5.6.7.8 STATE:active IN:123 OUT:456 |
+         */
+        result = IpsecVpnApp.execManager().execOutput(TUNNEL_STATUS_SCRIPT + " " + watcher.tunnelName);
+
+// THIS IS FOR ECLIPSE - @formatter:on
+
+        /*
+         * We use the IN: and OUT: tags to find the beginning of each value and
+         * the trailing space to isolate the numeric portions of the string to
+         * keep Long.valueOf happy.
+         */
+
+        try {
+            top = result.indexOf("IN:");
+            wid = 3;
+            if (top > 0) {
+                len = result.substring(top + wid).indexOf(" ");
+                if (len > 0) {
+                    inValue = Long.valueOf(result.substring(top + wid, top + wid + len));
+                }
+            }
+
+            top = result.indexOf("OUT:");
+            wid = 4;
+            if (top > 0) {
+                len = result.substring(top + wid).indexOf(" ");
+                if (len > 0) {
+                    outValue = Long.valueOf(result.substring(top + wid, top + wid + len));
+                }
+            }
+        }
+
+        /*
+         * If we can't parse the tunnel stats just return
+         */
+        catch (Exception exn) {
+            return;
+        }
+
+        /*
+         * if neither value changed there is nothing to log so just return
+         */
+        if ((inValue == watcher.inLast) && (outValue == watcher.outLast)) return;
+
+        /*
+         * The stats for each tunnel seem to get cleared by the daemon each time
+         * the tunnel is re-keyed, so we look for values less than we saw on the
+         * previous check and handle accordingly. Once we calculate the number
+         * of IN and OUT bytes since the last check, we update the last values
+         * and write the stat record to the database.
+         * 
+         * The downside to this whole approach is that we won't count any
+         * traffic on cycles with a re-key in between checks.
+         * 
+         * There is also an edge case where we could fail to record the first
+         * traffic after a re-key if both the IN and OUT values are exactly the
+         * same as they were during the last check.
+         */
+
+        if (inValue < watcher.inLast) inBytes = inValue;
+        else inBytes = (inValue - watcher.inLast);
+
+        if (outValue < watcher.outLast) outBytes = outValue;
+        else outBytes = (outValue - watcher.outLast);
+
+        watcher.inLast = inValue;
+        watcher.outLast = outValue;
+
+        // since we prepend some stuff to keep the tunnel names unique we
+        // now look for it and strip it off to keep it out of the report
+        String shortName = watcher.tunnelName;
+        int marker = watcher.tunnelName.indexOf('_');
+        if (marker > 0) shortName = watcher.tunnelName.substring(marker + 1);
+
+        TunnelStatusEvent event = new TunnelStatusEvent(shortName, inBytes, outBytes);
+        app.logEvent(event);
+        logger.debug("GrabTunnelStatistics(logEvent) " + event.toString());
+    }
+}

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnEvent.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnEvent.java
@@ -22,7 +22,7 @@ public class IpsecVpnEvent extends LogEvent implements Serializable, org.json.JS
 {
     public enum EventType
     {
-        CONNECT, DISCONNECT, UNREACHABLE
+        CONNECT, DISCONNECT, UNREACHABLE, RESTART
     };
 
     private String localAddress;

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
@@ -163,8 +163,13 @@ public class IpsecVpnPingTimer extends TimerTask
             // if we haven't reached the fail threshold just continue
             if (watcher.failCounter < PING_FAIL_THRESHOLD) continue;
 
-            // fail threshold reached so bring tunnel down and back up
+            // fail threshold reached so log event and bring tunnel down and back up
             logger.warn("Attempting restart for inactive tunnel " + watcher.controlName);
+
+            IpsecVpnEvent event = new IpsecVpnEvent(tunnel.getLeft(), tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.RESTART);
+            app.logEvent(event);
+            logger.debug("logEvent(ipsec_vpn_events) " + event.toSummaryString());
+
             IpsecVpnApp.execManager().exec("ipsec down " + watcher.controlName);
 
             // run the up command in the background as it can block if the other side is unreachable

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
@@ -13,17 +13,9 @@ import java.net.InetAddress;
 import org.apache.log4j.Logger;
 
 /**
- * This is our timer class where we handle periodic tasks. Sometimes we see
- * tunnels that have been connected for days suddenly just go away, almost like
- * ipsec just forgot about them. The only solution we've come up with is this
- * awful code that periodically looks at the status of all tunnels, and uses the
- * ipsec down/up utility to force the tunnel to reconnect.
- * 
- * Since we're already monitoring every minute, we're also using this code to
- * capture and record traffic statistics for reporting purposes.
- * 
- * We also added the ability to ping a host across the tunnel, so we use the
- * timer to implement that functionality as well.
+ * The PingTimer class runs periodically and uses ping to determine if tunnels
+ * are active or have stopped responding. It generates up and down events and
+ * will attempt to restart tunnels that seem to have failed.
  * 
  * @author mahotz
  * 
@@ -40,20 +32,19 @@ public class IpsecVpnPingTimer extends TimerTask
      */
     class TunnelWatcher
     {
-        int tunnelId;
         String tunnelName;
+        String controlName;
+        int tunnelId;
         boolean activeFlag;
-        long activeCounter;
         long cycleMark;
-        long outLast;
-        long inLast;
-        int pingCounter;
+        long failCounter;
 
         /**
          * Constructor
          * 
          * @param tunnelName
          *        The name of the tunnel
+         *
          * @param tunnelId
          *        The ID of the tunnel
          */
@@ -62,21 +53,17 @@ public class IpsecVpnPingTimer extends TimerTask
             this.tunnelName = tunnelName;
             this.tunnelId = tunnelId;
             activeFlag = false;
-            activeCounter = 0;
+            failCounter = 0;
             cycleMark = 0;
-            outLast = 0;
-            inLast = 0;
-            pingCounter = 0;
+            controlName = ("UT" + Integer.toString(tunnelId) + "_" + tunnelName);
         }
     }
 
-    private final String TUNNEL_STATUS_SCRIPT = System.getProperty("uvm.home") + "/bin/ipsec-tunnel-status";
     private final Logger logger = Logger.getLogger(getClass());
     private final IpsecVpnApp app;
 
-    // the mininum number of minutes (assuming 60000 msec timer calling interval) for
-    // a tunnel to be detected active before we try to restart if detected down
-    private final long RESTART_THRESHOLD = 5;
+    // the number of ping failures before we force a tunnel restart
+    private final long PING_FAIL_THRESHOLD = 3;
 
     private Hashtable<String, TunnelWatcher> watchTable = new Hashtable<>();
     private long cycleCounter = 0;
@@ -101,89 +88,87 @@ public class IpsecVpnPingTimer extends TimerTask
     }
 
     /**
-     * Function to check the status of all IPsec tunnels, and restart any that
-     * seem to be down.
+     * Function to check all IPsec tunnels with a configured ping target and
+     * restart any that seem to be down.
      */
     private void CheckAllTunnels()
     {
-        LinkedList<ConnectionStatusRecord> statusList = app.getTunnelStatus();
+        LinkedList<IpsecVpnTunnel> configList = app.getSettings().getTunnels();
         IpsecVpnTunnel tunnel;
         TunnelWatcher watcher;
         cycleCounter += 1;
         String key;
         int x;
 
-        // start by adding or updating watchTable with all enabled IPsec tunnels
-        for (x = 0; x < statusList.size(); x++) {
-            ConnectionStatusRecord status = statusList.get(x);
+        // process the list of configured tunnels
+        for (x = 0; x < configList.size(); x++) {
+            tunnel = configList.get(x);
+
+            // ignore disabled tunnels and those with no ping target configured
+            if (tunnel.getActive() == false) continue;
+            if (tunnel.getPingAddress() == null) continue;
+            if (tunnel.getPingAddress().length() == 0) continue;
 
             // see if there is an existing entry in the watch table
-            watcher = watchTable.get(status.getWorkName());
+            watcher = watchTable.get(tunnel.getDescription());
 
             if (watcher == null) {
-                logger.debug("Creating new watch table entry for " + status.getWorkName());
-                watcher = new TunnelWatcher(status.getWorkName(), Integer.parseInt(status.getId()));
-                watchTable.put(status.getWorkName(), watcher);
+                logger.debug("Creating new ping table entry for " + tunnel.getDescription());
+                watcher = new TunnelWatcher(tunnel.getDescription(), tunnel.getId());
+                watchTable.put(tunnel.getDescription(), watcher);
             }
 
             else {
-                logger.debug("Found existing watch table entry for " + status.getWorkName());
+                logger.debug("Found existing ping table entry for " + tunnel.getDescription());
             }
 
-            tunnel = findTunnelById(watcher.tunnelId);
-
-            // update the cycle mark for all watcher objects that match an enabled IPsec
-            // tunnel.  we'll use this later to remove any stale watcher entries
+            // update the cycle mark for the current tunnel
             watcher.cycleMark = cycleCounter;
 
-            // if the tunnel is active increment the active counter and grab the traffic stats
-            if (status.getMode().toLowerCase().equals("active")) {
-                watcher.activeCounter += 1;
-                GrabTunnelStatistics(watcher);
+            // check the ping target
+            boolean active = CheckTunnelPingTarget(tunnel);
 
-                if (tunnel != null) {
-                    CheckTunnelPingTarget(watcher, tunnel);
-
-                    // if the active flag is false we need to log an up event 
-                    if (watcher.activeFlag == false) {
-                        watcher.activeFlag = true;
-                        IpsecVpnEvent event = new IpsecVpnEvent(tunnel.getLeft(), tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.CONNECT);
-                        app.logEvent(event);
-                        logger.debug("logEvent(ipsec_vpn_events) " + event.toSummaryString());
-                    }
-                }
-            }
-
-            // ipsec screwed up again... or rather, the tunnel appears to be down
-            else {
-
-                // if our active flag is true we need to log a down event
-                if (watcher.activeFlag == true && tunnel != null) {
-                    watcher.activeFlag = false;
-                    IpsecVpnEvent event = new IpsecVpnEvent(tunnel.getLeft(), tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.DISCONNECT);
+            // if the tunnel is active increment the active counter
+            if (active == true) {
+                // if the active flag is false we transition from down to up 
+                if (watcher.activeFlag == false) {
+                    watcher.activeFlag = true;
+                    watcher.failCounter = 0;
+                    IpsecVpnEvent event = new IpsecVpnEvent(tunnel.getLeft(), tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.CONNECT);
                     app.logEvent(event);
                     logger.debug("logEvent(ipsec_vpn_events) " + event.toSummaryString());
                 }
 
-                // if the tunnel was detected as active for the minimum amount of time
-                // then we will attempt restart by calling ipsec down and ipsec up
-                if (watcher.activeCounter > RESTART_THRESHOLD) {
-                    long hval = (watcher.activeCounter / 60);
-                    long mval = (watcher.activeCounter % 60);
-                    logger.warn("Attempting restart for inactive tunnel " + watcher.tunnelName + " (UPTIME = " + Long.toString(hval) + " hours " + Long.toString(mval) + " minutes)");
-                    IpsecVpnApp.execManager().exec("ipsec down " + watcher.tunnelName);
-
-                    // run the up command in the background as it can block if the other side is unreachable
-                    IpsecVpnApp.execManager().exec("nohup ipsec up " + watcher.tunnelName + " >/dev/null 2>&1 &");
-                } else {
-                    logger.debug("Ignoring inactive tunnel " + watcher.tunnelName);
-                }
-
-                // finally we reset the active counter so no further attempt will be made
-                // to restart the tunnel until it has once again been detected as active
-                // for the minimum amount of time.
-                watcher.activeCounter = 0;
+                // continue the tunnel loop
+                continue;
             }
+
+            /*
+             * At this point the tunnel is enabled but the ping failed. We check
+             * the restart interval, and do event logging and force restart as
+             * required.
+             */
+
+            // if our active flag is true we need to log a down event
+            if (watcher.activeFlag == true) {
+                watcher.activeFlag = false;
+                IpsecVpnEvent event = new IpsecVpnEvent(tunnel.getLeft(), tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.DISCONNECT);
+                app.logEvent(event);
+                logger.debug("logEvent(ipsec_vpn_events) " + event.toSummaryString());
+            }
+
+            // increment the ping fail counter for the tunnel
+            watcher.failCounter++;
+
+            // if we haven't reached the fail threshold just continue
+            if (watcher.failCounter < PING_FAIL_THRESHOLD) continue;
+
+            // fail threshold reached so bring tunnel down and back up
+            logger.warn("Attempting restart for inactive tunnel " + watcher.controlName);
+            IpsecVpnApp.execManager().exec("ipsec down " + watcher.controlName);
+
+            // run the up command in the background as it can block if the other side is unreachable
+            IpsecVpnApp.execManager().exec("nohup ipsec up " + watcher.controlName + " >/dev/null 2>&1 &");
         }
 
         Iterator<String> ksi = watchTable.keySet().iterator();
@@ -192,169 +177,43 @@ public class IpsecVpnPingTimer extends TimerTask
             key = ksi.next();
             watcher = watchTable.get(key);
 
-            // if the cycle mark on this object doesn't match the cycle counter it
-            // means we didn't find an enabled IPsec tunnel so we remove the entry
+            // if the cycle mark on this object doesn't match the current cycle counter
+            // it means we didn't find an enabled IPsec tunnel so we remove the entry
             // using the iterator remove function since the Java docs say it's safe
             if (watcher.cycleMark != cycleCounter) {
-                logger.debug("Removing stale watchTable entry for " + watcher.tunnelName);
+                logger.debug("Removing stale ping table entry for " + watcher.tunnelName);
                 ksi.remove();
             }
         }
     }
 
     /**
-     * Function to capture and record the traffic statistics for each active
-     * tunnel.
-     * 
-     * @param watcher
-     *        The TunnelWatcher for the tunnel to be checked
-     */
-    private void GrabTunnelStatistics(TunnelWatcher watcher)
-    {
-        long outValue = 0;
-        long inValue = 0;
-        long outBytes = 0;
-        long inBytes = 0;
-        int top, wid, len;
-        String result;
-
-// THIS IS FOR ECLIPSE - @formatter:off
-
-        /*
-         * the script should return the tunnel status in the following format:
-         * | TUNNNEL:tunnel_name LOCAL:1.2.3.4 REMOTE:5.6.7.8 STATE:active IN:123 OUT:456 |
-         */
-        result = IpsecVpnApp.execManager().execOutput(TUNNEL_STATUS_SCRIPT + " " + watcher.tunnelName);
-
-// THIS IS FOR ECLIPSE - @formatter:on
-
-        /*
-         * We use the IN: and OUT: tags to find the beginning of each value and
-         * the trailing space to isolate the numeric portions of the string to
-         * keep Long.valueOf happy.
-         */
-
-        try {
-            top = result.indexOf("IN:");
-            wid = 3;
-            if (top > 0) {
-                len = result.substring(top + wid).indexOf(" ");
-                if (len > 0) {
-                    inValue = Long.valueOf(result.substring(top + wid, top + wid + len));
-                }
-            }
-
-            top = result.indexOf("OUT:");
-            wid = 4;
-            if (top > 0) {
-                len = result.substring(top + wid).indexOf(" ");
-                if (len > 0) {
-                    outValue = Long.valueOf(result.substring(top + wid, top + wid + len));
-                }
-            }
-        }
-
-        /*
-         * If we can't parse the tunnel stats just return
-         */
-        catch (Exception exn) {
-            return;
-        }
-
-        /*
-         * if neither value changed there is nothing to log so just return
-         */
-        if ((inValue == watcher.inLast) && (outValue == watcher.outLast)) return;
-
-        /*
-         * The stats for each tunnel seem to get cleared by the daemon each time
-         * the tunnel is re-keyed, so we look for values less than we saw on the
-         * previous check and handle accordingly. Once we calculate the number
-         * of IN and OUT bytes since the last check, we update the last values
-         * and write the stat record to the database.
-         * 
-         * The downside to this whole approach is that we won't count any
-         * traffic on cycles with a re-key in between checks.
-         * 
-         * There is also an edge case where we could fail to record the first
-         * traffic after a re-key if both the IN and OUT values are exactly the
-         * same as they were during the last check.
-         */
-
-        if (inValue < watcher.inLast) inBytes = inValue;
-        else inBytes = (inValue - watcher.inLast);
-
-        if (outValue < watcher.outLast) outBytes = outValue;
-        else outBytes = (outValue - watcher.outLast);
-
-        watcher.inLast = inValue;
-        watcher.outLast = outValue;
-
-        // since we prepend some stuff to keep the tunnel names unique we
-        // now look for it and strip it off to keep it out of the report
-        String shortName = watcher.tunnelName;
-        int marker = watcher.tunnelName.indexOf('_');
-        if (marker > 0) shortName = watcher.tunnelName.substring(marker + 1);
-
-        TunnelStatusEvent event = new TunnelStatusEvent(shortName, inBytes, outBytes);
-        app.logEvent(event);
-        logger.debug("GrabTunnelStatistics(logEvent) " + event.toString());
-    }
-
-    /**
-     * Function to ping a remote host across a tunnel. The main goal here is to
-     * give users a way to periodically generate traffic that goes across a
-     * tunnel, and generate alerts if the ping target does not respond.
-     * 
-     * @param watcher
-     *        The TunnelWatcher for the ping test
+     * Function to ping a remote host across an IPsec tunnel
      * 
      * @param tunnel
      *        The IpsecVpnTunnel for the ping test
+     *
+     * @return true for ping success, false for fail
      */
-    private void CheckTunnelPingTarget(TunnelWatcher watcher, IpsecVpnTunnel tunnel)
+    private boolean CheckTunnelPingTarget(IpsecVpnTunnel tunnel)
     {
-        if (tunnel == null) return;
-        if (tunnel.getPingInterval() == 0) return;
-        if (tunnel.getPingAddress() == null) return;
-        if (tunnel.getPingAddress().length() == 0) return;
-
-        // no ping if we haven't reached the configured interval threshold
-        watcher.pingCounter += 1;
-        if (watcher.pingCounter < tunnel.getPingInterval()) return;
+        if (tunnel == null) return (false);
+        if (tunnel.getPingAddress() == null) return (false);
+        if (tunnel.getPingAddress().length() == 0) return (false);
 
         try {
             InetAddress target = InetAddress.getByName(tunnel.getPingAddress());
             if (target.isReachable(2000)) {
                 logger.debug("PING SUCCESS: " + tunnel.getPingAddress());
-                return;
+                return (true);
             }
         } catch (Exception exn) {
             logger.debug("PING EXCEPTION: " + tunnel.getPingAddress(), exn);
         }
+
         IpsecVpnEvent event = new IpsecVpnEvent(tunnel.getLeft(), tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.UNREACHABLE);
         app.logEvent(event);
         logger.debug("logEvent(ipsec_vpn_events) " + event.toSummaryString());
-    }
-
-    /**
-     * Function to find the IpsecVpnTunnel matching a given ID value.
-     * 
-     * @param idValue
-     *        The ID value of the tunnel to find
-     * 
-     * @return The IpsecVpnTunnel if found, otherwise null
-     */
-    private IpsecVpnTunnel findTunnelById(int idValue)
-    {
-        LinkedList<IpsecVpnTunnel> configList = app.getSettings().getTunnels();
-
-        // create a status display record for all enabled tunnels
-        for (int x = 0; x < configList.size(); x++) {
-            IpsecVpnTunnel tunnel = configList.get(x);
-            if (tunnel.getId() == idValue) return (tunnel);
-        }
-
-        return (null);
+        return (false);
     }
 }

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
@@ -1,5 +1,5 @@
 /**
- * $Id: IpsecVpnTimer.java 37267 2014-02-26 23:42:19Z dmorris $
+ * $Id: IpsecVpnPingTimer.java 37267 2014-02-26 23:42:19Z dmorris $
  */
 
 package com.untangle.app.ipsec_vpn;
@@ -29,7 +29,7 @@ import org.apache.log4j.Logger;
  * 
  */
 
-public class IpsecVpnTimer extends TimerTask
+public class IpsecVpnPingTimer extends TimerTask
 {
 
     /**
@@ -87,7 +87,7 @@ public class IpsecVpnTimer extends TimerTask
      * @param app
      *        The application instance that created us
      */
-    public IpsecVpnTimer(IpsecVpnApp app)
+    public IpsecVpnPingTimer(IpsecVpnApp app)
     {
         this.app = app;
     }

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
@@ -49,7 +49,6 @@ public class IpsecVpnTunnel implements JSONString, Serializable
     private String rightProtoPort;
     private String rightNextHop;
     private String pingAddress;
-    private int pingInterval;
 
     public IpsecVpnTunnel()
     {
@@ -148,9 +147,6 @@ public class IpsecVpnTunnel implements JSONString, Serializable
 
     public String getPingAddress() { return(pingAddress); }
     public void setPingAddress(String pingAddress) { this.pingAddress = pingAddress; }
-
-    public int getPingInterval() { return(pingInterval); }
-    public void setPingInterval(int pingInterval) { this.pingInterval = pingInterval; }
 
     /*
     * Use the id and description to create a unique connection name that


### PR DESCRIPTION
This is ready for merge and testing. See the Jira ticket for low level implementation details.

The tunnel up/down detection and force restart logic has been reworked and is now completely driven by the ping target configured for the tunnel. If there is no ping target configured, we will not generate up/down events, and we will not attempt to detect or restart failed tunnels. As before, the configured ping target must only be reachable across the IPsec tunnel.

For testing, I would recommend bringing up an IPsec tunnel between two devices and configuring a valid ping target. Interrupting the tunnel (ie: unplug network cable) should cause a tunnel DISCONNECT event to be generated after at most 20 seconds. You will also so UNREACHABLE events for all ping failures. After around 60 seconds, you should see a RESTART event, indicating the tunnel is being force restarted. The restart events will continue until the tunnel successfully connects and a ping test is successful, at which point a CONNECT event will be logged.
