### PR TITLE
Add missing clean_table call for several apps

### DIFF
--- a/ipsec-vpn/hier/usr/lib/python2.7/dist-packages/reports/ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python2.7/dist-packages/reports/ipsec_vpn.py
@@ -9,6 +9,8 @@ def generate_tables():
 @sql_helper.print_timing
 def cleanup_tables(cutoff):
     sql_helper.clean_table("ipsec_user_events", cutoff)
+    sql_helper.clean_table("ipsec_tunnel_stats", cutoff)
+    sql_helper.clean_table("ipsec_vpn_events", cutoff)
 
 @sql_helper.print_timing
 def __create_ipsec_user_events_table():

--- a/openvpn/hier/usr/lib/python2.7/dist-packages/reports/openvpn.py
+++ b/openvpn/hier/usr/lib/python2.7/dist-packages/reports/openvpn.py
@@ -8,6 +8,7 @@ def generate_tables():
 @sql_helper.print_timing
 def cleanup_tables(cutoff):
     sql_helper.clean_table("openvpn_stats", cutoff)
+    sql_helper.clean_table("openvpn_events", cutoff)
 
 @sql_helper.print_timing
 def __create_openvpn_stats( ):

--- a/tunnel-vpn/hier/usr/lib/python2.7/dist-packages/reports/tunnel_vpn.py
+++ b/tunnel-vpn/hier/usr/lib/python2.7/dist-packages/reports/tunnel_vpn.py
@@ -8,6 +8,7 @@ def generate_tables():
 @sql_helper.print_timing
 def cleanup_tables(cutoff):
     sql_helper.clean_table("tunnel_vpn_events", cutoff)
+    sql_helper.clean_table("tunnel_vpn_stats", cutoff)
 
 @sql_helper.print_timing
 def __create_tunnel_vpn_events_table():

--- a/wireguard-vpn/hier/usr/lib/python2.7/dist-packages/reports/wireguard_vpn.py
+++ b/wireguard-vpn/hier/usr/lib/python2.7/dist-packages/reports/wireguard_vpn.py
@@ -6,6 +6,11 @@ def generate_tables():
     __create_wireguard_vpn_stats_table()
 
 @sql_helper.print_timing
+def cleanup_tables(cutoff):
+    sql_helper.clean_table("wireguard_vpn_events", cutoff)
+    sql_helper.clean_table("wireguard_vpn_stats", cutoff)
+
+@sql_helper.print_timing
 def __create_wireguard_vpn_events_table():
     sql_helper.create_table("""\
 CREATE TABLE reports.wireguard_vpn_events (


### PR DESCRIPTION
In several apps we never added a call to clean_table in the reports python script which allowed the tables to grow perpetually with old data never being pruned.
