### PR TITLE
Disable RADIUS Proxy auto account creation

### DIFF
--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -270,6 +270,18 @@ public class SystemManagerImpl implements SystemManager
         if (dirtyRadiusFields) {
             UvmContextFactory.context().localDirectory().setRadiusProxyComputerAccountExists(false);
         }
+
+/*
+
+This logic isn't working. The UI throws a bunch of exceptions and failure
+messages generated from exec'ing the create computer account command when
+called at this point. This happens when testing on a clean and never
+before configured system (ie: all settings wiped). Maybe a timing thing
+between the saving of the files, and restarting the external daemons?
+Not sure but I couldn't figure it out so I restored the UI button for
+creating the computer account and commented this as a quick fix until we
+can look deeper. - mahotz
+
         // If radius proxy enabled and a computer account needs to be added and fields were changed, add a computer account
         if (this.settings.getRadiusProxyEnabled() && !UvmContextFactory.context().localDirectory().getRadiusProxyComputerAccountExists() && dirtyRadiusFields) {
             ExecManagerResult addComputerAccount = UvmContextFactory.context().localDirectory().addRadiusComputerAccount();
@@ -279,6 +291,7 @@ public class SystemManagerImpl implements SystemManager
                 UvmContextFactory.context().localDirectory().setRadiusProxyComputerAccountExists(true);
             }
         }
+*/
     }
 
     /**

--- a/uvm/servlets/admin/config/local-directory/MainController.js
+++ b/uvm/servlets/admin/config/local-directory/MainController.js
@@ -189,6 +189,29 @@ Ext.define('Ung.config.local-directory.MainController', {
         });
     },
 
+    createComputerAccount: function (cmp) {
+        var v = cmp.isXType('button') ? cmp.up('panel') : cmp;
+        var dirtyFields = false;
+
+        Ext.Array.each(v.query('field'), function (field) {
+            if (!field._neverDirty && field._isChanged && !dirtyFields) {
+                dirtyFields = true;
+            }
+        });
+
+        if (dirtyFields) {
+            Ext.MessageBox.alert('Unsaved Changes'.t(), 'The settings must be saved before the computer account can be created.'.t());
+            return;
+        }
+
+        v.setLoading(true);
+        Rpc.asyncData('rpc.UvmContext.localDirectory.addRadiusComputerAccount')
+        .then(function(result){
+            v.setLoading(false);
+            Ext.MessageBox.alert({ buttons: Ext.Msg.OK, maxWidth: 1024, title: 'Account Creation Status'.t(), msg: '<tt>' + result.output + '</tt>' });
+        });
+    },
+
     testRadiusProxyLogin: function (cmp) {
         var v = cmp.isXType('button') ? cmp.up('panel') : cmp;
         var testuser = v.down("[fieldIndex='testUsername']").getValue();
@@ -235,16 +258,16 @@ Ext.define('Ung.config.local-directory.MainController', {
     radiusProxyDirtyFieldsHandler: function(field, newVal, oldVal) {
         var me = this;
 
-        //The first change occurs always when the value is binded, so set it to that value 
+        //The first change occurs always when the value is binded, so set it to that value
         // so original value is correct
         if (field._onFirstChange) {
             field.originalValue = newVal;
-        } 
+        }
         // Determine if any field is empty
         var emptyOrDirtyFields = me.checkDirtyOrEmpty(field);
 
         //If the checkbox is false, fields are empty, or a non-checkbox is dirty, disable fields
-        if (!newVal                                         || 
+        if (!newVal                                         ||
             emptyOrDirtyFields                              ||
             (field.xtype === 'checkbox' && !newVal)         ||
             (field.xtype !== 'checkbox' && field.isDirty()) ||

--- a/uvm/servlets/admin/config/local-directory/view/RadiusProxy.js
+++ b/uvm/servlets/admin/config/local-directory/view/RadiusProxy.js
@@ -168,6 +168,12 @@ Ext.define('Ung.config.local-directory.view.RadiusProxy', {
             target: 'radiusProxyStatus',
             handler: 'refreshRadiusProxyStatus'
         }, {
+            xtype: 'button',
+            iconCls: 'fa fa-link',
+            text: 'Create AD Computer Account',
+            margin: '10, 10',
+            handler: 'createComputerAccount'
+        }, {
             xtype: 'textarea',
             labelWidth: 120,
             width: '100%',


### PR DESCRIPTION
The UI throws a bunch of exceptions and failure messages generated from exec'ing the create computer account command when called in the setSettings function. This happens when testing on a clean and never before configured system (ie: all settings wiped). Maybe a timing thing between the saving of the files, and restarting the external daemons? Not sure but I couldn't figure it out so I restored the UI button for manually creating the computer account and commented the auto create logic as a quick fix until we can do more analysis.