### PR TITLE
Remove window prompting to install default apps

### DIFF
--- a/uvm/api/com/untangle/uvm/UvmContext.java
+++ b/uvm/api/com/untangle/uvm/UvmContext.java
@@ -348,6 +348,11 @@ public interface UvmContext
     boolean isDevel();
 
     /**
+     * Return true if running in an automated test environment.
+     */
+    boolean isAts();
+
+    /**
      * Returns true if this is a netbooted install on Untangle internal network
      */
     boolean isNetBoot();


### PR DESCRIPTION
The recommended applications are now installed automatically, so we no longer need to prompt the user. In addition to removing the prompt window, I also fixed the auto install logic so the apps will now be installed after the uvm is fully initialized. This eliminates the uvm startup delay and allows the apps to get the proper trial license automatically. Added a new isAts() function that detects when running on an ATS system, and the auto install is now skipped in both DEV and ATS environments.
