### PR TITLE
Rework live support message and buttons

### DIFF
--- a/live-support/js/Main.js
+++ b/live-support/js/Main.js
@@ -6,6 +6,7 @@ Ext.define('Ung.apps.livesupport.Main', {
     viewModel: {
         data: {
             companyName: '',
+            companyURL: '',
             serverUID: '',
             fullVersionAndRevision: ''
         }

--- a/live-support/js/MainController.js
+++ b/live-support/js/MainController.js
@@ -18,6 +18,7 @@ Ext.define('Ung.apps.livesupport.MainController', {
         v.setLoading(true);
         Ext.Deferred.sequence([
             Rpc.directPromise('rpc.companyName'),
+            Rpc.directPromise('rpc.companyURL'),
             Rpc.directPromise('rpc.serverUID'),
             Rpc.directPromise('rpc.fullVersionAndRevision')
         ], this)
@@ -27,8 +28,21 @@ Ext.define('Ung.apps.livesupport.MainController', {
             }
             vm.set({
                 companyName: result[0],
-                serverUID: result[1],
-                fullVersionAndRevision: result[2],
+                companyURL: result[1],
+                serverUID: result[2],
+                fullVersionAndRevision: result[3],
+            });
+
+            var paidFrame = v.down('[itemId=paidFrame]');
+            var freeFrame = v.down('[itemId=freeFrame]');
+
+            // get the license and show either the Get Support or Learn More section
+            Rpc.asyncData('rpc.UvmContext.licenseManager.getLicense', 'live-support').then(function(license) {
+                if ((license) && (license.valid)) {
+                    paidFrame.setHidden(false);
+                } else {
+                    freeFrame.setHidden(false);
+                }
             });
 
             v.setLoading(false);
@@ -37,6 +51,17 @@ Ext.define('Ung.apps.livesupport.MainController', {
 
     supportHandler: function(btn){
         this.getView().up('[itemId=main]').getController().supportHandler(btn);
-    }
+    },
 
+    // When the license is not valid we want the Learn More button open the companyURL configured
+    // in the branding manager. If it is not configured or is our Untangle default, we open
+    // our Live-Support app page.
+    learnMoreHandler: function(btn){
+        var target = this.getViewModel().get('companyURL');
+        if ((target) && (target !== '') && (! target.includes('untangle.com'))) {
+            window.open(target);
+        } else {
+            window.open("https://www.untangle.com/shop/Live-Support");
+        }
+    }
 });

--- a/live-support/js/view/Status.js
+++ b/live-support/js/view/Status.js
@@ -29,10 +29,11 @@ Ext.define('Ung.apps.livesupport.view.Status', {
         }, {
             xtype: 'fieldset',
             title: '<i class="fa fa-life-ring"></i> ' + 'Live Support'.t(),
+            itemId: 'paidFrame',
             padding: 10,
             margin: '20 0',
             cls: 'app-section',
-            hidden: '{!license || !license.trial}',
+            hidden: true,
             items: [{
                 xtype: 'component',
                 bind: {
@@ -44,6 +45,26 @@ Ext.define('Ung.apps.livesupport.view.Status', {
                 xtype: 'button',
                 text: 'Get Support!'.t(),
                 handler: 'supportHandler'
+            }]
+        }, {
+            xtype: 'fieldset',
+            title: '<i class="fa fa-life-ring"></i> ' + 'Live Support'.t(),
+            itemId: 'freeFrame',
+            padding: 10,
+            margin: '20 0',
+            cls: 'app-section',
+            hidden: true,
+            items: [{
+                xtype: 'component',
+                bind: {
+                    html: Ext.String.format('This {0} Server is NOT entitled to Live Support.'.t(), Rpc.directData('rpc.companyName'))
+                },
+                html: Ext.String.format('This {0} Server is NOT entitled to Live Support.'.t(), '{companyName}'),
+                margin: '0 0 10 0'
+            }, {
+                xtype: 'button',
+                text: 'Learn More!'.t(),
+                handler: 'learnMoreHandler'
             }]
         }, {
             xtype: 'fieldset',

--- a/uvm/impl/com/untangle/uvm/UvmContextImpl.java
+++ b/uvm/impl/com/untangle/uvm/UvmContextImpl.java
@@ -1244,6 +1244,7 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
             json.put("hostname", this.networkManager().getNetworkSettings().getHostName());
             json.put("networkSettings", this.networkManager().getNetworkSettings());
             json.put("companyName", this.brandingManager().getCompanyName());
+            json.put("companyURL", this.brandingManager().getCompanyUrl());
             
             String serialNumber = this.getServerSerialNumber();
             if(serialNumber == null){


### PR DESCRIPTION
If the live support license is valid, we operate as we always have. A message indicates live support is entitled and the Get Support button will allow submitting a request. If the license is not valid, we display a message indicating live support is NOT entitled and a Learn More button will open the Live-Support app page on the Untangle website.
