### PR TITLE
Fix urlValidator to allow all valid TLD's

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -449,7 +449,7 @@ Ext.define('Ung.util.Util', {
     },
 
     urlValidator: function (val) {
-        var res = val.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
+        var res = val.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g);
         return res ? true : 'Url missing or in wrong format!'.t();
     },
 


### PR DESCRIPTION
I fixed the urlValidator to allow all legal TLD's from 2 to 63 characters in length.
