### PR TITLE
Add OEM override processing to reports default settings

### DIFF
--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -743,7 +743,9 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
             settings.setDbRetention( 7 );
         }
 
-        return settings;
+        // pass the settings to the OEM override function and return the override settings
+        ReportsSettings overrideSettings = (ReportsSettings)UvmContextFactory.context().oemManager().applyOemOverrides(settings);
+        return overrideSettings;
     }
     
     /** 


### PR DESCRIPTION
Added logic to apply OEM overrides to the default settings in the reports application. The reports settings are a bit more complicated than the others already completed, and this revealed some edge cases that the Python script wasn't handling properly. I added additional type checking in the recursive processing so we only recurse into child lists and dictionaries to resolve the issue. While tracking this down I discovered it was helpful to include the exception message in the error output when handling unexpected conditions. I also added sort_keys=True to the json.dump calls for the debug and final output files which helps when using diff to compare the original and modified json while testing.
