### PR TITLE
Ngfw 13089 radius phase two

### DIFF
--- a/uvm/api/com/untangle/uvm/LocalDirectory.java
+++ b/uvm/api/com/untangle/uvm/LocalDirectory.java
@@ -70,4 +70,9 @@ public interface LocalDirectory
      * Adds computer account to the Active Directory domain controller
      */
     public String addRadiusComputerAccount();
+
+    /**
+     * Tests Active Directory authentication with passed credentials
+     */
+    public String testRadiusProxyLogin(String userName, String userPass, String userDomain);
 }

--- a/uvm/api/com/untangle/uvm/LocalDirectory.java
+++ b/uvm/api/com/untangle/uvm/LocalDirectory.java
@@ -6,8 +6,9 @@ package com.untangle.uvm;
 import java.util.LinkedList;
 
 /**
- * The Local Directory API provides functions for managing and authenticating "local users."
- * This is useful for some apps with lists of users (like Captive Portal)
+ * The Local Directory API provides functions for managing and authenticating
+ * "local users." This is useful for some apps with lists of users (like Captive
+ * Portal)
  */
 public interface LocalDirectory
 {
@@ -16,7 +17,7 @@ public interface LocalDirectory
      *
      * @returns true if valid uid/password, false otherwise
      */
-    public boolean authenticate( String username, String password );
+    public boolean authenticate(String username, String password);
 
     /**
      * Return a list of users
@@ -28,7 +29,7 @@ public interface LocalDirectory
     /**
      * Save a new list of users
      */
-    public void setUsers( LinkedList<LocalDirectoryUser> users );
+    public void setUsers(LinkedList<LocalDirectoryUser> users);
 
     /**
      * Adds a new user
@@ -55,6 +56,18 @@ public interface LocalDirectory
      */
     public void cleanupExpiredUsers();
 
+    /**
+     * Gets the freeRadius log file
+     */
+    public String getRadiusLogFile();
+
+    /**
+     * Gets the Active Directory account status
+     */
+    public String getRadiusProxyStatus();
+
+    /**
+     * Adds computer account to the Active Directory domain controller
+     */
+    public String addRadiusComputerAccount();
 }
-
-

--- a/uvm/api/com/untangle/uvm/SystemSettings.java
+++ b/uvm/api/com/untangle/uvm/SystemSettings.java
@@ -46,8 +46,21 @@ public class SystemSettings implements Serializable, JSONString
     private String ipsecCertificate = "apache.pem";
     private String radiusCertificate = "apache.pem";
 
+    /**
+     * These are used for LocalDirectory RADIUS server support
+     */
     private boolean radiusServerEnabled = false;
     private String radiusServerSecret = "SharedSecret";
+
+    /**
+     * These are used for RADIUS proxy support
+     */
+    private boolean radiusProxyEnabled = false;
+    private String radiusProxyServer = "";
+    private String radiusProxyWorkgroup = "";
+    private String radiusProxyRealm = "";
+    private String radiusProxyUsername = "";
+    private String radiusProxyPassword = "";
 
     private String installType = "";
 
@@ -158,6 +171,22 @@ public class SystemSettings implements Serializable, JSONString
     public void setRadiusServerEnabled(boolean newValue) { this.radiusServerEnabled = newValue; }
     public String getRadiusServerSecret() { return radiusServerSecret; }
     public void setRadiusServerSecret(String newValue) { this.radiusServerSecret = newValue; }
+
+    /**
+     * These are used to get and set the radius proxy settings
+     */
+    public boolean getRadiusProxyEnabled() { return radiusProxyEnabled; }
+    public void setRadiusProxyEnabled(boolean newValue) { this.radiusProxyEnabled = newValue; }
+    public String getRadiusProxyServer() { return radiusProxyServer; }
+    public void setRadiusProxyServer(String newValue) { this.radiusProxyServer = newValue; }
+    public String getRadiusProxyWorkgroup() { return radiusProxyWorkgroup; }
+    public void setRadiusProxyWorkgroup(String newValue) { this.radiusProxyWorkgroup = newValue; }
+    public String getRadiusProxyRealm() { return radiusProxyRealm; }
+    public void setRadiusProxyRealm(String newValue) { this.radiusProxyRealm = newValue; }
+    public String getRadiusProxyUsername() { return radiusProxyUsername; }
+    public void setRadiusProxyUsername(String newValue) { this.radiusProxyUsername = newValue; }
+    public String getRadiusProxyPassword() { return radiusProxyPassword; }
+    public void setRadiusProxyPassword(String newValue) { this.radiusProxyPassword = newValue; }
 
     /* DEPRECATED in 12.2 - moved to network settings */
     /* DEPRECATED in 12.1 - moved to network settings */

--- a/uvm/hier/usr/share/untangle/bin/ut-radius-proxy
+++ b/uvm/hier/usr/share/untangle/bin/ut-radius-proxy
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+#
+# Script to get the status of the computer in the Active Directory
+# domain controller
+
+import subprocess
+import json
+import sys
+
+# -----------------------------------------------------------------------------
+
+def parse_output(parse_data):
+    parse_lines = parse_data.split('\n')
+    status_info = ""
+
+    # look at every line
+    for line in parse_lines:
+
+        # strip the line and look for fields we want
+        line = line.strip()
+
+        spot = line.find("distinguishedName: ")
+        if (spot >= 0):
+            status_info += line + "\n"
+
+        spot = line.find("whenCreated: ")
+        if (spot >= 0):
+            status_info += line + "\n"
+
+        spot = line.find("whenChanged: ")
+        if (spot >= 0):
+            status_info += line + "\n"
+
+    # return the status
+    return status_info
+
+# -----------------------------------------------------------------------------
+
+if len(sys.argv) < 3:
+    print "ERROR: You must provide the AD username and password"
+    sys.exit(1)
+
+netcmd = "/usr/bin/net ads status -U %s%%%s" % (sys.argv[1], sys.argv[2])
+
+status_proc = subprocess.Popen(netcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+(status_out,status_err) = status_proc.communicate()
+status_txt = parse_output(status_out)
+
+if (len(status_txt) != 0):
+    print status_txt
+else:
+    if (len(status_out) != 0):
+        print status_out
+    if (len(status_err) != 0):
+        print status_err

--- a/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
+++ b/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
@@ -17,11 +17,14 @@ import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Scanner;
 import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.FormatterClosedException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -39,6 +42,11 @@ public class LocalDirectoryImpl implements LocalDirectory
     private final static String FREERADIUS_LOCAL_SECRETS = "/etc/freeradius/3.0/mods-config/files/untangle.local";
     private final static String FREERADIUS_AUTHORIZE = "/etc/freeradius/3.0/mods-config/files/authorize";
     private final static String FREERADIUS_RADIUSD = "/etc/freeradius/3.0/radiusd.conf";
+    private final static String FREERADIUS_SAMBA_CONFIG = "/etc/samba/smb.conf";
+    private final static String FREERADIUS_KRB5_CONFIG = "/etc/krb5.conf";
+    private final static String FREERADIUS_MSCHAP_CONFIG = "/etc/freeradius/3.0/mods-available/mschap";
+    private final static String FREERADIUS_NTLM_CONFIG = "/etc/freeradius/3.0/mods-available/ntlm_auth";
+    private final static String FREERADIUS_EAP_CONFIG = "/etc/freeradius/3.0/mods-available/eap";
 
     private final static String UNCHANGED_PASSWORD = "***UNCHANGED***";
     private final static String FILE_DISCLAIMER = "# This file is created and maintained by the Untangle Local Directory.\n" + "# If you modify this file manually, your changes will be overwritten!\n\n";
@@ -472,7 +480,7 @@ public class LocalDirectoryImpl implements LocalDirectory
                 for (LocalDirectoryUser user : list) {
                     byte[] rawPassword = Base64.decodeBase64(user.getPasswordBase64Hash().getBytes());
                     String userPassword = new String(rawPassword);
-                    fw.write(user.getUsername() + " Cleartext-Password := \"" + userPassword + "\"\n");
+                    fw.write(user.getUsername() + " Cleartext-Password := \"" + userPassword + "\", MS-CHAP-Use-NTLM-Auth := 0\n");
                 }
             }
             fw.flush();
@@ -611,6 +619,136 @@ public class LocalDirectoryImpl implements LocalDirectory
         }
 
         /*
+         * Create the smb.conf file
+         */
+        try {
+            fw = new FileWriter(FREERADIUS_SAMBA_CONFIG, false);
+            fw.write(FILE_DISCLAIMER);
+            if (systemSettings.getRadiusProxyEnabled()) {
+                fw.write("[global]\n");
+                fw.write("\tworkgroup = " + systemSettings.getRadiusProxyWorkgroup() + "\n");
+                fw.write("\tsecurity = ads\n");
+                fw.write("\tpassword server = " + systemSettings.getRadiusProxyServer() + "\n");
+                fw.write("\trealm = " + systemSettings.getRadiusProxyRealm() + "\n");
+                fw.write("\twinbind use default domain = yes\n");
+                fw.write("\tbind interfaces only = no\n");
+                fw.write("\tserver role = standalone server\n");
+                fw.write("\n");
+                fw.write("[homes]\n");
+                fw.write("\tcomment = Home Directories\n");
+                fw.write("\tbrowseable = no\n");
+                fw.write("\twritable = yes\n");
+            }
+            fw.flush();
+            fw.close();
+        } catch (Exception exn) {
+            logger.error("Exception creating SAMBA configuration file", exn);
+        } finally {
+            if (fw != null) {
+                try {
+                    fw.close();
+                } catch (IOException ex) {
+                    logger.error("Exception closing SAMBA configuration file", ex);
+                }
+            }
+        }
+
+        /*
+         * Create the krb5.conf file
+         */
+        try {
+            fw = new FileWriter(FREERADIUS_KRB5_CONFIG, false);
+            fw.write(FILE_DISCLAIMER);
+            if (systemSettings.getRadiusProxyEnabled()) {
+                fw.write("[libdefaults]\n");
+                fw.write("\tdefault_realm = " + systemSettings.getRadiusProxyRealm().toUpperCase() + "\n");
+                fw.write("\tdns_lookup_realm = false\n");
+                fw.write("\tdns_lookup_kds = false\n");
+                fw.write("\n");
+                fw.write("[realms]\n");
+                fw.write("\t" + systemSettings.getRadiusProxyRealm().toUpperCase() + " {\n");
+                fw.write("\t\tkdc = " + systemSettings.getRadiusProxyServer() + "\n");
+                fw.write("\t\tadmin_server = " + systemSettings.getRadiusProxyServer() + "\n");
+                fw.write("\t\tdefault_domain = " + systemSettings.getRadiusProxyRealm() + "\n");
+                fw.write("\t}\n");
+                fw.write("[domain_realm]\n");
+                fw.write("\t." + systemSettings.getRadiusProxyRealm().toLowerCase() + " = " + systemSettings.getRadiusProxyRealm().toUpperCase() + "\n");
+                fw.write("\t" + systemSettings.getRadiusProxyRealm().toLowerCase() + " = " + systemSettings.getRadiusProxyRealm().toUpperCase() + "\n");
+            }
+            fw.flush();
+            fw.close();
+        } catch (Exception exn) {
+            logger.error("Exception creating KRB5 configuration file", exn);
+        } finally {
+            if (fw != null) {
+                try {
+                    fw.close();
+                } catch (IOException ex) {
+                    logger.error("Exception closing KRB5 configuration file", ex);
+                }
+            }
+        }
+
+        /*
+         * Create the mschap config file
+         */
+        try {
+            fw = new FileWriter(FREERADIUS_MSCHAP_CONFIG, false);
+            fw.write(FILE_DISCLAIMER);
+            if (systemSettings.getRadiusProxyEnabled()) {
+                fw.write("mschap {\n");
+                fw.write("\twith_ntdomain_hack = yes\n");
+                fw.write("\tntlm_auth = \"/usr/bin/ntlm_auth --request-nt-key --username=%{%{Stripped-User-Name}:-%{%{User-Name}:-None}} --challenge=%{%{mschap:Challenge}:-00} --nt-response=%{%{mschap:NT-Response}:-00}\"\n");
+                fw.write("}\n");
+            }
+            fw.flush();
+            fw.close();
+        } catch (Exception exn) {
+            logger.error("Exception creating MSCHAP configuration file", exn);
+        } finally {
+            if (fw != null) {
+                try {
+                    fw.close();
+                } catch (IOException ex) {
+                    logger.error("Exception closing MSCHAP configuration file", ex);
+                }
+            }
+        }
+
+        /*
+         * Create the ntlm_auth config file
+         */
+        try {
+            fw = new FileWriter(FREERADIUS_NTLM_CONFIG, false);
+            fw.write(FILE_DISCLAIMER);
+            if (systemSettings.getRadiusProxyEnabled()) {
+                fw.write("exec ntlm_auth {\n");
+                fw.write("\twait = yes\n");
+                fw.write("\tprogram = \"/usr/bin/ntlm_auth --request-nt-key --domain=MYDOMAIN --username=%{mschap:User-Name} --password=%{User-Password}\"\n");
+                fw.write("}\n");
+            }
+            fw.flush();
+            fw.close();
+        } catch (Exception exn) {
+            logger.error("Exception creating NTLM configuration file", exn);
+        } finally {
+            if (fw != null) {
+                try {
+                    fw.close();
+                } catch (IOException ex) {
+                    logger.error("Exception closing NTLM configuration file", ex);
+                }
+            }
+        }
+
+        // Update the eap config file
+        try {
+            updateFreeradiusEapConfig(FREERADIUS_EAP_CONFIG, "default_eap_type", "peap");
+        } catch (Exception exn) {
+            logger.error("Exception modifying EAP configuration file", exn);
+        }
+
+        /*
          * If server is enabled restart the freeradius service
          */
         if (systemSettings.getRadiusServerEnabled()) {
@@ -736,6 +874,70 @@ public class LocalDirectoryImpl implements LocalDirectory
         }
 
         return (secbuff.toString());
+    }
+
+    /**
+     * Modify the freeradius eap configuration file in place
+     *
+     * Note that this function will not currently allow modifying config items
+     * on lines that are commented. We simply look for the name and replace
+     * everything after it with the new value. It also won't work if you're
+     * dealing with partial matches or config items with short names that might
+     * occur in other configuration items. It also stops looking once it
+     * replaces the first occurrence so we don't make unwanted changes in the
+     * nested configuration sections within eap { inside the eap config file.
+     *
+     * @param fileName
+     *        The file to modify
+     * @param configItem
+     *        The configuration item to modify
+     * @param configValue
+     *        The new value for the configuration item
+     * @throws Exception
+     */
+    public void updateFreeradiusEapConfig(String fileName, String configItem, String configValue) throws Exception
+    {
+        int counter = 0;
+
+        java.util.Scanner scanner = new Scanner(new File(fileName));
+        List<String> config = new ArrayList<String>();
+        while (scanner.hasNextLine()) {
+            config.add(scanner.nextLine());
+        }
+        scanner.close();
+
+        FileWriter fw = new FileWriter(fileName, false);
+
+        for (String line : config) {
+            // if we already processed a match write without modification
+            if (counter > 0) {
+                fw.write(line + "\n");
+                continue;
+            }
+
+            // lines with comments are written without modification
+            if (line.contains("#")) {
+                fw.write(line + "\n");
+                continue;
+            }
+
+            // look for the configItem in the line
+            int cfgloc = line.indexOf(configItem);
+
+            // lines without the configItem are written without modification
+            if (cfgloc < 0) {
+                fw.write(line + "\n");
+                continue;
+            }
+
+            // write the configItem file entries using our configured crt file
+            fw.write(line.substring(0, cfgloc));
+            fw.write(configItem + " = " + configValue + "\n");
+            counter++;
+        }
+
+        fw.flush();
+        fw.close();
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
+++ b/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
@@ -804,6 +804,12 @@ public class LocalDirectoryImpl implements LocalDirectory
         if (systemSettings.getRadiusServerEnabled()) {
             UvmContextFactory.context().execManager().exec("systemctl restart freeradius.service");
         }
+        /*
+         * If proxy is enabled restart the winbind service
+         */
+        if (systemSettings.getRadiusServerEnabled()) {
+            UvmContextFactory.context().execManager().exec("systemctl restart winbind.service");
+        }
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
+++ b/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
@@ -86,7 +86,7 @@ public class LocalDirectoryImpl implements LocalDirectory
     public String getRadiusProxyStatus()
     {
         SystemSettings systemSettings = UvmContextFactory.context().systemManager().getSettings();
-        String command = (FREERADIUS_PROXY_SCRIPT + " " + systemSettings.getRadiusProxyUsername() + " " + systemSettings.getRadiusProxyPassword());
+        String command = (FREERADIUS_PROXY_SCRIPT + " \"" + systemSettings.getRadiusProxyUsername() + "\" \"" + systemSettings.getRadiusProxyPassword() + "\"");
 
         return UvmContextFactory.context().execManager().execOutput(command);
     }
@@ -102,11 +102,31 @@ public class LocalDirectoryImpl implements LocalDirectory
         SystemSettings systemSettings = UvmContextFactory.context().systemManager().getSettings();
 
         String command = ("/usr/bin/net ads --no-dns-updates join");
-        command += (" -U " + systemSettings.getRadiusProxyUsername() + "%" + systemSettings.getRadiusProxyPassword());
+        command += (" -U \"" + systemSettings.getRadiusProxyUsername() + "%" + systemSettings.getRadiusProxyPassword() + "\"");
         command += (" -S " + systemSettings.getRadiusProxyServer());
         command += (" osName=\"Untangle NG Firewall\"");
-//        command += (" osVer=\"" + UvmContextFactory.context().adminManager().getFullVersionAndRevision() + "\"");
         command += (" osVer=\"" + UvmContextFactory.context().getFullVersion() + "\"");
+
+        return UvmContextFactory.context().execManager().execOutput(command);
+    }
+
+    /**
+     * Called to test Active Directory authentication
+     *
+     * @param userName
+     *        The username for the test
+     * @param userPass
+     *        The password for the test
+     * @param userDomain
+     *        The domain for the test
+     * @return The result of the test
+     */
+    public String testRadiusProxyLogin(String userName, String userPass, String userDomain)
+    {
+        String command = ("/usr/bin/ntlm_auth --request-nt-key");
+        command += (" --domain=\"" + userDomain + "\"");
+        command += (" --username=\"" + userName + "\"");
+        command += (" --password=\"" + userPass + "\"");
 
         return UvmContextFactory.context().execManager().execOutput(command);
     }

--- a/uvm/servlets/admin/config/local-directory/Main.js
+++ b/uvm/servlets/admin/config/local-directory/Main.js
@@ -17,7 +17,23 @@ Ext.define('Ung.config.local-directory.Main', {
     items: [
         { xtype: 'config-local-directory-users' },
         {
-            xtype: 'config-local-directory-radius',
+            xtype: 'config-local-directory-radius-server',
+            tabConfig: {
+                bind: {
+                    hidden: '{!expertMode}'
+                }
+            }
+        },
+        {
+            xtype: 'config-local-directory-radius-proxy',
+            tabConfig: {
+                bind: {
+                    hidden: '{!expertMode}'
+                }
+            }
+        },
+        {
+            xtype: 'config-local-directory-radius-log',
             tabConfig: {
                 bind: {
                     hidden: '{!expertMode}'

--- a/uvm/servlets/admin/config/local-directory/MainController.js
+++ b/uvm/servlets/admin/config/local-directory/MainController.js
@@ -141,6 +141,34 @@ Ext.define('Ung.config.local-directory.MainController', {
         });
     },
 
+    refreshRadiusProxyStatus: function (cmp) {
+        var v = cmp.isXType('button') ? cmp.up('panel') : cmp;
+        var target = v.down('textarea');
+
+        target.setValue('');
+
+        v.setLoading(true);
+        Rpc.asyncData('rpc.UvmContext.localDirectory.getRadiusProxyStatus')
+        .then(function(result){
+            if(Util.isDestroyed(v, target)){
+                return;
+            }
+            target.setValue(result);
+            v.setLoading(false);
+        });
+    },
+
+    createComputerAccount: function (cmp) {
+        var v = cmp.isXType('button') ? cmp.up('panel') : cmp;
+
+        v.setLoading(true);
+        Rpc.asyncData('rpc.UvmContext.localDirectory.addRadiusComputerAccount')
+        .then(function(result){
+            v.setLoading(false);
+            Ext.MessageBox.alert({ buttons: Ext.Msg.OK, maxWidth: 1024, title: 'Account Creation Status'.t(), msg: '<tt>' + result + '</tt>' });
+        });
+    },
+
     statics:{
         expirationRenderer: function( value ){
             var date;

--- a/uvm/servlets/admin/config/local-directory/MainController.js
+++ b/uvm/servlets/admin/config/local-directory/MainController.js
@@ -7,7 +7,8 @@ Ext.define('Ung.config.local-directory.MainController', {
         '#': {
             beforerender: 'loadSettings'
         },
-        '#radius-log': { afterrender: 'refreshRadiusLogFile' }
+        '#radius-log': { afterrender: 'refreshRadiusLogFile' },
+        '#radius-proxy': { afterrender: 'refreshRadiusProxyStatus' }
     },
 
     loadSettings: function () {
@@ -166,6 +167,20 @@ Ext.define('Ung.config.local-directory.MainController', {
         .then(function(result){
             v.setLoading(false);
             Ext.MessageBox.alert({ buttons: Ext.Msg.OK, maxWidth: 1024, title: 'Account Creation Status'.t(), msg: '<tt>' + result + '</tt>' });
+        });
+    },
+
+    testRadiusProxyLogin: function (cmp) {
+        var v = cmp.isXType('button') ? cmp.up('panel') : cmp;
+        var testuser = v.down("[fieldIndex='testUsername']").getValue();
+        var testpass = v.down("[fieldIndex='testPassword']").getValue();
+        var testdom = v.down("[fieldIndex='testDomain']").getValue();
+
+        v.setLoading(true);
+        Rpc.asyncData('rpc.UvmContext.localDirectory.testRadiusProxyLogin', testuser, testpass, testdom)
+        .then(function(result){
+            v.setLoading(false);
+            Ext.MessageBox.alert({ buttons: Ext.Msg.OK, maxWidth: 1024, title: 'Test Authentication Result'.t(), msg: '<tt>' + result + '</tt>' });
         });
     },
 

--- a/uvm/servlets/admin/config/local-directory/view/Radius.js
+++ b/uvm/servlets/admin/config/local-directory/view/Radius.js
@@ -11,7 +11,8 @@ Ext.define('Ung.config.local-directory.view.Radius', {
     items: [{
         xtype: 'fieldset',
         padding: '10 20',
-        width: 500,
+        itemId: 'radius-server',
+        width: 600,
         title: 'Wi-Fi Authentication (RADIUS server)'.t(),
         items: [{
             xtype: 'checkbox',
@@ -44,8 +45,102 @@ Ext.define('Ung.config.local-directory.view.Radius', {
     }, {
         xtype: 'fieldset',
         padding: '10 20',
+        itemId: 'radius-proxy',
+        width: 600,
+        title: 'Active Directory (RADIUS Proxy)'.t(),
+        items: [{
+            xtype: 'checkbox',
+            reference: 'activeProxy',
+            padding: '5 0',
+            boxLabel: 'Enable Active Directory Proxy'.t(),
+            bind: {
+                value: '{systemSettings.radiusProxyEnabled}'
+            }
+        }, {
+            xtype: 'textfield',
+            fieldLabel: 'AD Server'.t(),
+            labelWidth: 120,
+            width: '100%',
+            allowBlank: false,
+            bind: {
+                value: '{systemSettings.radiusProxyServer}',
+                disabled: '{!activeProxy.checked}'
+            }
+        }, {
+            xtype: 'textfield',
+            fieldLabel: 'AD Workgroup'.t(),
+            labelWidth: 120,
+            width: '100%',
+            allowBlank: false,
+            bind: {
+                value: '{systemSettings.radiusProxyWorkgroup}',
+                disabled: '{!activeProxy.checked}'
+            }
+        }, {
+            xtype: 'textfield',
+            fieldLabel: 'AD Domain'.t(),
+            labelWidth: 120,
+            width: '100%',
+            allowBlank: false,
+            bind: {
+                value: '{systemSettings.radiusProxyRealm}',
+                disabled: '{!activeProxy.checked}'
+            }
+        }, {
+            xtype: 'textfield',
+            fieldLabel: 'AD Admin Username'.t(),
+            labelWidth: 120,
+            width: '100%',
+            allowBlank: false,
+            bind: {
+                value: '{systemSettings.radiusProxyUsername}',
+                disabled: '{!activeProxy.checked}'
+            }
+        }, {
+            xtype: 'textfield',
+            fieldLabel: 'AD Admin Password'.t(),
+            labelWidth: 120,
+            width: '100%',
+            allowBlank: false,
+            bind: {
+                value: '{systemSettings.radiusProxyPassword}',
+                disabled: '{!activeProxy.checked}'
+            }
+        }, {
+            xtype: 'button',
+            iconCls: 'fa fa-link',
+            text: 'Create AD Computer Account',
+            margin: '10, 0',
+            bind: {
+                disabled: '{!systemSettings.radiusProxyEnabled}',
+            },
+            handler: 'createComputerAccount'
+        }, {
+            xtype: 'button',
+            iconCls: 'fa fa-refresh',
+            text: 'Refresh AD Account Status',
+            margin: '10, 10',
+            bind: {
+                disabled: '{!systemSettings.radiusProxyEnabled}',
+            },
+            target: 'radiusProxyStatus',
+            handler: 'refreshRadiusProxyStatus'
+        }, {
+            xtype: 'textarea',
+            fieldLabel: 'AD Account Status'.t(),
+            labelWidth: 120,
+            width: '100%',
+            allowBlank: true,
+            readOnly: true,
+            bind: {
+                disabled: '{!activeProxy.checked}'
+            }
+        }]
+    }, {
+        xtype: 'fieldset',
+        padding: '10 20',
         itemId: 'radius-log',
-        width: '80%',
+        width: '100%',
         title: 'RADIUS Server Log'.t(),
         items: [{
             xtype: 'button',

--- a/uvm/servlets/admin/config/local-directory/view/RadiusLog.js
+++ b/uvm/servlets/admin/config/local-directory/view/RadiusLog.js
@@ -1,0 +1,40 @@
+Ext.define('Ung.config.local-directory.view.RadiusLog', {
+    extend: 'Ext.panel.Panel',
+    alias: 'widget.config-local-directory-radius-log',
+    itemId: 'radius-log',
+    title: 'RADIUS Log',
+    scrollable: false,
+    viewModel: true,
+
+    bodyPadding: 10,
+    layout: 'fit',
+
+    items: [{
+        xtype: 'fieldset',
+        padding: '10 20',
+        itemId: 'radius-log',
+        width: '100%',
+        height: '100%',
+        title: 'RADIUS Server Log'.t(),
+        items: [{
+            xtype: 'button',
+            iconCls: 'fa fa-refresh',
+            text: 'Refresh',
+            target: 'radiusLogFile',
+            handler: 'refreshRadiusLogFile'
+        }, {
+            xtype: 'textarea',
+            itemId: 'radiusLogFile',
+            spellcheck: false,
+            padding: '5 0 5 0',
+            border: true,
+            width: '100%',
+            height: '95%',
+            bind: '{radiusLogFile}',
+            fieldStyle: {
+                'fontFamily'   : 'courier new',
+                'fontSize'     : '12px'
+            }
+        }]
+    }]
+});

--- a/uvm/servlets/admin/config/local-directory/view/RadiusProxy.js
+++ b/uvm/servlets/admin/config/local-directory/view/RadiusProxy.js
@@ -1,48 +1,14 @@
-Ext.define('Ung.config.local-directory.view.Radius', {
+Ext.define('Ung.config.local-directory.view.RadiusProxy', {
     extend: 'Ext.panel.Panel',
-    alias: 'widget.config-local-directory-radius',
-    itemId: 'radius',
-    title: 'RADIUS',
+    alias: 'widget.config-local-directory-radius-proxy',
+    itemId: 'radius-proxy',
+    title: 'RADIUS Proxy',
     scrollable: true,
     viewModel: true,
 
     bodyPadding: 10,
 
     items: [{
-        xtype: 'fieldset',
-        padding: '10 20',
-        itemId: 'radius-server',
-        width: 600,
-        title: 'Wi-Fi Authentication (RADIUS server)'.t(),
-        items: [{
-            xtype: 'checkbox',
-            reference: 'externalAccess',
-            padding: '5 0',
-            boxLabel: 'Enable external access point authentication'.t(),
-            bind: {
-                value: '{systemSettings.radiusServerEnabled}'
-            }
-        }, {
-            xtype: 'textfield',
-            fieldLabel: 'RADIUS password'.t(),
-            labelWidth: 120,
-            width: '100%',
-            allowBlank: false,
-            bind: {
-                value: '{systemSettings.radiusServerSecret}',
-                disabled: '{!externalAccess.checked}'
-            }
-        }, {
-            xtype: 'button',
-            iconCls: 'fa fa-cog',
-            text: 'Configure Server Certificate'.t(),
-            margin: '10, 0',
-            bind: {
-                disabled: '{!systemSettings.radiusServerEnabled}',
-            },
-            handler: 'configureCertificate'
-        }]
-    }, {
         xtype: 'fieldset',
         padding: '10 20',
         itemId: 'radius-proxy',
@@ -139,28 +105,48 @@ Ext.define('Ung.config.local-directory.view.Radius', {
     }, {
         xtype: 'fieldset',
         padding: '10 20',
-        itemId: 'radius-log',
-        width: '100%',
-        title: 'RADIUS Server Log'.t(),
+        itemId: 'radius-test',
+        width: 600,
+        title: 'Active Directory Test'.t(),
         items: [{
-            xtype: 'button',
-            iconCls: 'fa fa-refresh',
-            text: 'Refresh',
-            target: 'radiusLogFile',
-            handler: 'refreshRadiusLogFile'
-        }, {
-            xtype: 'textarea',
-            itemId: 'radiusLogFile',
-            spellcheck: false,
-            padding: '5 0',
-            border: true,
+            xtype: 'textfield',
+            fieldLabel: 'Test Username'.t(),
+            fieldIndex: 'testUsername',
+            labelWidth: 120,
             width: '100%',
-            height: 500,
-            bind: '{radiusLogFile}',
-            fieldStyle: {
-                'fontFamily'   : 'courier new',
-                'fontSize'     : '12px'
+            allowBlank: false,
+            bind: {
+                disabled: '{!activeProxy.checked}'
             }
+        }, {
+            xtype: 'textfield',
+            fieldLabel: 'Test Password'.t(),
+            fieldIndex: 'testPassword',
+            labelWidth: 120,
+            width: '100%',
+            allowBlank: false,
+            bind: {
+                disabled: '{!activeProxy.checked}'
+            }
+        }, {
+            xtype: 'textfield',
+            fieldLabel: 'Test Domain'.t(),
+            fieldIndex: 'testDomain',
+            labelWidth: 120,
+            width: '100%',
+            allowBlank: false,
+            bind: {
+                disabled: '{!activeProxy.checked}'
+            }
+        }, {
+            xtype: 'button',
+            iconCls: 'fa fa-cogs',
+            text: 'Test Authentication',
+            margin: '10, 10',
+            bind: {
+                disabled: '{!systemSettings.radiusProxyEnabled}',
+            },
+            handler: 'testRadiusProxyLogin'
         }]
     }]
 });

--- a/uvm/servlets/admin/config/local-directory/view/RadiusServer.js
+++ b/uvm/servlets/admin/config/local-directory/view/RadiusServer.js
@@ -1,0 +1,46 @@
+Ext.define('Ung.config.local-directory.view.RadiusServer', {
+    extend: 'Ext.panel.Panel',
+    alias: 'widget.config-local-directory-radius-server',
+    itemId: 'radius-server',
+    title: 'RADIUS Server',
+    scrollable: true,
+    viewModel: true,
+
+    bodyPadding: 10,
+
+    items: [{
+        xtype: 'fieldset',
+        padding: '10 20',
+        itemId: 'radius-server',
+        width: 600,
+        title: 'Wi-Fi Authentication (RADIUS Server)'.t(),
+        items: [{
+            xtype: 'checkbox',
+            reference: 'externalAccess',
+            padding: '5 0',
+            boxLabel: 'Enable external access point authentication'.t(),
+            bind: {
+                value: '{systemSettings.radiusServerEnabled}'
+            }
+        }, {
+            xtype: 'textfield',
+            fieldLabel: 'RADIUS password'.t(),
+            labelWidth: 120,
+            width: '100%',
+            allowBlank: false,
+            bind: {
+                value: '{systemSettings.radiusServerSecret}',
+                disabled: '{!externalAccess.checked}'
+            }
+        }, {
+            xtype: 'button',
+            iconCls: 'fa fa-cog',
+            text: 'Configure Server Certificate'.t(),
+            margin: '10, 0',
+            bind: {
+                disabled: '{!systemSettings.radiusServerEnabled}',
+            },
+            handler: 'configureCertificate'
+        }]
+    }]
+});


### PR DESCRIPTION
This branch includes the NGFW user interface and uvm enhancements to support the RADIUS Phase 2 project. Like Phase 1 of this project, the expert-mode-flag must be enabled to activate and use these features, and everything is configured under Config / Local Directory.

We're calling this an engineering alpha release, so the supporting Debian packages are not yet integrated as part of our standard platform due to the additional size it will add to our distribution. Thus, to use these features, you must download and install the following development provided package:

wget http://auth-relay.untangle.com/netdev/ngfw-radius-proxy.tar.gz

Once you have a machine installed with a build that includes these changes, download the archive from the link above, extract into a convenient location, and execute (as root) the install-ut-radius-proxy script. This will install and configure the additional packages required to support the new functionality.