### PR TITLE
NGFW-13102: qos-status: Fixup parsing for latest tc class output

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/qos-status.py
+++ b/uvm/hier/usr/share/untangle/bin/qos-status.py
@@ -24,11 +24,9 @@ def statusToJSON(input):
     #Parse patterns for qos-service.py status output
     firstLine='interface: {} class {} {} {} rate {} ceil {} burst {} cburst {}'
     secondLine=' Sent {:d} bytes {:d} pkt (dropped {:d}, overlimits {:d} requeues {:d}) '
-    thirdLine=' rate {} {} backlog {} {} requeues {:d} '
-    fourthLine= ' lended: {:d} borrowed: {:d} giants: {:d}'
     lastLine=' tokens: {} ctokens:{}'
     priorityParser='parent {} leaf {} prio {:d}'
-    indexMap={1:firstLine, 2:secondLine, 3:thirdLine, 4:fourthLine, 5:lastLine}
+    indexMap={1:firstLine, 2:secondLine, 3:lastLine}
     priorityQueueToName = { '10:': '0 - Default','11:': '1 - Very High','12:': '2 - High', '13:':'3 - Medium','14:':'4 - Low','15:':'5 - Limited','16:':'6 - Limited More','17:':'7 - Limited Severely' }
 
     output = []
@@ -37,7 +35,7 @@ def statusToJSON(input):
     skipEntry=False
     for line in input:
         line = str(line, 'ascii','ignore')
-        if count <= 5:
+        if count <= 3:
             res=parse.parse(indexMap[count],line)
             if res == None:
                 continue
@@ -55,8 +53,6 @@ def statusToJSON(input):
             if count == 2:
                 entry['sent']=str(parsed[0]) + ' bytes'
             if count == 3:
-                entry['rate']=parsed[0]
-            if count == 5:
                 entry['tokens']=int(parsed[0])
                 entry['ctokens']=int(parsed[1])
             count+=1


### PR DESCRIPTION
In the latest version of tc, the third line of tc class output
does not provide a rate value.  Which is fine, since we don't
use that value on the qos statistics page.  Since rate was the
only thing we tried to parse out of the thirdLine, stop parsing
it completely.  Also stop parsing fourthLine, since we weren't
getting anything out of that line either.

NGFW-13102