### PR TITLE
Fix null handling in license manager

### DIFF
--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -711,7 +711,7 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                     if(lic.has("end")) {newLic.setEnd(lic.getLong("end"));}
                     if(lic.has("key")) {newLic.setKey(lic.getString("key"));}
                     if(lic.has("keyVersion")) {newLic.setKeyVersion(lic.getInt("keyVersion"));}
-                    if(lic.has("seats")) {newLic.setSeats(lic.getInt("seats"));}
+                    if((lic.has("seats")) && (!lic.isNull("seats"))) {newLic.setSeats(lic.getInt("seats"));}
 
                     licenses.add(newLic);
                 }


### PR DESCRIPTION
The license manager assumed the presence of seats in a license would always be a valid integer. This causes an exception if we find "seats": null in a license file. Added isNull check when attempting to parse the value.
