### PR TITLE
NGFW-13468 Undo hostable to device table sync.

### DIFF
--- a/uvm/impl/com/untangle/uvm/HostTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/HostTableImpl.java
@@ -596,11 +596,6 @@ public class HostTableImpl implements HostTable
         if (deviceEntry == null) return;
 
         /**
-         * We need to keep the username consistent for host and device. Hostentry has priority.
-         */
-        if (entry.getUsername() != null) deviceEntry.setUsername(entry.getUsername());
-
-        /**
          * Restore known information from the device entry where able
          */
         if (deviceEntry.getHostname() != null) entry.setHostnameDevice(deviceEntry.getHostname());


### PR DESCRIPTION
Removed the automated update of usernames to the device table. This caused confusion as to the login status of a user and deviated from previous behavior. 