### PR TITLE
Add logic to stop reporting when disk nearly full

### DIFF
--- a/docs/EventsDescriptionExtensionImpl.java
+++ b/docs/EventsDescriptionExtensionImpl.java
@@ -51,9 +51,9 @@ public class ExtensionImpl implements Runnable
         classDescriptions.put("QuotaEvent","These events are created by the [[Bandwidth Control]] and inserted or update the [[Database_Schema#quotas|quotas]] table when quotas are given or exceeded.");
         classDescriptions.put("PrioritizeEvent","These events are created by the [[Bandwidth Control]] and update the [[Database_Schema#sessions|session]] table when a session is prioritized.");
         classDescriptions.put("SettingsChangesEvent","These events are created by the base system and inserted to the [[Database_Schema#settings_changes|settings_changes]] table when settings are changed.");
+        classDescriptions.put("CriticalAlertEvent","These events are created by the base system and inserted to the [[Database_Schema#critical_alerts|critical_alerts]] table to record critical system alerts.");
         classDescriptions.put("LogEvent","These base class for all events.");
-        classDescriptions.put("InterfaceStatEvent","These events are created by the base system and inserted to the [[Database_Schema#settings_changes|interface_stat_events]] table periodically with interface stats.");
-        classDescriptions.put("StatisticEvent","These events are created by the base system and inserted to the the [[Database_Schema#settings_changes|interface_stat_events]] table periodically with interface stats.");
+        classDescriptions.put("InterfaceStatEvent","These events are created by the base system and inserted to the [[Database_Schema#interface_stat_events|interface_stat_events]] table periodically with interface stats.");
         classDescriptions.put("SystemStatEvent","These events are created by the base system and inserted to the [[Database_Schema#server_events|server_events]] table periodically.");
         classDescriptions.put("TunnelStatusEvent","These events are created by [[IPsec VPN]] and inserted to the [[Database_Schema#ipsec_tunnel_stats|ipsec_tunnel_stats]] table periodically.");
         classDescriptions.put("IpsecVpnEvent","These events are created by [[IPsec VPN]] and inserted to the [[Database_Schema#ipsec_vpn_events|ipsec_vpn_events]] table when an IPsec connection event occurs.");

--- a/docs/EventsDocumentationExtensionImpl.java
+++ b/docs/EventsDocumentationExtensionImpl.java
@@ -49,9 +49,9 @@ public class ExtensionImpl implements Runnable
         classDescriptions.put("QuotaEvent","These events are created by the [[Bandwidth Control]] and inserted or update the [[Database_Schema#quotas|quotas]] table when quotas are given or exceeded.");
         classDescriptions.put("PrioritizeEvent","These events are created by the [[Bandwidth Control]] and update the [[Database_Schema#sessions|session]] table when a session is prioritized.");
         classDescriptions.put("SettingsChangesEvent","These events are created by the base system and inserted to the [[Database_Schema#settings_changes|settings_changes]] table when settings are changed.");
+        classDescriptions.put("CriticalAlertEvent","These events are created by the base system and inserted to the [[Database_Schema#critical_alerts|critical_alerts]] table to record critical system alerts.");
         classDescriptions.put("LogEvent","These base class for all events.");
-        classDescriptions.put("InterfaceStatEvent","These events are created by the base system and inserted to the [[Database_Schema#settings_changes|interface_stat_events]] table periodically with interface stats.");
-        classDescriptions.put("StatisticEvent","These events are created by the base system and inserted to the the [[Database_Schema#settings_changes|interface_stat_events]] table periodically with interface stats.");
+        classDescriptions.put("InterfaceStatEvent","These events are created by the base system and inserted to the [[Database_Schema#interface_stat_events|interface_stat_events]] table periodically with interface stats.");
         classDescriptions.put("SystemStatEvent","These events are created by the base system and inserted to the [[Database_Schema#server_events|server_events]] table periodically.");
         classDescriptions.put("TunnelStatusEvent","These events are created by [[IPsec VPN]] and inserted to the [[Database_Schema#ipsec_tunnel_stats|ipsec_tunnel_stats]] table periodically.");
         classDescriptions.put("IpsecVpnEvent","These events are created by [[IPsec VPN]] and inserted to the [[Database_Schema#ipsec_vpn_events|ipsec_vpn_events]] table when IPsec connection event occurs.");

--- a/docs/reports-generate-docs-db-schema.py
+++ b/docs/reports-generate-docs-db-schema.py
@@ -148,6 +148,9 @@ human_names = {
 'server_longitude': 'Server Longitude',
 'session_id': 'Session ID',
 'settings_file': 'Settings File',
+'component': 'System Component Name',
+'message': 'Critical Alert Message',
+'problem': 'Critical Alert Problem',
 'sig_id': 'Signature ID',
 'size': 'Size',
 'source_addr': 'Source Address',
@@ -186,6 +189,7 @@ human_names = {
 'threat_prevention_server_categories': 'Threat Prevention ' + 'Server Categories',
 'tunnel_description': 'Tunnel Description',
 'tunnel_name': 'Tunnel Name',
+'peer_address' : 'The IP address of the tunnel peer',
 'tx_bytes': 'Bytes Sent',
 'tx_rate': 'Tx Rate',
 'type': 'Type',
@@ -456,9 +460,14 @@ dict['http_events'].update({
     'web_filter_flagged' : 'If Web Filter flagged this request',
     'threat_prevention_blocked' : 'If Threat Prevention blocked this request',
     'threat_prevention_flagged' : 'If Threat Prevention flagged this request',
+    'threat_prevention_reason'  : 'The reason Threat Prevention blocked this requiest',
     'threat_prevention_rule_id' : 'This numeric rule according to Threat Prevention',
     'threat_prevention_reputation' : 'This numeric threat reputation',
     'threat_prevention_categories' : 'This bitmask of threat categories',
+    'threat_prevention_client_reputation': 'The numeric client reputation',
+    'threat_prevention_client_categories': 'The client categories',
+    'threat_prevention_server_reputation': 'The numeric server reputation',
+    'threat_prevention_server_categories': 'The server categories'
 })
 
 dict['http_query_events'] = copy.deepcopy(generic)
@@ -643,6 +652,14 @@ dict['settings_changes'].update({
     'settings_file' : 'The name of the file changed',
     'username' : 'The username logged in at the time of the change',
     'hostname' : 'The remote hostname',
+})
+
+dict['critical_alerts'] = copy.deepcopy(generic)
+dict['critical_alerts'].update({
+    'table_description' : 'This table stores critical system alert events.',
+    'component' : 'The name of the component that generated the alert',
+    'message'   : 'The alert message',
+    'problem'   : 'Additional information about the alert',
 })
 
 dict['interface_stat_events'] = copy.deepcopy(generic)

--- a/reports/hier/usr/lib/python2.7/dist-packages/reports/untangle_vm.py
+++ b/reports/hier/usr/lib/python2.7/dist-packages/reports/untangle_vm.py
@@ -11,6 +11,7 @@ def generate_tables():
     __create_user_table_updates_table()
     __create_alerts_events_table()
     __create_settings_changes_table()
+    __create_critical_alerts_table()
     # 13.0 conversion
     if sql_helper.table_exists( "penaltybox" ):
         sql_helper.drop_table("penaltybox") 
@@ -220,6 +221,15 @@ CREATE TABLE reports.settings_changes (
         settings_file text NOT NULL,
         username text NOT NULL,
         hostname text NOT NULL)""")
+
+@sql_helper.print_timing
+def __create_critical_alerts_table(  ):
+    sql_helper.create_table("""\
+CREATE TABLE reports.critical_alerts (
+        time_stamp timestamp NOT NULL,
+        component text NOT NULL,
+        message text NOT NULL,
+        problem text NOT NULL)""")
 
 @sql_helper.print_timing
 def __create_quotas_table(  ):

--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -427,6 +427,17 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
         return ReportsApp.eventWriter.getWriteDelaySec();
     }
 
+    /**
+     * Return the disk full flag
+     * @return
+     *  Boolean value the indicates if event processing is suspended
+     *  due to low disk space.
+     */
+    public boolean getDiskFullFlag()
+    {
+        return ReportsApp.eventWriter.getDiskFullFlag();
+    }
+
     /** 
      * Return email addresses with alert permission.
      *

--- a/uvm/api/com/untangle/uvm/CriticalAlertEvent.java
+++ b/uvm/api/com/untangle/uvm/CriticalAlertEvent.java
@@ -7,7 +7,7 @@ import com.untangle.uvm.logging.LogEvent;
 
 /**
  * Critical alert event. Originally created to manage the alert we generate
- * when we transition to/from discard mode for logger events when the amout
+ * when we transition to/from discard mode for logger events when the amount
  * of free disk space gets too low.
  */
 @SuppressWarnings("serial")

--- a/uvm/api/com/untangle/uvm/CriticalAlertEvent.java
+++ b/uvm/api/com/untangle/uvm/CriticalAlertEvent.java
@@ -1,0 +1,68 @@
+/**
+ * $Id: CriticalAlertEvent.java $
+ */
+package com.untangle.uvm;
+
+import com.untangle.uvm.logging.LogEvent;
+
+/**
+ * Critical alert event. Originally created to manage the alert we generate
+ * when we transition to/from discard mode for logger events when the amout
+ * of free disk space gets too low.
+ */
+@SuppressWarnings("serial")
+public class CriticalAlertEvent extends LogEvent
+{
+    private String component = "component";
+    private String message = "message";
+    private String problem = "problem";
+
+    public CriticalAlertEvent( String argComponent, String argMessage, String argProblem )
+    {
+        if( argComponent != null ){
+            this.component = argComponent;
+        }
+        if( argMessage != null ){
+            this.message = argMessage;
+        }
+        if( argProblem != null){
+            this.problem = argProblem;
+        }
+    }
+
+    public String getComponent() { return this.component; }
+    public void setComponent(String newValue ) { this.component = newValue; }
+
+    public String getMessage() { return this.message; }
+    public void setMessage( String newValue ) { this.message = newValue; }
+
+    public String getProblem() { return this.problem; }
+    public void getProblem( String newValue ) { this.problem = newValue; }
+
+    @Override
+    public void compileStatements( java.sql.Connection conn, java.util.Map<String,java.sql.PreparedStatement> statementCache ) throws Exception
+    {
+        String sql = "INSERT INTO " + schemaPrefix() + "critical_alerts" + getPartitionTablePostfix() + " " +
+            "( time_stamp, component, message, problem)" +
+            " values " +
+            "( ?, ?, ?, ?); ";
+
+        java.sql.PreparedStatement pstmt = getStatementFromCache( sql, statementCache, conn );        
+
+        int i=0;
+        pstmt.setTimestamp(++i, getSqlTimeStamp());
+        pstmt.setString(++i, this.component);
+        pstmt.setString(++i, this.message);
+        pstmt.setString(++i, this.problem);
+
+        pstmt.addBatch();
+        return;
+    }
+
+    @Override
+    public String toSummaryString()
+    {
+        String summary = "CriticalAlertEvent" + " " + this.component + "/" + this.message;
+        return summary;
+    }
+}

--- a/uvm/api/com/untangle/uvm/app/Reporting.java
+++ b/uvm/api/com/untangle/uvm/app/Reporting.java
@@ -17,5 +17,7 @@ public interface Reporting
 
     long getWriteDelaySec();
 
+    boolean getDiskFullFlag();
+
     List<String> getAlertEmailAddresses();
 }

--- a/uvm/hier/usr/share/untangle/lib/untangle-vm/events/classFields.json
+++ b/uvm/hier/usr/share/untangle/lib/untangle-vm/events/classFields.json
@@ -1342,7 +1342,7 @@
     ]
     },
     InterfaceStatEvent: {
-    description: "These events are created by the base system and inserted to the [[Database_Schema#settings_changes|interface_stat_events]] table periodically with interface stats.",
+    description: "These events are created by the base system and inserted to the [[Database_Schema#interface_stat_events|interface_stat_events]] table periodically with interface stats.",
     fields: [
         {
         name: "class",
@@ -1628,6 +1628,36 @@
         name: "username",
         type: "String",
         description: "The username",
+        },
+    ]
+    },
+    CriticalAlertEvent: {
+    description: "These events are created by the base system and inserted to the [[Database_Schema#critical_alerts|critical_alerts]] table to record critical system alerts.",
+    fields: [
+        {
+        name: "class",
+        type: "Class",
+        description: "The class name",
+        },
+        {
+        name: "component",
+        type: "String",
+        description: "The name of the component that generated the alert",
+        },
+        {
+        name: "message",
+        type: "String",
+        description: "The alert message",
+        },
+        {
+        name: "timeStamp",
+        type: "Timestamp",
+        description: "The timestamp",
+        },
+        {
+        name: "problem",
+        type: "String",
+        description: "Additional information about the alert",
         },
     ]
     },

--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -430,6 +430,38 @@ public class EventManagerImpl implements EventManager
             this.setSettings( settings );
         }
 
+        boolean criticalFlag = false;
+        boolean reportsFlag = false;
+
+        // search for the CriticalAlertEvent REPORTS rule
+        for (EventRule er : settings.getAlertRules()) {
+            for(EventRuleCondition c : er.getConditions()) {
+                if(c.getField().equals("class") && c.getFieldValue().equals("*CriticalAlertEvent*")){
+                    criticalFlag = true;
+                }
+                if(c.getField().equals("component") && c.getFieldValue().equals("REPORTS")){
+                    reportsFlag = true;
+                }
+            }
+        }
+
+        // if we didn't find the CriticalAlertEvent REPORTS rule create at top
+        if ((!criticalFlag) || (!reportsFlag)) {
+            LinkedList<EventRuleCondition> conditions;
+            EventRuleCondition condition1;
+            EventRuleCondition condition2;
+            AlertRule eventRule;
+
+            conditions = new LinkedList<>();
+            condition1 = new EventRuleCondition( "class", "=", "*CriticalAlertEvent*" );
+            conditions.add( condition1 );
+            condition2 = new EventRuleCondition( "component", "=", "REPORTS" );
+            conditions.add( condition2 );
+            eventRule = new AlertRule( true, conditions, true, true, "Reporting disabled due to low disk space", false, 0 );
+            settings.getAlertRules().addFirst( eventRule );
+
+            this.setSettings( settings );
+        }
     }
 
     /**
@@ -460,6 +492,14 @@ public class EventManagerImpl implements EventManager
         EventRuleCondition condition2;
         EventRuleCondition condition3;
         AlertRule eventRule;
+
+        conditions = new LinkedList<>();
+        condition1 = new EventRuleCondition( "class", "=", "*CriticalAlertEvent*" );
+        conditions.add( condition1 );
+        condition2 = new EventRuleCondition( "component", "=", "REPORTS" );
+        conditions.add( condition2 );
+        eventRule = new AlertRule( true, conditions, true, true, "Reporting disabled due to low disk space", false, 0 );
+        rules.add( eventRule );
 
         conditions = new LinkedList<>();
         condition1 = new EventRuleCondition( "class", "=", "*WanFailoverEvent*" );

--- a/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
@@ -819,7 +819,7 @@ public class NotificationManagerImpl implements NotificationManager
         boolean fullFlag = reports.getDiskFullFlag();
         if (fullFlag) {
             String notificationText = "";
-            notificationText += i18nUtil.tr("Reports event processing disabled due to low disk space.");
+            notificationText += i18nUtil.tr("Reports event processing disabled due to low disk space. <a href='/admin/index.do#service/reports/data'>Manage reports data here</a>");
             notificationList.add(notificationText);
         }
     }

--- a/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
@@ -157,6 +157,11 @@ public class NotificationManagerImpl implements NotificationManager
             logger.warn("Notification test exception", e);
         }
         try {
+            testReportingDiskSpace(notificationList);
+        } catch (Exception e) {
+            logger.warn("Notification test exception", e);
+        }
+        try {
             testShieldEnabled(notificationList);
         } catch (Exception e) {
             logger.warn("Notification test exception", e);
@@ -796,6 +801,25 @@ public class NotificationManagerImpl implements NotificationManager
             notificationText += String.format("%.1f", (((float) delay) / 60.0)) + " minute delay";
             notificationText += "). ";
 
+            notificationList.add(notificationText);
+        }
+    }
+
+    /**
+     * This test that event writing is not disabled due to low disk space
+     *
+     * @param notificationList - the current list of notifications
+     */
+    private void testReportingDiskSpace(List<String> notificationList)
+    {
+        Reporting reports = (Reporting) UvmContextFactory.context().appManager().app("reports");
+        /* if reports not installed - no events - just return */
+        if (reports == null) return;
+
+        boolean fullFlag = reports.getDiskFullFlag();
+        if (fullFlag) {
+            String notificationText = "";
+            notificationText += i18nUtil.tr("Reports event processing disabled due to low disk space.");
             notificationList.add(notificationText);
         }
     }

--- a/uvm/js/common/util/_Map.js
+++ b/uvm/js/common/util/_Map.js
@@ -423,6 +423,18 @@ Ext.define('Ung.util.Map', {
             col: { text: 'Protocol'.t(), filter: Rndr.filters.numeric, width: 80 },
             fld: { type: 'integer', convert: Converter.protocol }
         },
+        component: {
+            col: { text: 'Component'.t(), width: 100 },
+            fld: { type: 'string' }
+        },
+        message: {
+            col: { text: 'Message'.t(), width: 200 },
+            fld: { type: 'string' }
+        },
+        problem: {
+            col: { text: 'Problem'.t(), width: 200 },
+            fld: { type: 'string' }
+        },
         reason: {
             col: { text: 'Reason'.t(), width: 200 },
             fld: { type: 'string' }
@@ -1211,6 +1223,12 @@ Ext.define('Ung.util.Map', {
             'username',
             'hostname',
             'differences' // custom non sql table field
+        ],
+        critical_alerts: [
+            'time_stamp',
+            'component',
+            'message',
+            'problem'
         ],
         smtp_tarpit_events: [
             'time_stamp',


### PR DESCRIPTION
Added logic to stop capturing reporting data when free disk space falls below 5GB to preserve system function and stability. When the condition is triggered, an alert will be displayed in the user interface and will be generated and sent via the standard alert email mechanism. When free disk space is no longer below the threshold, capture of reporting data will resume, the user interface alert will be cleared, and a "service restored" alert will be generated.
