### PR TITLE
Add persistence for the tempfs database

### DIFF
--- a/uvm/api/com/untangle/uvm/UvmContext.java
+++ b/uvm/api/com/untangle/uvm/UvmContext.java
@@ -470,6 +470,12 @@ public interface UvmContext
     boolean useTempFileSystem();
 
     /**
+     * Returns the interval at which we should backup the tempfs database
+     * to physical storage or zero if the feature is not enabled.
+     */
+    long getTempBackupTimer();
+
+    /**
      * Returns true if this server is installed on an official Untangle appliance
      *
      * @return a <code>boolean</code> value

--- a/uvm/hier/usr/share/untangle/bin/ut-factory-defaults
+++ b/uvm/hier/usr/share/untangle/bin/ut-factory-defaults
@@ -15,6 +15,7 @@ rm -rf /usr/share/untangle/settings/*
 rm -rf /usr/share/untangle/quarantine
 rm -rf /etc/openvpn/*
 rm -f /var/cache/untangle-ssl/*.p12
+rm -f /usr/share/untangle/tempfs-database.backup
 
 # drop database
 if [ -f /usr/bin/psql ] ; then

--- a/uvm/hier/usr/share/untangle/bin/ut-tempfs-backup
+++ b/uvm/hier/usr/share/untangle/bin/ut-tempfs-backup
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# This script is called from Uvm a Pulse periodically when useTempFileSystem
+# is true. It will backup data stored in tempfs to the physical disk so
+# it can be restored during system reboot.
+
+SCRIPT_LOG_FILE="/dev/shm/tempfs_backup.log"
+
+PG_VERSION="11"
+PG_BIN_DIR="/usr/lib/postgresql/${PG_VERSION}/bin"
+PG_BACKUP_WORK="@PREFIX@/usr/share/untangle/tempfs-database.worker"
+PG_BACKUP_FILE="@PREFIX@/usr/share/untangle/tempfs-database.backup"
+
+# Calling exec with no arguments changes the I/O redirections in
+# the current shell so we can capture output to a log file
+exec >> $SCRIPT_LOG_FILE
+exec 2>&1
+
+# remove any existing backup worker file
+rm -f $PG_BACKUP_WORK
+
+# create a backup of the PostgreSQL database in a worker file using nice
+# on both the pg_dump and the gzip processes to minimize system impact
+nice $PG_BIN_DIR/pg_dump -U postgres -d uvm | nice gzip > $PG_BACKUP_WORK
+
+# remove any existing backup and replace with the file we just created
+rm -f $PG_BACKUP_FILE
+mv $PG_BACKUP_WORK $PG_BACKUP_FILE
+
+printf "tempfs backup completed\n"
+
+exit 0

--- a/uvm/hier/usr/share/untangle/bin/ut-tempfs-setup
+++ b/uvm/hier/usr/share/untangle/bin/ut-tempfs-setup
@@ -4,7 +4,6 @@
 # It will move the reporting database and any other write-intensive files to a
 # tempfs partition to reduce wear on storage media with limited write cycles.
 
-
 TEMPFS_SETUP_FLAG="/dev/shm/tempfs_setup.flag"
 TEMPFS_LOG_FILE="/dev/shm/tempfs_setup.log"
 
@@ -15,6 +14,8 @@ exec 2>&1
 
 DB_DRIVER_FILE="@PREFIX@/usr/share/untangle/conf/database-driver"
 DB_DRIVER_NAME="postgresql"
+PG_RESTORE_SCRIPT="@PREFIX@/usr/share/untangle/bin/reports-restore-backup.sh"
+PG_BACKUP_FILE="@PREFIX@/usr/share/untangle/tempfs-database.backup"
 
 PG_VERSION="11"
 PG_LOCALE="en_US.UTF-8"
@@ -45,25 +46,35 @@ if [ "$DB_DRIVER_NAME" != "postgresql" ] && [ "$DB_DRIVER_NAME" != "sqlite" ]; t
 fi
 
 # move the postgresql database to tempfs if configured
-# we have to create the database cluster so postgres can start 
-# this logic is based on untangle-postgresql-config.postinst 
+# we have to create the database cluster so postgres can start
+# this logic is based on untangle-postgresql-config.postinst
 if [ "$DB_DRIVER_NAME" == "postgresql" ]; then
   rm -r -f $PG_SYS_DIR
   mkdir $PG_TFS_DIR
   chown -R postgres:postgres $PG_TFS_DIR
   ln -s $PG_TFS_DIR $PG_SYS_DIR
   su -c "${PG_BIN_DIR}/initdb --encoding=utf8 --locale=${PG_LOCALE} -D ${PG_MAIN_DIR}" postgres
+
+  # if the backup file exists we start the postgresql daemon
+  # create the database, and restore the backup file
+  if [ -f $PG_BACKUP_FILE ]; then
+    printf "restoring database backup:%s\n" $PG_BACKUP_FILE
+    systemctl start postgresql
+    $PG_BIN_DIR/psql -U postgres -c "CREATE DATABASE uvm"
+    $PG_RESTORE_SCRIPT -f $PG_BACKUP_FILE
+  fi
+
 fi
 
 # move the sqlite database to tempfs if configured
-# this is easier because sqlite will create the db when missing 
+# this is easier because sqlite will create the db when missing
 if [ "$DB_DRIVER_NAME" == "sqlite" ]; then
   rm -r -f $SL_SYS_DIR
   mkdir $SL_TFS_DIR
   ln -s $SL_TFS_DIR $SL_SYS_DIR
 fi
 
-# create our setup flag 
+# create our setup flag
 /bin/date > $TEMPFS_SETUP_FLAG
 printf "tempfs setup completed\n"
 exit 0

--- a/uvm/impl/com/untangle/uvm/UvmContextImpl.java
+++ b/uvm/impl/com/untangle/uvm/UvmContextImpl.java
@@ -72,8 +72,7 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
 
     private static final Object startupWaitLock = new Object();
 
-    private static final String TEMPFS_BACKUP_COMMAND = "pg_dump -U postgres -d uvm";
-    private static final String TEMPFS_BACKUP_FILE = System.getProperty("uvm.home") + "/tempfs-database.backup";
+    private static final String TEMPFS_BACKUP_SCRIPT = System.getProperty("uvm.bin.dir") + "/ut-tempfs-backup";
     private final static long TEMPFS_BACKUP_FREQUENCY = (60 * 60 * 1000L);
     private Pulse tempfsBackupPulse = null;
 
@@ -1889,8 +1888,8 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
         public void run()
         {
             Logger logger = Logger.getLogger(UvmContextImpl.class);
-            logger.info("Creating tempfs database backup: " + TEMPFS_BACKUP_FILE);
-            owner.execManager.exec(TEMPFS_BACKUP_COMMAND + " | gzip > " + TEMPFS_BACKUP_FILE);
+            logger.info("Calling tempfs backup script");
+            owner.execManager.exec(TEMPFS_BACKUP_SCRIPT);
         }
     }
 }

--- a/uvm/impl/com/untangle/uvm/UvmContextImpl.java
+++ b/uvm/impl/com/untangle/uvm/UvmContextImpl.java
@@ -11,6 +11,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URL;
+import java.util.Scanner;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
     private static final String WIZARD_SETTINGS_FILE = System.getProperty("uvm.conf.dir") + "/" + "wizard.js";
     private static final String DISKLESS_MODE_FLAG_FILE = System.getProperty("uvm.conf.dir") + "/diskless-mode-flag";
     private static final String TEMPFS_MODE_FLAG_FILE = System.getProperty("uvm.conf.dir") + "/tempfs-mode-flag";
+    private static final String TEMPFS_BACKUP_TIMER_FILE = System.getProperty("uvm.conf.dir") + "/tempfs-backup-timer";
     private static final String TEMPFS_SETUP_SCRIPT = System.getProperty("uvm.bin.dir") + "/ut-tempfs-setup";
     private static final String IS_REGISTERED_FLAG_FILE = System.getProperty("uvm.conf.dir") + "/is-registered-flag";
     private static final String IS_REMOTE_SETUP_DISABLED_FLAG_FILE = System.getProperty("uvm.conf.dir") + "/setup-remote-disabled-flag";
@@ -73,7 +75,6 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
     private static final Object startupWaitLock = new Object();
 
     private static final String TEMPFS_BACKUP_SCRIPT = System.getProperty("uvm.bin.dir") + "/ut-tempfs-backup";
-    private final static long TEMPFS_BACKUP_FREQUENCY = (60 * 60 * 1000L);
     private Pulse tempfsBackupPulse = null;
 
     private static final Logger logger = Logger.getLogger(UvmContextImpl.class);
@@ -1010,6 +1011,36 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
     }
 
     /**
+     * getTempBackupTimer - returns the number of seconds to be used for the
+     * periodic backup interval of the tempfs database or zero if the
+     * configuration file does not exist.
+     *
+     * @return long
+     */
+    public long getTempBackupTimer()
+    {
+        File keyFile = new File(TEMPFS_BACKUP_TIMER_FILE);
+
+        if (!keyFile.exists()) {
+            return 0;
+        }
+
+        long backupInterval = 0;
+
+        try {
+            Scanner fileScanner = new Scanner(keyFile);
+            if (fileScanner.hasNextLong()) {
+                backupInterval = fileScanner.nextLong();
+            }
+            fileScanner.close();
+        } catch (Exception exn) {
+            logger.warn("Error reading file: " + TEMPFS_BACKUP_TIMER_FILE, exn);
+        }
+
+        return backupInterval;
+    }
+
+    /**
      * Returns true if this is a developer build in the development
      * environment
      * @return <doc>
@@ -1516,8 +1547,13 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
             Integer exitValue = this.execManager().execResult(TEMPFS_SETUP_SCRIPT);
             logger.info("TempFS setup result: " + exitValue);
 
-            tempfsBackupPulse = new Pulse("tempfsDatabaseBackupWorker", new tempfsDatabaseBackupWorker(this), TEMPFS_BACKUP_FREQUENCY);
-            tempfsBackupPulse.start();
+            // check the backup timer and create Pulse if non-zero
+            long backupTimer = getTempBackupTimer();
+            if (backupTimer > 0) {
+                logger.info("TempFS backup interval: " + backupTimer);
+                tempfsBackupPulse = new Pulse("tempfsDatabaseBackupWorker", new tempfsDatabaseBackupWorker(this), backupTimer * 1000L);
+                tempfsBackupPulse.start();
+            }
         }
 
         mailSender.postInit();


### PR DESCRIPTION
When the tempfs-mode-flag is enabled, and the postgresql database is running from tempfs, we use an hourly Pulse to create a copy of the database on the physical disk using the pg_dump command. I then modified the ut-tempfs-setup script to restore the database from the backup file if it exists. I also added cleanup of the backup file to the ut-factory-defaults script.
