### PR TITLE
Check for null pointers when building network list

### DIFF
--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
@@ -497,8 +497,14 @@ public class WireGuardVpnApp extends AppBase
     {
         LinkedList<WireGuardVpnNetwork> networkList = new LinkedList<WireGuardVpnNetwork>();
 
+        if (intfStatuses == null) {
+            return networkList;
+        }
+
         for (InterfaceStatus intfStatus : intfStatuses) {
-            networkList.add(new WireGuardVpnNetwork(intfStatus.getV4MaskedAddress().getIPMaskedAddress()));
+            if (intfStatus.getV4MaskedAddress() != null) {
+                networkList.add(new WireGuardVpnNetwork(intfStatus.getV4MaskedAddress().getIPMaskedAddress()));
+            }
         }
 
         return networkList;


### PR DESCRIPTION
Added null check for the passed status list and for each masked address in the list when building the network list to solve a null pointer exception I saw during app installation.
