### PR TITLE
Rework the getAvailableAddressSpace function

### DIFF
--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
@@ -174,8 +174,8 @@ public class IpsecVpnApp extends AppBase
         tmp.setLeft(firstWan.getHostAddress());
         tmp.setRight(exampleAddress.getHostAddress());
 
-        tmp.setLeftSubnet(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0, 24).toString());
-        tmp.setRightSubnet(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0, 24).toString());
+        tmp.setLeftSubnet(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0).toString());
+        tmp.setRightSubnet(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0).toString());
 
         tunnelList.add(tmp);
 
@@ -189,15 +189,15 @@ public class IpsecVpnApp extends AppBase
         tmp.setLeft(firstWan.getHostAddress());
         tmp.setRight(exampleAddress.getHostAddress());
 
-        tmp.setLeftSubnet(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0, 24).toString());
-        tmp.setRightSubnet(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0, 24).toString());
+        tmp.setLeftSubnet(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0).toString());
+        tmp.setRightSubnet(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0).toString());
 
         tunnelList.add(tmp);
 
         //Setup default GRE/Xauth/L2TP addresses:
-        settings.setVirtualNetworkPool(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0, 24).toString());
-        settings.setVirtualAddressPool(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0, 24).toString());
-        settings.setVirtualXauthPool(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0, 24).toString());
+        settings.setVirtualNetworkPool(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0).toString());
+        settings.setVirtualAddressPool(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0).toString());
+        settings.setVirtualXauthPool(nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0).toString());
 
         settings.setTunnels(tunnelList);
         setSettings(settings);

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
@@ -748,7 +748,7 @@ public class OpenVpnAppImpl extends AppBase
 
         NetspaceManager nsmgr = UvmContextFactory.context().netspaceManager();
 
-        IPMaskedAddress newAddrPool = nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0, 24);
+        IPMaskedAddress newAddrPool = nsmgr.getAvailableAddressSpace(IPVersion.IPv4, 0);
 
         newSettings.setAddressSpace(newAddrPool);
 

--- a/uvm/api/com/untangle/uvm/NetspaceManager.java
+++ b/uvm/api/com/untangle/uvm/NetspaceManager.java
@@ -25,7 +25,7 @@ public interface NetspaceManager
 
     NetworkSpace isNetworkAvailable(String ownerName, IPMaskedAddress tester);
 
-    IPMaskedAddress getAvailableAddressSpace(IPVersion version, int hostId, int networkSize);
+    IPMaskedAddress getAvailableAddressSpace(IPVersion version, int hostId);
     
     InetAddress getFirstUsableAddress(InetAddress networkAddress, Integer networkSize);
 

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
@@ -391,7 +391,7 @@ public class WireGuardVpnApp extends AppBase
 
         settings.setNetworks(buildNetworkList(lanStatuses));
 
-        IPMaskedAddress newSpace = UvmContextFactory.context().netspaceManager().getAvailableAddressSpace(IPVersion.IPv4, 1, 24);
+        IPMaskedAddress newSpace = UvmContextFactory.context().netspaceManager().getAvailableAddressSpace(IPVersion.IPv4, 1);
 
         settings.setAutoAddressAssignment(true);
         settings.setAddressPool(newSpace);
@@ -432,7 +432,7 @@ public class WireGuardVpnApp extends AppBase
      */
     public String getNewAddressPool()
     {
-        IPMaskedAddress newSpace = UvmContextFactory.context().netspaceManager().getAvailableAddressSpace(IPVersion.IPv4, 1, 24);
+        IPMaskedAddress newSpace = UvmContextFactory.context().netspaceManager().getAvailableAddressSpace(IPVersion.IPv4, 1);
         return newSpace.toString();
     }
 


### PR DESCRIPTION
Our previous implementation could fail and return a problematic default in some cases, particularly if the entire 10.0.0.0/8 network was already consumed such as when assigned to the LAN device. I replaced the random generation approach we used for IPv4 with a more structured mechanism that works through all of the RFC1918 reserved space in sequence. I also simplified things so we'll always use /24's as the auto-generated defaults since there isn't any reason or facility provided to automatically request a network of arbitrary size. This new method also handles a very rare edge case where an app might request multiple blocks before the settings are saved, which is when assigned networks are registered. Since we now try them in order, there is no chance we'll randomly generate the same network twice in a row.
