### PR TITLE
Fix issue with xl2tpd daemon restart

### DIFF
--- a/ipsec-vpn/hier/usr/share/untangle/bin/ipsec-reload
+++ b/ipsec-vpn/hier/usr/share/untangle/bin/ipsec-reload
@@ -6,6 +6,7 @@
 /usr/sbin/ipsec reload 2>&1 1>> /dev/null
 
 # Restart the xlt2pd daemon
+systemctl reset-failed xl2tpd 2>&1 1>> /dev/null
 systemctl restart xl2tpd 2>&1 1>> /dev/null
 
 # Call the script to create the L2TP interface status file


### PR DESCRIPTION
Really only an issue during ATS runs where IPsec settings get updated
quickly many times in a row, triggering the systemd protection thing.

systemd[1]: xl2tpd.service: Start request repeated too quickly.
systemd[1]: xl2tpd.service: Failed with result 'start-limit-hit'.

Solved by calling reset-failed to prevent triggering the quick restart limit.