### PR TITLE
reports: Add back the ability to export full report database

### DIFF
--- a/uvm/js/common/reports/view/Entry.js
+++ b/uvm/js/common/reports/view/Entry.js
@@ -156,30 +156,53 @@ Ext.define('Ung.view.reports.Entry', {
                     },
                     handler: 'dashboardAddRemove'
                 }, {
-                    xtype: 'exporterbutton',
-                    itemId: 'exportCsv',
+                    xtype: 'button',
                     text: 'Export Data (csv)'.t(),
+                    itemId: 'exportData',
                     iconCls: 'fa fa-external-link-square',
-                    hidden: true,
-                    disabled: true,
-                    component: this,
-                    store: this,
+                    menu: {
+                        plain: true,
+                        showSeparator: false,
+                        items: [{
+                            itemId: 'exportDatabase',
+                            text: 'Export All Events'.t(),
+                            handler: 'exportEventsHandler',
+                            hidden: false,
+                            disabled: false,
+                        }, {
+                            text: 'Export Displayed Events'.t(),
+                            itemId: 'exportCsv',
+                            hidden: false,
+                            disabled: false,
+                            component: this,
+                            store: this,
+                            format: 'csv',
+                            remote: false,
+                            title: 'export',
+                            onClick: function(e) {
+                                var me = this,
+                                   blobURL = "",
+                                   format = me.format,
+                                   remote = me.remote,
+                                   title = me.title,
+                                   dt = new Date(),
+                                   link = me.el.dom.children[0],
+                                   res, filename;
+
+                                res = Ext.ux.exporter.Exporter.exportAny(me.component, me.store, format, { title : title });
+                                filename = title + "_" + Ext.Date.format(dt, "Y-m-d h:i:s") + "." + res.ext;
+                                Ext.ux.exporter.FileSaver.saveAs(res.data, res.mimeType, res.charset, filename, link, remote, me.onComplete, me);
+                            },
+                            onComplete: function() {
+                                this.fireEvent('complete', this);
+                                this.blur();
+                            }
+                        }],
+                    },
+                    hidden: false,
+                    disabled: false,
                     bind: {
                         hidden: '{entry.type !== "EVENT_LIST" || eEntry}',
-                        disabled: '{fetching}'
-                    }
-                }, {
-                    xtype: 'exporterbutton',
-                    itemId: 'exportXls',
-                    text: 'Export (xls)'.t(),
-                    title: 'Export Template XLS',
-                    format: 'excel',
-                    iconCls: 'fa fa-external-link-square',
-                    hidden: true,
-                    disabled: true,
-                    component: this,
-                    store: this,
-                    bind: {
                         disabled: '{fetching}'
                     }
                 }, {

--- a/uvm/js/common/reports/view/EventReport.js
+++ b/uvm/js/common/reports/view/EventReport.js
@@ -297,7 +297,7 @@ Ext.define('Ung.view.reports.EventReport', {
         },
 
         /**
-         * bindExportButtons handles the binding of the ungrid component and store to the exportCsv and exportXls buttons
+         * bindExportButtons handles the binding of the ungrid component and store to the exportCsv button
          * Within this functionality we create an Ext.js default grid panel and set the current columns and store to the grid.
          * The grid is not rendered, but passed directly into the Exporter tools, which handle proper exporting of the data.
          *
@@ -308,11 +308,15 @@ Ext.define('Ung.view.reports.EventReport', {
             var me = this,
             entry = me.getViewModel().get('entry'),
             export_title = 'export', // default export title
-            csvButton = me.getView().up().up().down('#exportCsv'),
-            xlsButton = me.getView().up().up().down('#exportXls'),
+            csvButton,
+            exportButton = me.getView().up().up().down('#exportData');
             grid = me.getView().down('grid');
 
-            if (!csvButton || !xlsButton || !grid) { return; }
+            if (!exportButton || !grid) { return; }
+
+            csvButton = exportButton.down('#exportCsv');
+
+            if (!csvButton) { return; }
 
             if (entry) {
                 export_title = (entry.get('category') + '-' + entry.get('title')).replace(/ /g, '_');
@@ -323,7 +327,6 @@ Ext.define('Ung.view.reports.EventReport', {
              * given that the title is altered so it contains the report entry category/title
              */
             csvButton.title = export_title;
-            xlsButton.title = export_title;
 
             /**
              * it is necessary to generate a different grid which is decoupled from original one
@@ -404,10 +407,8 @@ Ext.define('Ung.view.reports.EventReport', {
             });
 
             csvButton.component = exportGrid;
-            xlsButton.component = exportGrid;
 
             csvButton.store = exportStore;
-            xlsButton.store = exportStore;
         }
     },
     statics:{


### PR DESCRIPTION
In NGFW-12571 the 'Export Data (csv)' button was changed to export
the displayed report data, instead of the data returned by the
database query.  This commit changes the 'Export Data (csv)' button
to a menu button with options to export the queried data or just the
displayed data.

NGFW-12916