### PR TITLE
Fix table name in wireguard connection events report

### DIFF
--- a/wireguard-vpn/hier/usr/share/untangle/lib/wireguard-vpn/reports/wireguardvpn-connect-events.json
+++ b/wireguard-vpn/hier/usr/share/untangle/lib/wireguard-vpn/reports/wireguardvpn-connect-events.json
@@ -7,7 +7,7 @@
     "description": "WireGuard VPN client connection events.",
     "displayOrder": 1010,
     "javaClass": "com.untangle.app.reports.ReportEntry",
-    "table": "wireuard_vpn_events",
+    "table": "wireguard_vpn_events",
     "title": "Connection Events",
     "uniqueId": "wireguardvpn-wg0328AZC5E3"
 }


### PR DESCRIPTION
Fixed a typo in the database table name of the connection events report.
