### PR TITLE
intrusion-prevention-get-updates: Use /usr/bin/suricata

### DIFF
--- a/intrusion-prevention/hier/etc/cron.daily/intrusion-prevention-get-updates
+++ b/intrusion-prevention/hier/etc/cron.daily/intrusion-prevention-get-updates
@@ -322,7 +322,7 @@ def main(argv):
         uri_manager_template = UVM_CONTEXT.uriManager().getUri(SIGNATURE_URL_TEMPLATE)
         # Set version parameter
         uri_manager_template = uri_manager_template.replace(".tar.gz", "{version}.tar.gz")
-        suricata_version = subprocess.check_output(["/bin/suricata","-V"])
+        suricata_version = subprocess.check_output(["/usr/bin/suricata","-V"])
         match = re.search(SURICATA_VERSION_RE, suricata_version.decode('ascii'))
         if match:
             urls.append(uri_manager_template.format(version=match.group(1)))


### PR DESCRIPTION
On older installs /bin is not symlinked to /usr/bin and so
the version lookup fails.  /usr/bin/suricata will work for new
and old installs.

NGFW-13187