### PR TITLE
Add interface details and appliance model to API results

### DIFF
--- a/uvm/api/com/untangle/uvm/InterfaceMetrics.java
+++ b/uvm/api/com/untangle/uvm/InterfaceMetrics.java
@@ -20,6 +20,17 @@ public class InterfaceMetrics implements Serializable, JSONString
 {
     private Integer portId;
 
+    private InetAddress v4Address = null;
+    private InetAddress v4Netmask = null;
+    private InetAddress v4Gateway = null;
+    private InetAddress v4Dns1 = null;
+    private InetAddress v4Dns2 = null;
+    private Integer v4PrefixLength = null;
+
+    private InetAddress v6Address = null;
+    private InetAddress v6Gateway = null;
+    private Integer v6PrefixLength = null;
+
     private String portName;
     private String portMac;
     private String portStatus;
@@ -54,6 +65,33 @@ public class InterfaceMetrics implements Serializable, JSONString
 
     public int getPortId( ) { return this.portId; }
     public void setPortId( int argValue ) { this.portId = argValue; }
+
+    public InetAddress getV4Address( ) { return this.v4Address; }
+    public void setV4Address( InetAddress newValue ) { this.v4Address = newValue; }
+
+    public InetAddress getV4Netmask( ) { return this.v4Netmask; }
+    public void setV4Netmask( InetAddress newValue ) { this.v4Netmask = newValue; }
+
+    public InetAddress getV4Gateway( ) { return this.v4Gateway; }
+    public void setV4Gateway( InetAddress newValue ) { this.v4Gateway = newValue; }
+
+    public InetAddress getV4Dns1( ) { return this.v4Dns1; }
+    public void setV4Dns1( InetAddress newValue ) { this.v4Dns1 = newValue; }
+
+    public InetAddress getV4Dns2( ) { return this.v4Dns2; }
+    public void setV4Dns2( InetAddress newValue ) { this.v4Dns2 = newValue; }
+
+    public Integer getV4PrefixLength( ) { return this.v4PrefixLength; }
+    public void setV4PrefixLength( Integer newValue ) { this.v4PrefixLength = newValue; }
+
+    public InetAddress getV6Address( ) { return this.v6Address; }
+    public void setV6Address( InetAddress newValue ) { this.v6Address = newValue; }
+
+    public Integer getV6PrefixLength( ) { return this.v6PrefixLength; }
+    public void setV6PrefixLength( Integer newValue ) { this.v6PrefixLength = newValue; }
+
+    public InetAddress getV6Gateway( ) { return this.v6Gateway; }
+    public void setV6Gateway( InetAddress newValue ) { this.v6Gateway = newValue; }
 
     public String getPortName( ) { return this.portName; }
     public void setPortName( String argValue ) { this.portName = argValue; }
@@ -93,7 +131,6 @@ public class InterfaceMetrics implements Serializable, JSONString
 
     public Long getRxMulticast( ) { return this.rxMulticast; }
     public void setRxMulticast( Long argValue ) { this.rxMulticast = argValue; }
-
 
     public Long getTxBytes( ) { return this.txBytes; }
     public void setTxBytes( Long argValue ) { this.txBytes = argValue; }

--- a/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
@@ -6,6 +6,7 @@ package com.untangle.uvm;
 
 import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.network.InterfaceSettings;
+import com.untangle.uvm.network.InterfaceStatus;
 import com.untangle.uvm.network.DeviceStatus;
 import com.untangle.uvm.event.EventSettings;
 import com.untangle.uvm.UvmContext;
@@ -177,9 +178,9 @@ public class ConfigManagerImpl implements ConfigManager
         String deviceName = context.networkManager().getNetworkSettings().getHostName() + "." + context.networkManager().getNetworkSettings().getDomainName();
 
         // TODO - need to figure out the source for the following:
-        // ModelName, Description, MacAddress, Temperature
+        // Description, MacAddress, Temperature
         TreeMap<String, Object> info = new TreeMap<>();
-        info.put("ModelName", "model name goes here");
+        info.put("ModelName", context.getApplianceModel());
         info.put("Description", "description goes here");
         info.put("DeviceName", deviceName);
         info.put("SerialNumber", context.getServerUID());
@@ -540,6 +541,7 @@ public class ConfigManagerImpl implements ConfigManager
             String deviceName = column[0].replace(':', ' ').trim();
 
             InterfaceSettings faceSettings = null;
+            InterfaceStatus faceStatus = null;
             DeviceStatus devStatus = null;
 
             // look for a configured interface with matching device name
@@ -563,6 +565,9 @@ public class ConfigManagerImpl implements ConfigManager
 
             // if no matching device status ignore the line
             if (devStatus == null) continue;
+
+            // get the interface status for the interface
+            faceStatus = context.networkManager().getInterfaceStatus(faceSettings.getInterfaceId());
 
             // create a new interface metrics object
             InterfaceMetrics metric = new InterfaceMetrics();
@@ -593,6 +598,18 @@ public class ConfigManagerImpl implements ConfigManager
             metric.setTxCollisions(Long.parseLong(column[14]));
             metric.setTxCarrier(Long.parseLong(column[15]));
             metric.setTxCompressed(Long.parseLong(column[16]));
+
+            if (faceStatus != null) {
+                metric.setV4Address(faceStatus.getV4Address());
+                metric.setV4Netmask(faceStatus.getV4Netmask());
+                metric.setV4Gateway(faceStatus.getV4Gateway());
+                metric.setV4Dns1(faceStatus.getV4Dns1());
+                metric.setV4Dns2(faceStatus.getV4Dns2());
+                metric.setV4PrefixLength(faceStatus.getV4PrefixLength());
+                metric.setV6Address(faceStatus.getV6Address());
+                metric.setV6PrefixLength(faceStatus.getV6PrefixLength());
+                metric.setV6Gateway(faceStatus.getV6Gateway());
+            }
 
             // append the metric to the list we return
             metricList.add(metric);


### PR DESCRIPTION
Added the network config details (addr, netmask, etc.) to the InterfaceMetrics objects returned from the getNetworkPortStats call. Added a call to Uvm getApplianceModel so we return the correct model in the getSystemInfo call.
