### PR TITLE
Fix information displayed in the live support app

### DIFF
--- a/live-support/js/view/Status.js
+++ b/live-support/js/view/Status.js
@@ -32,6 +32,7 @@ Ext.define('Ung.apps.livesupport.view.Status', {
             padding: 10,
             margin: '20 0',
             cls: 'app-section',
+            hidden: '{!license || !license.trial}',
             items: [{
                 xtype: 'component',
                 bind: {


### PR DESCRIPTION
The live support app was indicating live support was available even with an expired license. Solved by hiding the Is Entitled message and Get Support button when the license is not valid. I also added logic to the license manager to look for NGFW_LICENSE_TEST in the environment to simplify testing the license stuff on dev systems.
