### PR TITLE
uvm: Load tun module before starting uvm

### DIFF
--- a/uvm/hier/usr/bin/uvm
+++ b/uvm/hier/usr/bin/uvm
@@ -150,6 +150,10 @@ def prepareSystem():
     if developmentEnv:
         devEnvSetup()
 
+    # load tun (if not already loaded)
+    # this ensures that /dev/net/tun exists before we try to initialize netcap
+    os.system('/sbin/modprobe -q tun');
+
     # load nfnetlink_queue (if not already loaded)
     os.system('/sbin/modprobe -q nfnetlink_queue');
 


### PR DESCRIPTION
The systemd-tmpfiles-setup service is responsible for creating the
/dev/net/tun devnode on boot up.  But we have observed a number of
cases (usually after a kernel upgrade) where the /dev/net/tun node
was not created before we started the uvm.  Thats bad, because we
can't initialize netcap without it.  Since we know we are always
going to need /dev/net/tun (which is backed by the tun kernel
module) just go ahead and make sure the tun module is inserted
prior to starting the uvm.

NGFW-13144