### PR TITLE
Force Uppercase on Radius Proxy AD Workgroup text field

### DIFF
--- a/uvm/servlets/admin/config/local-directory/view/RadiusProxy.js
+++ b/uvm/servlets/admin/config/local-directory/view/RadiusProxy.js
@@ -48,6 +48,7 @@ Ext.define('Ung.config.local-directory.view.RadiusProxy', {
             fieldLabel: 'AD Workgroup'.t(),
             labelWidth: 120,
             width: '100%',
+            fieldStyle: 'text-transform:uppercase',
             allowBlank: false,
             _onFirstChange: true,
             bind: {


### PR DESCRIPTION
Remove the need to have "important" text in the wiki that you need to have the AD Workgroup UpperCase.

https://wiki.untangle.com/index.php/RADIUS_Proxy