### PR TITLE
ipsec-vpn: Add ike=aes256-sha384-modp1024 for l2tp

### DIFF
--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnManager.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnManager.java
@@ -322,6 +322,7 @@ public class IpsecVpnManager
                         ipsec_conf.write(TAB + "leftprotoport=17/1701" + RET);
                         ipsec_conf.write(TAB + "right=%any" + RET);
                         ipsec_conf.write(TAB + "rightprotoport=17/%any" + RET);
+                        ipsec_conf.write(TAB + "ike=aes256-sha384-modp1024" + RET);
                         ipsec_conf.write(RET);
 
                         // -----------------------------------------------------------


### PR DESCRIPTION
Debian Buster dropped modp1024 from the default ikev1 cipher list.
But, android devices only support ciphers that use modp1024.  So
explicitly add back aes256-sha384-modp1024 to allow android devices
to connect.

NGFW-13163