### PR TITLE
Fix truncation of radius usernames

### DIFF
--- a/uvm/api/com/untangle/uvm/HostTableEntry.java
+++ b/uvm/api/com/untangle/uvm/HostTableEntry.java
@@ -87,7 +87,7 @@ public class HostTableEntry implements Serializable, JSONString
         this.setCaptivePortalAuthenticated( other.getCaptivePortalAuthenticated() );
         this.setUsernameIpsecVpn( other.getUsernameIpsecVpn() );
         this.setUsernameOpenVpn( other.getUsernameOpenVpn() );
-        this.setusernameRadius( other.getUsernameRadius());
+        this.setUsernameRadius( other.getUsernameRadius());
         this.setQuotaSize( other.getQuotaSize() );
         this.setQuotaRemaining( other.getQuotaRemaining() );
         this.setQuotaIssueTime( other.getQuotaIssueTime() );
@@ -299,7 +299,7 @@ public class HostTableEntry implements Serializable, JSONString
     }
 
     public String getUsernameRadius() { return this.usernameRadius; }
-    public void setusernameRadius( String newValue)
+    public void setUsernameRadius( String newValue )
     {
         newValue = (newValue == null ? null : newValue.toLowerCase());
 

--- a/uvm/api/com/untangle/uvm/LocalDirectory.java
+++ b/uvm/api/com/untangle/uvm/LocalDirectory.java
@@ -68,12 +68,6 @@ public interface LocalDirectory
     public String getRadiusProxyStatus();
 
     /**
-     * Get Radius users
-     * @return Map of IP to username
-     */
-    public Map<String, String> getRadiusUsers();
-
-    /**
      * Adds computer account to the Active Directory domain controller
      */
     public ExecManagerResult addRadiusComputerAccount();

--- a/uvm/hier/usr/share/untangle/bin/ut-radwho.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-radwho.sh
@@ -1,3 +1,18 @@
 #!/bin/bash
 
-/bin/radwho | awk 'NR >1 {print $NF, $1 }' 2> /dev/null
+if [[ -x "/usr/bin/radwho" ]]
+then
+    CMDFILE="/usr/bin/radwho"
+fi
+
+if [[ -x "/bin/radwho" ]]
+then
+    CMDFILE="/bin/radwho"
+fi
+
+if [[ "$CMDFILE" == "" ]]
+then
+    exit 1
+fi
+
+$CMDFILE -r | awk -F',' '{ print $1, $7 }' 2> /dev/null

--- a/uvm/impl/com/untangle/uvm/HostTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/HostTableImpl.java
@@ -986,8 +986,6 @@ public class HostTableImpl implements HostTable
                 }
                 logger.info("HostTableReverseHostnameLookup: Running... ");
 
-                Map<String, String>radusers = UvmContextFactory.context().localDirectory().getRadiusUsers();
-                
                 try {
                     LinkedList<HostTableEntry> entries = new LinkedList<>(hostTable.values());
                     for (HostTableEntry entry : entries) {
@@ -995,7 +993,6 @@ public class HostTableImpl implements HostTable
                         String currentHostname = entry.getHostname();
                         InetAddress address = entry.getAddress();
 
-                        entry.setusernameRadius(radusers.get(address.getHostAddress()));
                         syncWithDeviceEntry(entry, address);
                         
                         if (address == null) {


### PR DESCRIPTION
I modified the ut-radwho script to get the full username. I also added logic to look for the radwho binary in both /usr/bin and /bin since it seems to be in the former on my dev machine. Did some additional work to improve the reliability of the radius user name scanning and updating logic. Details are in NGFW-13566
