### PR TITLE
NetworkManager: Check for duplicate interfaceIds

### DIFF
--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1603,6 +1603,17 @@ public class NetworkManagerImpl implements NetworkManager
         networkSettings.setInterfaces(interfaceList);
         
         /**
+         * Check if all interfaceIds are unique
+         */
+        for ( InterfaceSettings intf1 : networkSettings.getInterfaces() ) {
+            for ( InterfaceSettings intf2 : networkSettings.getInterfaces() ) {
+                if ( intf1.getInterfaceId() == intf2.getInterfaceId() &&
+                     intf1 != intf2 )
+                    throw new RuntimeException( intf1.getName() + " & " + intf2.getName() + " interfaceId conflict." );
+            }
+        }
+
+        /**
          *  Sanitize dynamic routing settings
          */
         if (networkSettings.getDynamicRoutingSettings() != null ){


### PR DESCRIPTION
Whether they came from a user mucking with their settings
or a bug in our code, if there are duplicate interfaceIds,
bad stuff will happen.

NGFW-13209