### PR TITLE
Ngfw 13696 netgear port status api call

### DIFF
--- a/uvm/api/com/untangle/uvm/ConfigManager.java
+++ b/uvm/api/com/untangle/uvm/ConfigManager.java
@@ -38,7 +38,7 @@ public interface ConfigManager
     Object getSyslogServer();
     Object setSyslogServer(boolean argEnabled, String argHost, int argPort, String argProtocol);
 
-    Object getNetworkPortStats();
+    List<InterfaceMetrics> getNetworkPortStats();
 
     Object getTrafficMetrics();
 

--- a/uvm/api/com/untangle/uvm/InterfaceMetrics.java
+++ b/uvm/api/com/untangle/uvm/InterfaceMetrics.java
@@ -1,0 +1,121 @@
+/**
+ * $Id$
+ */
+package com.untangle.uvm;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+
+import com.untangle.uvm.app.IPMaskedAddress;
+
+import org.json.JSONObject;
+import org.json.JSONString;
+
+/**
+ * This object represents the current metrics of an interface.
+ * This is not a settings object.
+ */
+@SuppressWarnings("serial")
+public class InterfaceMetrics implements Serializable, JSONString
+{
+    private Integer portId;
+
+    private String portName;
+    private String portMac;
+    private String portStatus;
+    private String portDuplex;
+    private Integer portSpeed;
+
+    private Long rxBytes;
+    private Long rxPackets;
+    private Long rxErrors;
+    private Long rxDrop;
+    private Long rxFifo;
+    private Long rxFrame;
+    private Long rxCompressed;
+    private Long rxMulticast;
+
+    private Long txBytes;
+    private Long txPackets;
+    private Long txErrors;
+    private Long txDrop;
+    private Long txFifo;
+    private Long txCollisions;
+    private Long txCarrier;
+    private Long txCompressed;
+
+    public InterfaceMetrics() {}
+
+    public String toJSONString()
+    {
+        JSONObject jO = new JSONObject(this);
+        return jO.toString();
+    }
+
+    public int getPortId( ) { return this.portId; }
+    public void setPortId( int argValue ) { this.portId = argValue; }
+
+    public String getPortName( ) { return this.portName; }
+    public void setPortName( String argValue ) { this.portName = argValue; }
+
+    public String getPortMac( ) { return this.portMac; }
+    public void setPortMac( String argValue ) { this.portMac = argValue; }
+
+    public String getPortStatus( ) { return this.portStatus; }
+    public void setPortStatus( String argValue ) { this.portStatus = argValue; }
+
+    public String getPortDuplex( ) { return this.portDuplex; }
+    public void setPortDuplex( String argValue ) { this.portDuplex = argValue; }
+
+    public int getPortSpeed( ) { return this.portSpeed; }
+    public void setPortSpeed( int argValue ) { this.portSpeed = argValue; }
+
+    public Long getRxBytes( ) { return this.rxBytes; }
+    public void setRxBytes( Long argValue ) { this.rxBytes = argValue; }
+
+    public Long getRxPackets( ) { return this.rxPackets; }
+    public void setRxPackets( Long argValue ) { this.rxPackets = argValue; }
+
+    public Long getRxErrors( ) { return this.rxErrors; }
+    public void setRxErrors( Long argValue ) { this.rxErrors = argValue; }
+
+    public Long getRxDrop( ) { return this.rxDrop; }
+    public void setRxDrop( Long argValue ) { this.rxDrop = argValue; }
+
+    public Long getRxFifo( ) { return this.rxFifo; }
+    public void setRxFifo( Long argValue ) { this.rxFifo = argValue; }
+
+    public Long getRxFrame( ) { return this.rxFrame; }
+    public void setRxFrame( Long argValue ) { this.rxFrame = argValue; }
+
+    public Long getRxCompressed( ) { return this.rxCompressed; }
+    public void setRxCompressed( Long argValue ) { this.rxCompressed = argValue; }
+
+    public Long getRxMulticast( ) { return this.rxMulticast; }
+    public void setRxMulticast( Long argValue ) { this.rxMulticast = argValue; }
+
+
+    public Long getTxBytes( ) { return this.txBytes; }
+    public void setTxBytes( Long argValue ) { this.txBytes = argValue; }
+
+    public Long getTxPackets( ) { return this.txPackets; }
+    public void setTxPackets( Long argValue ) { this.txPackets = argValue; }
+
+    public Long getTxErrors( ) { return this.txErrors; }
+    public void setTxErrors( Long argValue ) { this.txErrors = argValue; }
+
+    public Long getTxDrop( ) { return this.txDrop; }
+    public void setTxDrop( Long argValue ) { this.txDrop = argValue; }
+
+    public Long getTxFifo( ) { return this.txFifo; }
+    public void setTxFifo( Long argValue ) { this.txFifo = argValue; }
+
+    public Long getTxCollisions( ) { return this.txCollisions; }
+    public void setTxCollisions( Long argValue ) { this.txCollisions = argValue; }
+
+    public Long getTxCarrier( ) { return this.txCarrier; }
+    public void setTxCarrier( Long argValue ) { this.txCarrier = argValue; }
+
+    public Long getTxCompressed( ) { return this.txCompressed; }
+    public void setTxCompressed( Long argValue ) { this.txCompressed = argValue; }
+}

--- a/uvm/hier/usr/share/untangle/bin/ut-factory-defaults
+++ b/uvm/hier/usr/share/untangle/bin/ut-factory-defaults
@@ -50,6 +50,11 @@ if [ $? != 101 ] ; then # action is allowed, we're not in a chroot
 fi
 echo "Restoring File System State...done"
 
-systemctl start untangle-vm
+if [ "$1" == "force-reboot" ]
+then
+    shutdown -r now
+else
+    systemctl start untangle-vm
+fi
 
 exit 0

--- a/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
@@ -35,7 +35,6 @@ import org.json.JSONObject;
 public class ConfigManagerImpl implements ConfigManager
 {
     private static final String FACTORY_RESET_SCRIPT = System.getProperty("uvm.bin.dir") + "/ut-factory-defaults";
-    private static final String SYSTEM_REBOOT_COMMAND = "/sbin/shutdown";
 
     private final Logger logger = Logger.getLogger(getClass());
     private final UvmContext context = UvmContextFactory.context();
@@ -259,21 +258,21 @@ public class ConfigManagerImpl implements ConfigManager
      */
     public JSONObject doFactoryReset()
     {
-        context.execManager().exec(FACTORY_RESET_SCRIPT);
-
         new java.util.Timer().schedule(new java.util.TimerTask()
         {
             /**
-             * Execute the reboot command after a short delay
+             * Execute the factory reset after a short delay. The force-reboot
+             * flag tells the script to reboot the system rather than restart
+             * the uvm when the factory reset operation is finished.
              */
             @Override
             public void run()
             {
-                context.execManager().exec(SYSTEM_REBOOT_COMMAND + " -r now");
+                context.execManager().exec(FACTORY_RESET_SCRIPT + " force-reboot");
             }
         }, 5000);
 
-        return createResponse(0, "Factory reset complete. System is restarting.");
+        return createResponse(0, "Factory reset initiated. System is restarting.");
     }
 
     /**


### PR DESCRIPTION
Since this branch still needs to be reviewed and merged, I added the fix for the doFactoryReset API call in this branch. 

The existing ut-factory-defaults script stops and starts the uvm which prevented our API response for the reset command from being sent. It also doesn't make much sense to restart the uvm after restoring factory defaults since we're just going to reboot anyhow. I added a force-reboot flag to the ut-factory-defaults script that will reboot instead of restart the uvm when set, and we now use that script/flag to handle the reboot. Cleaner and more efficient that my original implementation.
