### PR TITLE
Add logic to install recommended apps by default

### DIFF
--- a/application-control/hier/usr/share/untangle/lib/application-control/appProperties.json
+++ b/application-control/hier/usr/share/untangle/lib/application-control/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Application Control",
         "type" : "FILTER",
         "viewPosition" : 99,
+        "autoInstall" : true,
         "autoStart" : true,
         "parents" : {
             "javaClass": "java.util.LinkedList",

--- a/bandwidth-control/hier/usr/share/untangle/lib/bandwidth-control/appProperties.json
+++ b/bandwidth-control/hier/usr/share/untangle/lib/bandwidth-control/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Bandwidth Control",
         "type" : "FILTER",
         "viewPosition" : 90,
+        "autoInstall" : true,
         "autoStart" : false,
         "parents" : {
             "javaClass": "java.util.LinkedList",

--- a/branding-manager/hier/usr/share/untangle/lib/branding-manager/appProperties.json
+++ b/branding-manager/hier/usr/share/untangle/lib/branding-manager/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Branding Manager",
         "type" : "SERVICE",
         "viewPosition" : 1130,
+        "autoInstall" : true,
         "hasPowerButton" : false,
         "parents" : {
             "javaClass": "java.util.LinkedList",

--- a/captive-portal/hier/usr/share/untangle/lib/captive-portal/appProperties.json
+++ b/captive-portal/hier/usr/share/untangle/lib/captive-portal/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Captive Portal",
         "type" : "FILTER",
         "viewPosition" : 105,
+        "autoInstall" : true,
         "autoStart" : true,
         "parents" : {
             "javaClass": "java.util.LinkedList",

--- a/configuration-backup/hier/usr/share/untangle/lib/configuration-backup/appProperties.json
+++ b/configuration-backup/hier/usr/share/untangle/lib/configuration-backup/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Configuration Backup",
         "type" : "SERVICE",
         "viewPosition" : 1120,
+        "autoInstall" : true,
         "parents" : {
             "javaClass": "java.util.LinkedList",
             "list": [

--- a/directory-connector/hier/usr/share/untangle/lib/directory-connector/appProperties.json
+++ b/directory-connector/hier/usr/share/untangle/lib/directory-connector/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Directory Connector",
         "type" : "SERVICE",
         "viewPosition" : 1030,
+        "autoInstall" : true,
         "hasPowerButton" : false,
         "parents" : {
             "javaClass": "java.util.LinkedList",

--- a/firewall/hier/usr/share/untangle/lib/firewall/appProperties.json
+++ b/firewall/hier/usr/share/untangle/lib/firewall/appProperties.json
@@ -4,6 +4,7 @@
         "name" : "firewall",
         "displayName" : "Firewall",
         "type" : "FILTER",
-        "viewPosition" : 110
+        "viewPosition" : 110,
+        "autoInstall" : true
 }
 

--- a/ipsec-vpn/hier/usr/share/untangle/lib/ipsec-vpn/appProperties.json
+++ b/ipsec-vpn/hier/usr/share/untangle/lib/ipsec-vpn/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "IPsec VPN",
         "type" : "SERVICE",
         "viewPosition" : 1070,
+        "autoInstall" : true,
         "parents" : {
             "javaClass": "java.util.LinkedList",
             "list": [

--- a/live-support/hier/usr/share/untangle/lib/live-support/appProperties.json
+++ b/live-support/hier/usr/share/untangle/lib/live-support/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Live Support",
         "type" : "SERVICE",
         "viewPosition" : 1140,
+        "autoInstall" : true,
         "hasPowerButton" : false,
         "parents" : {
             "javaClass": "java.util.LinkedList",

--- a/openvpn/hier/usr/share/untangle/lib/openvpn/appProperties.json
+++ b/openvpn/hier/usr/share/untangle/lib/openvpn/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "OpenVPN",
         "type" : "SERVICE",
         "viewPosition" : 1080,
+        "autoInstall" : true,
         "autoStart" : "false"
 }
 

--- a/policy-manager/hier/usr/share/untangle/lib/policy-manager/appProperties.json
+++ b/policy-manager/hier/usr/share/untangle/lib/policy-manager/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Policy Manager",
         "type" : "SERVICE",
         "viewPosition" : 1020,
+        "autoInstall" : true,
         "hasPowerButton" : false,
         "parents" : {
             "javaClass": "java.util.LinkedList",

--- a/reports/hier/usr/share/untangle/lib/reports/appProperties.json
+++ b/reports/hier/usr/share/untangle/lib/reports/appProperties.json
@@ -4,6 +4,7 @@
         "name" : "reports",
         "displayName" : "Reports",
         "type" : "SERVICE",
-        "viewPosition" : 1010
+        "viewPosition" : 1010,
+        "autoInstall" : true
 }
 

--- a/ssl-inspector/hier/usr/share/untangle/lib/ssl-inspector/appProperties.json
+++ b/ssl-inspector/hier/usr/share/untangle/lib/ssl-inspector/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "SSL Inspector",
         "type" : "FILTER",
         "viewPosition" : 98,
+        "autoInstall" : true,
         "autoStart" : false,
         "parents" : {
             "javaClass": "java.util.LinkedList",

--- a/threat-prevention/hier/usr/share/untangle/lib/threat-prevention/appProperties.json
+++ b/threat-prevention/hier/usr/share/untangle/lib/threat-prevention/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Threat Prevention",
         "type" : "FILTER",
         "viewPosition" : 111,
+        "autoInstall" : true,
         "parents" : {
                 "javaClass": "java.util.LinkedList",
                 "list": [

--- a/tunnel-vpn/hier/usr/share/untangle/lib/tunnel-vpn/appProperties.json
+++ b/tunnel-vpn/hier/usr/share/untangle/lib/tunnel-vpn/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "Tunnel VPN",
         "type" : "SERVICE",
         "viewPosition" : 1085,
+        "autoInstall" : true,
         "autoStart" : "false"
 }
 

--- a/uvm/api/com/untangle/uvm/app/AppProperties.java
+++ b/uvm/api/com/untangle/uvm/app/AppProperties.java
@@ -31,6 +31,7 @@ public class AppProperties implements Serializable, JSONString, Comparable<AppPr
     private Type type;
     
     private boolean hasPowerButton = true;
+    private boolean autoInstall = false;
     private boolean autoStart = true;
     private boolean autoLoad = false;
     private boolean invisible = false;
@@ -87,7 +88,7 @@ public class AppProperties implements Serializable, JSONString, Comparable<AppPr
     public void setAppBase( String newValue ) { this.appBase = newValue; }
 
     /**
-     * The dawmon is the optional name of an associated daemon.
+     * The daemon is the optional name of an associated daemon.
      */
     public String getDaemon() { return daemon; }
     public void setDaemon( String newValue ) { this.daemon = newValue; }
@@ -109,6 +110,12 @@ public class AppProperties implements Serializable, JSONString, Comparable<AppPr
      */
     public boolean getHasPowerButton() { return hasPowerButton; }
     public void setHasPowerButton( boolean newValue ) { this.hasPowerButton = newValue; }
+
+    /**
+     * True if this app should be installed automatically on first setup
+     */
+    public boolean getAutoInstall() { return autoInstall; }
+    public void setAutoInstall( boolean newValue ) { this.autoInstall = newValue; }
 
     /**
      * True if this app should be started automatically (once loaded).

--- a/virus-blocker/hier/usr/share/untangle/lib/virus-blocker/appProperties.json
+++ b/virus-blocker/hier/usr/share/untangle/lib/virus-blocker/appProperties.json
@@ -5,6 +5,7 @@
         "appBase" : "virus-blocker-base",
         "displayName" : "Virus Blocker",
         "type" : "FILTER",
+        "autoInstall" : true,
         "viewPosition" : 30,
         "parents" : {
             "javaClass": "java.util.LinkedList",

--- a/web-filter/hier/usr/share/untangle/lib/web-filter/appProperties.json
+++ b/web-filter/hier/usr/share/untangle/lib/web-filter/appProperties.json
@@ -6,6 +6,7 @@
         "displayName" : "Web Filter",
         "type" : "FILTER",
         "viewPosition" : 10,
+        "autoInstall" : true,
         "parents" : {
             "javaClass": "java.util.LinkedList",
             "list": [

--- a/wireguard-vpn/hier/usr/share/untangle/lib/wireguard-vpn/appProperties.json
+++ b/wireguard-vpn/hier/usr/share/untangle/lib/wireguard-vpn/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "WireGuard VPN",
         "type" : "SERVICE",
         "viewPosition" : 1080,
+        "autoInstall" : true,
         "autoStart" : "false",
         "parents" : {
             "javaClass": "java.util.LinkedList",


### PR DESCRIPTION
I added a new autoInstall flag to the AppProperties class. When set to true in the corresponding appProperties.json file, that app will automatically be installed when the uvm launches for the first time and initializes the default app manager settings. The new logic also honors the autoStart flag so apps can be set to auto install in either enabled or disabled mode. I then added autoStart:true to the 18 recommended apps we suggest the user install by default. Note that this logic is NOT triggered when isDevel() returns true to maintain the speed and overall consistency when working in the development environment.
