### PR TITLE
Fix reports link to Google Drive configuration

### DIFF
--- a/reports/js/MainController.js
+++ b/reports/js/MainController.js
@@ -155,11 +155,7 @@ Ext.define('Ung.apps.reports.MainController', {
     },
 
     configureGoogleDrive: function () {
-        if(Rpc.directData('rpc.appManager.app', 'directory-connector')){
-            Ung.app.redirectTo('#service/directory-connector/google');
-        } else {
-            Ext.MessageBox.alert('Error'.t(), 'Google Drive requires Directory Connector application.'.t());
-        }
+        Ung.app.redirectTo('#config/administration/google');
     },
 
     onUpload: function (btn) {


### PR DESCRIPTION
The Reports UI was already getting the Google Drive connection status from the correct location after the move from Directory Connector to the core uvm. It seems the redirect target on the Configure Google Drive button just never got updated. I fixed and verified the button functionality, confirmed expected behavior both with and without Google Drive configured, and manually ran the reports google backup cron scripts to confirm that backups are properly generated and pushed to the configured location.
