### PR TITLE
Add createDiagnosticDump API call to ConfigManager

### DIFF
--- a/uvm/api/com/untangle/uvm/ConfigManager.java
+++ b/uvm/api/com/untangle/uvm/ConfigManager.java
@@ -40,8 +40,6 @@ public interface ConfigManager
 
     List<InterfaceMetrics> getNetworkPortStats();
 
-    Object getTrafficMetrics();
-
     SnmpSettings getSnmpSettings();
     Object setSnmpSettings(SnmpSettings argSettings);
 
@@ -49,9 +47,7 @@ public interface ConfigManager
 
     Object restoreSystemBackup(String argFileName, String maintainRegex);
 
-    Object getNotifications();
-
-    Object getDiagnosticInfo();
-
     Object doDatabaseQuery(String argQuery);
+
+    Object createDiagnosticDump();
 }

--- a/uvm/hier/usr/share/untangle/bin/ut-diagnostic-dump
+++ b/uvm/hier/usr/share/untangle/bin/ut-diagnostic-dump
@@ -7,13 +7,13 @@
 
 # Check for filename argument
 if [ -z "$1" ]; then
-  printf "The destination file was not specified"
+  printf "ERROR: The destination file was not specified"
   exit 1
 fi
 
 # Make sure the file does not already exist
 if [ -f "$1" ]; then
-  printf "The destination file already exists"
+  printf "ERROR: The destination file already exists"
   exit 1
 fi
 

--- a/uvm/hier/usr/share/untangle/bin/ut-diagnostic-dump
+++ b/uvm/hier/usr/share/untangle/bin/ut-diagnostic-dump
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# This script is called from ConfigManagerImpl.createDiagnosticDump()
+# It will create a tarball with the argumented file name that contains
+# critical settings, configuration, and log data that will be useful
+# for advance diagnostic and debugging purposes.
+
+# Check for filename argument
+if [ -z "$1" ]; then
+  printf "The destination file was not specified"
+  exit 1
+fi
+
+# Make sure the file does not already exist
+if [ -f "$1" ]; then
+  printf "The destination file already exists"
+  exit 1
+fi
+
+# Use the transform option so during extraction all of the directories we
+# add will be created under a single directory in the extraction target
+tar cfz $1 /var/log /etc /usr/share/untangle/settings /usr/share/untangle/conf --transform 's,^,diagdump/,' > /dev/null 2>&1
+printf "Diagnostic dump successfully created"
+exit 0

--- a/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
@@ -690,7 +690,7 @@ public class ConfigManagerImpl implements ConfigManager
         }
 
         // return the success message
-        return createResponse(0, "System restore initiated.");
+        return createResponse(0, "System restore initiated");
     }
 
     /**
@@ -887,9 +887,9 @@ public class ConfigManagerImpl implements ConfigManager
      *          /tmp/diagdump_timestamp_serial.tar.gz. The caller should remove
      *          the file when no longer needed.
      *
-     * @return A JSON Object with the result code and message plus the name of
-     *         the diagnostic file that was created and the status message
-     *         returned by the file creation script.
+     * @return A JSON Object with the result code and message plus the name and
+     *         size of the diagnostic file that was created and the status
+     *         message returned by the file creation script.
      */
     public Object createDiagnosticDump()
     {
@@ -906,9 +906,18 @@ public class ConfigManagerImpl implements ConfigManager
         fileName.append(".tar.gz");
 
         String output = context.execManager().execOutput(DIAGNOSTIC_DUMP_SCRIPT + " " + fileName.toString());
+        if (output.startsWith("ERROR:")) {
+            return createResponse(1, output);
+        }
+
+        File target = new File(fileName.toString());
+        if (!target.exists()) {
+            return createResponse(2, "The diagnostic dump file could not be created");
+        }
 
         TreeMap<String, Object> info = new TreeMap<>();
         info.put("FileName", fileName.toString());
+        info.put("FileSize", target.length());
         info.put("DumpMessage", output);
         return createResponse(info);
     }


### PR DESCRIPTION
Added the API function to create an archive of diagnostic info. The file is created by the new ut-diagnostic-dump script and will capture everything in /var/log, /etc, and the settings and conf directories under /usr/share/untangle. I also removed the API functions for traffic metrics and notifications since this data will be pulled using the doDatabaseQuery call. Cleaned up and enhanced the javadoc comments in a few places.
