### PR TITLE
ipsec-vpn: l2tp: Use same ciphers as ipsec tunnels

### DIFF
--- a/ipsec-vpn/js/view/VpnConfig.js
+++ b/ipsec-vpn/js/view/VpnConfig.js
@@ -84,6 +84,196 @@ Ext.define('Ung.apps.ipsecvpn.view.VpnConfig', {
             xtype: 'checkbox',
             bind: '{settings.allowConcurrentLogins}',
             fieldLabel: 'Allow Concurrent Logins',
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 0',
+            items: [{
+                xtype:'checkbox',
+                bind: '{settings.phase1Manual}',
+                fieldLabel: 'Phase 1 IKE/ISAKMP Manual Configuration'.t(),
+                labelWidth: 300
+            }]
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 40',
+            bind: { hidden: '{!settings.phase1Manual}' },
+            items: [{
+                xtype:'combobox',
+                bind: {
+                    value: '{settings.phase1Cipher}',
+                    store: '{P1CipherStore}'
+                },
+                fieldLabel: 'Encryption'.t(),
+                labelWidth: 120,
+                editable: false,
+                displayField: 'name',
+                valueField: 'value'
+            }, {
+                xtype: 'displayfield',
+                margin: '0 0 0 10',
+                value: 'Default = 3DES'.t()
+            }]
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 40',
+            bind: { hidden: '{!settings.phase1Manual}' },
+            items: [{
+                xtype:'combobox',
+                bind: {
+                    value: '{settings.phase1Hash}',
+                    store: '{P1HashStore}'
+                },
+                fieldLabel: 'Hash'.t(),
+                labelWidth: 120,
+                editable: false,
+                displayField: 'name',
+                valueField: 'value'
+            }, {
+                xtype: 'displayfield',
+                margin: '0 0 0 10',
+                value: 'Default = MD5'.t()
+            }]
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 40',
+            bind: { hidden: '{!settings.phase1Manual}' },
+            items: [{
+                xtype:'combobox',
+                bind: {
+                    value: '{settings.phase1Group}',
+                    store: '{P1GroupStore}'
+                },
+                fieldLabel: 'DH Key Group'.t(),
+                labelWidth: 120,
+                editable: false,
+                displayField: 'name',
+                valueField: 'value'
+            }, {
+                xtype: 'displayfield',
+                margin: '0 0 0 10',
+                value: 'Default = 14 (modp2048)'.t()
+            }]
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 40',
+            bind: { hidden: '{!settings.phase1Manual}' },
+            items: [{
+                xtype:'numberfield',
+                bind: {
+                    value: '{settings.phase1Lifetime}',
+                },
+                fieldLabel: 'Lifetime'.t(),
+                labelWidth: 120,
+                allowBlank: false,
+                allowDecimals: false,
+                minValue: 3600,
+                maxValue: 86400
+            }, {
+                xtype: 'displayfield',
+                margin: '0 0 0 10',
+                value: 'Default = 28800 seconds, min = 3600, max = 86400'.t()
+            }]
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 0',
+            items: [{
+                xtype:'checkbox',
+                bind: '{settings.phase2Manual}',
+                fieldLabel: 'Phase 2 ESP Manual Configuration'.t(),
+                labelWidth: 300
+            }]
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 40',
+            bind: { hidden: '{!settings.phase2Manual}' },
+            items: [{
+                xtype:'combobox',
+                bind: {
+                    value: '{settings.phase2Cipher}',
+                    store: '{P2CipherStore}'
+                },
+                fieldLabel: 'Encryption'.t(),
+                labelWidth: 120,
+                editable: false,
+                displayField: 'name',
+                valueField: 'value'
+            }, {
+                xtype: 'displayfield',
+                margin: '0 0 0 10',
+                value: 'Default = 3DES'.t()
+            }]
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 40',
+            bind: { hidden: '{!settings.phase2Manual}' },
+            items: [{
+                xtype:'combobox',
+                bind: {
+                    value: '{settings.phase2Hash}',
+                    store: '{P2HashStore}'
+                },
+                fieldLabel: 'Hash'.t(),
+                labelWidth: 120,
+                editable: false,
+                displayField: 'name',
+                valueField: 'value'
+            }, {
+                xtype: 'displayfield',
+                margin: '0 0 0 10',
+                value: 'Default = MD5'.t()
+            }]
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 40',
+            bind: { hidden: '{!settings.phase2Manual}' },
+            items: [{
+                xtype:'combobox',
+                bind: {
+                    value: '{settings.phase2Group}',
+                    hidden: '{!settings.phase2Manual}',
+                    store: '{P2GroupStore}'
+                },
+                fieldLabel: 'PFS Key Group'.t(),
+                labelWidth: 120,
+                editable: false,
+                displayField: 'name',
+                valueField: 'value'
+            }, {
+                xtype: 'displayfield',
+                margin: '0 0 0 10',
+                value: 'Default = 14 (modp2048)'.t()
+            }]
+        }, {
+            xtype: 'container',
+            layout: 'column',
+            margin: '0 0 5 40',
+            bind: { hidden: '{!settings.phase2Manual}' },
+            items: [{
+                xtype:'numberfield',
+                bind: {
+                    value: '{settings.phase2Lifetime}',
+                    hidden: '{!settings.phase2Manual}'
+                },
+                fieldLabel: 'Lifetime'.t(),
+                labelWidth: 120,
+                allowBlank: false,
+                allowDecimals: false,
+                minValue: 3600,
+                maxValue: 86400
+            }, {
+                xtype: 'displayfield',
+                margin: '0 0 0 10',
+                value: 'Default = 3600 seconds, min = 3600, max = 86400'.t()
+            }]
         },{
             xtype: 'radiogroup',
             bind: '{settings.authenticationType}',

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnManager.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnManager.java
@@ -312,8 +312,6 @@ public class IpsecVpnManager
                             ipsec_conf.write(TAB + "replay_window=0" + RET);
                         }
 
-                        ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
-                        ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
                         ipsec_conf.write(TAB + "dpddelay=10" + RET);
                         ipsec_conf.write(TAB + "dpdtimeout=90" + RET);
                         ipsec_conf.write(TAB + "dpdaction=clear" + RET);
@@ -322,6 +320,27 @@ public class IpsecVpnManager
                         ipsec_conf.write(TAB + "leftprotoport=17/1701" + RET);
                         ipsec_conf.write(TAB + "right=%any" + RET);
                         ipsec_conf.write(TAB + "rightprotoport=17/%any" + RET);
+
+                        if (settings.getPhase1Manual() == true) {
+                            ipsec_conf.write(TAB + "ike=" + settings.getPhase1Cipher() + "-" + settings.getPhase1Hash() + "-" + settings.getPhase1Group() + "!" + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1Lifetime() + "s" + RET);
+                        } else {
+                            ipsec_conf.write(TAB + "ike=" + ike_default + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
+                        }
+
+                        if (settings.getPhase2Manual() == true) {
+                            if (settings.getPhase2Group().equals("disabled") == true) {
+                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "!" + RET);
+                            } else {
+                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "-" + settings.getPhase2Group() + "!" + RET);
+                            }
+                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2Lifetime() + "s" + RET);
+                        } else {
+                            ipsec_conf.write(TAB + "esp=" + esp_default + RET);
+                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
+                        }
+
                         ipsec_conf.write(RET);
 
                         // -----------------------------------------------------------
@@ -351,8 +370,6 @@ public class IpsecVpnManager
                             ipsec_conf.write(TAB + "replay_window=0" + RET);
                         }
 
-                        ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
-                        ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
                         ipsec_conf.write(TAB + "left=" + listen.getAddress() + RET);
                         ipsec_conf.write(TAB + "leftsubnet=0.0.0.0/0" + RET);
                         ipsec_conf.write(TAB + "leftupdown=" + XAUTH_UPDOWN_SCRIPT + RET);
@@ -379,6 +396,26 @@ public class IpsecVpnManager
                             ipsec_conf.write(TAB + "rightdns=" + settings.getVirtualDnsOne() + "," + settings.getVirtualDnsTwo() + RET);
                         }
 
+                        if (settings.getPhase1Manual() == true) {
+                            ipsec_conf.write(TAB + "ike=" + settings.getPhase1Cipher() + "-" + settings.getPhase1Hash() + "-" + settings.getPhase1Group() + "!" + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1Lifetime() + "s" + RET);
+                        } else {
+                            ipsec_conf.write(TAB + "ike=" + ike_default + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
+                        }
+
+                        if (settings.getPhase2Manual() == true) {
+                            if (settings.getPhase2Group().equals("disabled") == true) {
+                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "!" + RET);
+                            } else {
+                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "-" + settings.getPhase2Group() + "!" + RET);
+                            }
+                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2Lifetime() + "s" + RET);
+                        } else {
+                            ipsec_conf.write(TAB + "esp=" + esp_default + RET);
+                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
+                        }
+
                         ipsec_conf.write(RET);
 
                         // -----------------------------------------------------------
@@ -389,8 +426,6 @@ public class IpsecVpnManager
                         ipsec_conf.write(TAB + "keyexchange=ikev2" + RET);
                         ipsec_conf.write(TAB + "auto=add" + RET);
                         ipsec_conf.write(TAB + "type=tunnel" + RET);
-                        ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
-                        ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
 
                         if (osArch.equals("arm") == true) {
                             ipsec_conf.write(TAB + "replay_window=0" + RET);
@@ -450,6 +485,26 @@ public class IpsecVpnManager
                         // add the L2TP PSK to the shared secrets file
                         ipsec_secrets.write("# VPN-L2TP-" + Integer.toString(x) + RET);
                         ipsec_secrets.write(listen.getAddress() + " %any : PSK 0x" + StringHexify(settings.getVirtualSecret()) + RET);
+
+                        if (settings.getPhase1Manual() == true) {
+                            ipsec_conf.write(TAB + "ike=" + settings.getPhase1Cipher() + "-" + settings.getPhase1Hash() + "-" + settings.getPhase1Group() + "!" + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1Lifetime() + "s" + RET);
+                        } else {
+                            ipsec_conf.write(TAB + "ike=" + ike_default + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
+                        }
+
+                        if (settings.getPhase2Manual() == true) {
+                            if (settings.getPhase2Group().equals("disabled") == true) {
+                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "!" + RET);
+                            } else {
+                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "-" + settings.getPhase2Group() + "!" + RET);
+                            }
+                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2Lifetime() + "s" + RET);
+                        } else {
+                            ipsec_conf.write(TAB + "esp=" + esp_default + RET);
+                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
+                        }
                     }
                 }
 

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnSettings.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnSettings.java
@@ -39,6 +39,16 @@ public class IpsecVpnSettings implements java.io.Serializable, JSONString
     private String virtualDnsTwo = "";
     private String charonDebug = "";
     private String uniqueIds = "yes";
+    private boolean phase1Manual = false;
+    private String phase1Cipher = "3des";
+    private String phase1Hash = "md5";
+    private String phase1Group = "modp2048";
+    private String phase1Lifetime = "28800";
+    private boolean phase2Manual = false;
+    private String phase2Cipher = "3des";
+    private String phase2Hash = "md5";
+    private String phase2Group = "modp2048";
+    private String phase2Lifetime = "3600";
     private String phase1DefaultLifetime = "8h";
     private String phase2DefaultLifetime = "1h";
 
@@ -104,6 +114,36 @@ public class IpsecVpnSettings implements java.io.Serializable, JSONString
 
     public String getPhase2DefaultLifetime() { return(phase2DefaultLifetime); }
     public void setPhase2DefaultLifetime(String argString) { this.phase2DefaultLifetime = argString; }
+
+    public boolean getPhase1Manual() { return (phase1Manual); }
+    public void setPhase1Manual(boolean phase1Manual) { this.phase1Manual = phase1Manual; }
+
+    public String getPhase1Cipher() { return (phase1Cipher); }
+    public void setPhase1Cipher(String phase1Cipher) { this.phase1Cipher = phase1Cipher; }
+
+    public String getPhase1Hash() { return (phase1Hash); }
+    public void setPhase1Hash(String phase1Hash) { this.phase1Hash = phase1Hash; }
+
+    public String getPhase1Group() { return (phase1Group); }
+    public void setPhase1Group(String phase1Group) { this.phase1Group = phase1Group; }
+
+    public String getPhase1Lifetime() { return (phase1Lifetime); }
+    public void setPhase1Lifetime(String phase1Lifetime) { this.phase1Lifetime = phase1Lifetime; }
+
+    public boolean getPhase2Manual() { return (phase2Manual); }
+    public void setPhase2Manual(boolean phase2Manual) { this.phase2Manual = phase2Manual; }
+
+    public String getPhase2Cipher() { return (phase2Cipher); }
+    public void setPhase2Cipher(String phase2Cipher) { this.phase2Cipher = phase2Cipher; }
+
+    public String getPhase2Hash() { return (phase2Hash); }
+    public void setPhase2Hash(String phase2Hash) { this.phase2Hash = phase2Hash; }
+
+    public String getPhase2Group() { return (phase2Group); }
+    public void setPhase2Group(String phase2Group) { this.phase2Group = phase2Group; }
+
+    public String getPhase2Lifetime() { return (phase2Lifetime); }
+    public void setPhase2Lifetime(String phase2Lifetime) { this.phase2Lifetime = phase2Lifetime; }
 
 // THIS IS FOR ECLIPSE - @formatter:on
 


### PR DESCRIPTION
For ipsec tunnels we have a curated set of ike and esp ciphers.  Use
those same ciphers for l2tp/xauth/IKEv2.  This ensures we've got a
compatible cipher for android devices.  Also add the same manual
configuration settings for ike and esp that are available for ipsec
tunnels for customers who want to nail down a specific cipher.

NGFW-13163