### PR TITLE
Fix how the endpoint is displayed in the status grid

### DIFF
--- a/wireguard-vpn/js/Main.js
+++ b/wireguard-vpn/js/Main.js
@@ -27,6 +27,8 @@ Ext.define('Ung.apps.wireguard-vpn.Main', {
                     name: 'preshared-key'
                 },{
                     name: 'endpoint'
+                }, {
+                    name: 'configured-endpoint',
                 },{
                     name: 'allowed-ips'
                 },{

--- a/wireguard-vpn/js/MainController.js
+++ b/wireguard-vpn/js/MainController.js
@@ -116,10 +116,10 @@ Ext.define('Ung.apps.wireguard-vpn.MainController', {
     /**
      * From Util.storeGetChangedRecords result, add tunnels by waiting
      * for tunnel store to be reloaded then pulling publicKeys.
-     * 
+     *
      * This is neccessary because on new tunnels, the keypair is added when
      * the records are written and not known until after we reload.
-     * 
+     *
      * @param {*} changes Util.storeGetChangedRecords result with added field.
      */
     addTunnels: function( changes ){
@@ -217,6 +217,7 @@ Ext.define('Ung.apps.wireguard-vpn.MainController', {
                     status.wireguard.forEach(function(status){
                         if(tunnel.get('publicKey') == status['peer-key']){
                             status['tunnel-description'] = tunnel.get('description');
+                            status['configured-endpoint'] = tunnel.get('endpointAddress');
                         }
                     });
                 });
@@ -316,7 +317,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
     alias: 'controller.unwireguardvpntunnelrecordeditorcontroller',
 
     pasteTunnel: function(component){
-        if(!component.target || 
+        if(!component.target ||
            !component.target.dataset.componentid ||
            !component.target.dataset.componentid){
             return;
@@ -327,7 +328,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
         }
         var view = el.up('unwireguardvpntunnelrecordeditor'),
             controller = view.getController(),
-            record = view.record; 
+            record = view.record;
         if(record.get('id') != -1){
             // Only on a new record.
             return;

--- a/wireguard-vpn/js/view/Status.js
+++ b/wireguard-vpn/js/view/Status.js
@@ -96,13 +96,18 @@ Ext.define('Ung.apps.wireguard-vpn.view.Status', {
                     flex: 1,
                     hidden: true
                 }, {
+                    header: 'Remote Endpoint'.t(),
+                    dataIndex: 'configured-endpoint',
+                    width: Renderer.ipWidth + Renderer.portWidth
+                }, {
+                    header: 'Detected Endpoint'.t(),
+                    dataIndex: 'endpoint',
+                    width: Renderer.ipWidth + Renderer.portWidth,
+                    hidden: true
+                }, {
                     header: 'Remote Networks'.t(),
                     dataIndex: 'allowed-ips',
                     width: Renderer.networkWidth,
-                }, {
-                    header: 'Remote Endpoint'.t(),
-                    dataIndex: 'endpoint',
-                    width: Renderer.ipWidth + Renderer.portWidth
                 }, {
                     header: 'Last Handshake'.t(),
                     dataIndex: 'latest-handshake',


### PR DESCRIPTION
I changed the column header on the endpoint detected by the wireguard daemon to Detected Endpoint and made it hidden by default. I then updated the status display to get and use the configured endpoint address as the Remote Endpoint by default. This should clear up the confusion described in the ticket.