### PR TITLE
Implement backup and restore calls in ConfigManager

### DIFF
--- a/uvm/api/com/untangle/uvm/BackupManager.java
+++ b/uvm/api/com/untangle/uvm/BackupManager.java
@@ -8,4 +8,5 @@ import java.io.File;
 public interface BackupManager
 {
     public File createBackup();
+    public String restoreBackup(File restoreFile, String maintainRegex);
 }

--- a/uvm/api/com/untangle/uvm/ConfigManager.java
+++ b/uvm/api/com/untangle/uvm/ConfigManager.java
@@ -47,7 +47,7 @@ public interface ConfigManager
 
     Object createSystemBackup();
 
-    Object restoreSystembackup(Object argBackup);
+    Object restoreSystemBackup(String argFileName, String maintainRegex);
 
     Object getNotifications();
 

--- a/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Calendar;
 import java.text.SimpleDateFormat;
@@ -80,7 +82,40 @@ public class BackupManagerImpl implements BackupManager
     }
 
     /**
-     * Restore a backup file
+     * Restore a backup from a File object
+     *
+     * @param restoreFile
+     *        The File containing the backup to restore
+     * @param maintainRegex
+     *        Regular expression
+     * @return Null for success or an error String
+     */
+    public String restoreBackup(File restoreFile, String maintainRegex)
+    {
+        FileInputStream fileInputStream = null;
+        ExecManagerResult execResult;
+        byte[] fileData = new byte[(int)restoreFile.length()];
+
+        // read the raw backup data into a byte array
+        try {
+            fileInputStream = new FileInputStream(restoreFile);
+            fileInputStream.read(fileData);
+            fileInputStream.close();
+        } catch (Exception exn) {
+            return exn.getMessage();
+        }
+
+        try {
+            execResult = restoreBackup(fileData, maintainRegex);
+        } catch (Exception exn) {
+            return exn.getMessage();
+        }
+
+        return null;
+    }
+
+    /**
+     * Restore a backup file from raw backup data
      * 
      * @param backupFileBytes
      *        The raw backup data

--- a/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
@@ -616,21 +616,53 @@ public class ConfigManagerImpl implements ConfigManager
      */
     public Object createSystemBackup()
     {
-        // TODO - how do we do this
-        return createResponse(999, "Not yet implemented");
+        File backupFile = context.backupManager().createBackup();
+        String fileName;
+
+        try {
+            fileName = backupFile.getCanonicalPath();
+        } catch (Exception exn) {
+            return createResponse(1, exn.getMessage());
+        }
+
+        TreeMap<String, Object> info = new TreeMap<>();
+        info.put("BackupFile", fileName);
+        return createResponse(info);
     }
 
     /**
      * Called to restore a system backup
      *
-     * @param argBackup
-     *        The backup to restore
-     * @return
+     * @param argFileName
+     *        The backup file to restore
+     * @param maintainRegex
+     *        An optional regex expression of existing files or directories that
+     *        should not be replaced by content in the backup.
+     * @return A JSON object with the result code and message
      */
-    public Object restoreSystembackup(Object argBackup)
+    public Object restoreSystemBackup(String argFileName, String maintainRegex)
     {
-        // TODO - how do we do this
-        return createResponse(999, "Not yet implemented");
+        // The UI currently passes the following maintainRegex values to restoreBackup:
+        // Restore all settings = ''
+        // Restore all except keep current network settings = '.*/network.*',
+
+        File file = new File(argFileName);
+        String resultMessage = null;
+
+        // pass the file and regex to the restoreBackup function
+        try {
+            resultMessage = context.backupManager().restoreBackup(file, maintainRegex);
+        } catch (Exception exn) {
+            return createResponse(1, exn.getMessage());
+        }
+
+        // null return messages indicates an error
+        if (resultMessage != null) {
+            return createResponse(2, resultMessage);
+        }
+
+        // return the success message
+        return createResponse(0, "System restore initiated.");
     }
 
     /**


### PR DESCRIPTION
I was able to use the existing createBackup function in the BackupManager, as it creates a tar.gz file on the local file system which satisfies the implementation requirement.

I created a new public restoreBackup since the existing method is private and previously only called by the upload handler when submitting a backup via the user interface. The new public method takes a File object and String (maintain regex), loads the raw backup bytes, and then calls the existing private restore function, just as would happen when interactively restoring from the user interface.
