### PR TITLE
Fix license check during startup

### DIFF
--- a/wireguard-vpn/hier/usr/share/untangle/lib/wireguard-vpn/appProperties.json
+++ b/wireguard-vpn/hier/usr/share/untangle/lib/wireguard-vpn/appProperties.json
@@ -5,6 +5,11 @@
         "displayName" : "WireGuard VPN",
         "type" : "SERVICE",
         "viewPosition" : 1080,
-        "autoStart" : "true"
+        "autoStart" : "false",
+        "parents" : {
+            "javaClass": "java.util.LinkedList",
+            "list": [
+                "license"
+            ]
+        }
 }
-


### PR DESCRIPTION
The application needs to list the license app as a parent otherwise it can be instantiated before the license manager has fully initialized, causing the startup license check to fail.
