### PR TITLE
Fix RADIUS rule upgrade on older installations

### DIFF
--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -918,15 +918,15 @@ public class NetworkManagerImpl implements NetworkManager
         for( FilterRule rule : accessRules ) {
             int pos = 1;
             // look for the rule where we want to insert the RADIUS rules
-            if (rule.getReadOnly() && ("Allow HTTPS on non-WANs".equals(rule.getDescription()))) {
+            if (rule.getDescription() != null && ("Allow HTTPS on non-WANs".equals(rule.getDescription()))) {
                 addLocation = pos;
             }
             // see if the LAN rule already exists
-            if (rule.getReadOnly() && ("Allow RADIUS on non-WANs".equals(rule.getDescription()))) {
+            if (rule.getDescription() != null && ("Allow RADIUS on non-WANs".equals(rule.getDescription()))) {
                 lanLocation = pos;
             }
             // see if the WAN rule already exists
-            if (rule.getReadOnly() && ("Allow RADIUS on WANs".equals(rule.getDescription()))) {
+            if (rule.getDescription() != null && ("Allow RADIUS on WANs".equals(rule.getDescription()))) {
                 wanLocation = pos;
             }
             pos++;


### PR DESCRIPTION
Older systems may not have a readOnly boolean on access rules which can cause a null pointer exception when trying to add the new RADIUS rules. Fixed by not using the readOnly flag.
