### PR TITLE
Make RADIUS Proxy generally available

### DIFF
--- a/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
@@ -959,9 +959,8 @@ public class CertificateManagerImpl implements CertificateManager
         statusInfo.append("<TR><TD WIDTH=120>HTTPS Certificate</TD><TD>" + httpsInfo + "</TD></TR>");
         statusInfo.append("<TR><TD WIDTH=120>SMTPS Certificate</TD><TD>" + smtpsInfo + "</TD></TR>");
         statusInfo.append("<TR><TD WIDTH=120>IPSEC Certificate</TD><TD>" + ipsecInfo + "</TD></TR>");
-        if (UvmContextFactory.context().isExpertMode()) {
-            statusInfo.append("<TR><TD WIDTH=120>RADIUS Certificate</TD><TD>" + radiusInfo + "</TD></TR>");
-        }
+        statusInfo.append("<TR><TD WIDTH=120>RADIUS Certificate</TD><TD>" + radiusInfo + "</TD></TR>");
+
         statusInfo.append("</TABLE>");
         return (statusInfo.toString());
     }

--- a/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
+++ b/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
@@ -749,12 +749,12 @@ public class LocalDirectoryImpl implements LocalDirectory
         try {
             fw = new FileWriter(FREERADIUS_MSCHAP_CONFIG, false);
             fw.write(FILE_DISCLAIMER);
+            fw.write("mschap {\n");
             if (systemSettings.getRadiusProxyEnabled()) {
-                fw.write("mschap {\n");
                 fw.write("\twith_ntdomain_hack = yes\n");
                 fw.write("\tntlm_auth = \"/usr/bin/ntlm_auth --request-nt-key --username=%{%{Stripped-User-Name}:-%{%{User-Name}:-None}} --challenge=%{%{mschap:Challenge}:-00} --nt-response=%{%{mschap:NT-Response}:-00}\"\n");
-                fw.write("}\n");
             }
+            fw.write("}\n");
             fw.flush();
             fw.close();
         } catch (Exception exn) {

--- a/uvm/servlets/admin/config/administration/view/Certificates.js
+++ b/uvm/servlets/admin/config/administration/view/Certificates.js
@@ -202,9 +202,6 @@ Ext.define('Ung.config.administration.view.Certificates', {
                 xtype: 'checkcolumn',
                 width: 80,
                 dataIndex: 'radiusServer',
-                bind: {
-                    hidden: '{!expertMode}'
-                },
                 listeners: {
                     // don't allow uncheck - they must pick a different cert
                     beforecheckchange: function (el, rowIndex, checked) {

--- a/uvm/servlets/admin/config/local-directory/Main.js
+++ b/uvm/servlets/admin/config/local-directory/Main.js
@@ -17,28 +17,13 @@ Ext.define('Ung.config.local-directory.Main', {
     items: [
         { xtype: 'config-local-directory-users' },
         {
-            xtype: 'config-local-directory-radius-server',
-            tabConfig: {
-                bind: {
-                    hidden: '{!expertMode}'
-                }
-            }
+            xtype: 'config-local-directory-radius-server'
         },
         {
-            xtype: 'config-local-directory-radius-proxy',
-            tabConfig: {
-                bind: {
-                    hidden: '{!expertMode}'
-                }
-            }
+            xtype: 'config-local-directory-radius-proxy'
         },
         {
-            xtype: 'config-local-directory-radius-log',
-            tabConfig: {
-                bind: {
-                    hidden: '{!expertMode}'
-                }
-            }
+            xtype: 'config-local-directory-radius-log'
         }
     ]
 });

--- a/uvm/servlets/admin/config/local-directory/MainController.js
+++ b/uvm/servlets/admin/config/local-directory/MainController.js
@@ -14,9 +14,6 @@ Ext.define('Ung.config.local-directory.MainController', {
     loadSettings: function () {
         var me = this, v = me.getView(), vm = me.getViewModel();
 
-        // set expert mode used to show/hide RADIUS section
-        vm.set('expertMode', Rpc.directData('rpc.isExpertMode'));
-
         v.setLoading(true);
         Ext.Deferred.sequence([
             Rpc.asyncPromise('rpc.UvmContext.localDirectory.getUsers'),
@@ -143,6 +140,11 @@ Ext.define('Ung.config.local-directory.MainController', {
     },
 
     refreshRadiusProxyStatus: function (cmp) {
+        var vm = this.getViewModel();
+        if (vm.get('systemSettings.radiusProxyEnabled') !== true) {
+            return;
+        }
+
         var v = cmp.isXType('button') ? cmp.up('panel') : cmp;
         var target = v.down('textarea');
 

--- a/uvm/servlets/admin/config/local-directory/view/RadiusProxy.js
+++ b/uvm/servlets/admin/config/local-directory/view/RadiusProxy.js
@@ -20,7 +20,8 @@ Ext.define('Ung.config.local-directory.view.RadiusProxy', {
             padding: '5 0',
             boxLabel: 'Enable Active Directory Proxy'.t(),
             bind: {
-                value: '{systemSettings.radiusProxyEnabled}'
+                value: '{systemSettings.radiusProxyEnabled}',
+                disabled: '{!systemSettings.radiusServerEnabled}'
             }
         }, {
             xtype: 'textfield',

--- a/uvm/servlets/admin/config/local-directory/view/RadiusServer.js
+++ b/uvm/servlets/admin/config/local-directory/view/RadiusServer.js
@@ -21,6 +21,16 @@ Ext.define('Ung.config.local-directory.view.RadiusServer', {
             boxLabel: 'Enable external access point authentication'.t(),
             bind: {
                 value: '{systemSettings.radiusServerEnabled}'
+            },
+            listeners: {
+                change: {
+                    fn: function(box,nval,oval,opts) {
+                        if (nval === false) {
+                            vm = box.ownerCt.ownerCt.getViewModel();
+                            vm.set('systemSettings.radiusProxyEnabled', false);
+                        }
+                    }
+                }
             }
         }, {
             xtype: 'textfield',


### PR DESCRIPTION
The main change was to remove expert mode protecting access to the RADIUS proxy feature. Fixed UI so the RADIUS server must be enabled before the proxy feature can be enabled. Fixed mschap configuration file so server_only and server+proxy modes both work.
