### PR TITLE
Add support for Secure Diagnostic Mode control interface

### DIFF
--- a/uvm/hier/usr/share/untangle/conf/apache2/conf.d/support.conf
+++ b/uvm/hier/usr/share/untangle/conf/apache2/conf.d/support.conf
@@ -1,0 +1,20 @@
+JkMount /support* uvmWorker
+
+<Location /support>
+    AuthType Basic
+    AuthName "Administrator"
+    require valid-user
+
+    <IfModule mod_auth_basic.c>
+        AuthBasicAuthoritative Off
+        AuthUserFile /dev/null
+    </IfModule>
+    <IfModule mod_auth_pam.c>
+        AuthPAM_Enabled Off
+    </IfModule>
+
+    PythonOption Realm Administrator
+    PythonPath "['@PREFIX@/usr/lib/python2.7/dist-packages/'] + sys.path"
+    PythonAuthenHandler uvm_login
+    PythonHeaderParserHandler uvm_login
+</Location>

--- a/uvm/impl/com/untangle/uvm/TomcatManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/TomcatManagerImpl.java
@@ -119,6 +119,8 @@ public class TomcatManagerImpl implements TomcatManager
         ctx = loadServlet("/blockpage", "blockpage");
 
         ctx = loadServlet("/gdrive", "gdrive");
+
+        ctx = loadServlet("/support", "support");
     }
 
     /**

--- a/uvm/package.rb
+++ b/uvm/package.rb
@@ -49,6 +49,8 @@ ServletBuilder.new(uvm_lib, "com.untangle.uvm.installer.servlet", ["uvm/servlets
 
 deps=[]
 
+ServletBuilder.new(uvm_lib, "com.untangle.uvm.support.servlet", ["./uvm/servlets/support"], deps)
+
 ServletBuilder.new(uvm_lib, "com.untangle.uvm.gdrive.servlet", ["./uvm/servlets/gdrive"], deps)
 
 ServletBuilder.new(uvm_lib, "com.untangle.uvm.admin.servlet", ["./uvm/servlets/admin"], deps + Jars::Jstl)

--- a/uvm/servlets/support/root/WEB-INF/web.xml
+++ b/uvm/servlets/support/root/WEB-INF/web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- $Id: web.xml 40842 2015-07-31 01:04:35Z dmorris $ -->
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee  http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd" version="3.0" metadata-complete="true">
+
+  <display-name>AdvancedSupport</display-name>
+
+  <description>
+    Advanced Support Handler
+  </description>
+
+  <servlet>
+    <servlet-name>AdvancedSupportHandler</servlet-name>
+    <servlet-class>com.untangle.uvm.AdvancedSupportHandler</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>AdvancedSupportHandler</servlet-name>
+    <url-pattern>/index.do</url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/uvm/servlets/support/root/index.jsp
+++ b/uvm/servlets/support/root/index.jsp
@@ -1,0 +1,4 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<%-- Redirected because we can't set the support page to a virtual URL. --%>
+<c:redirect url="/index.do"/>

--- a/uvm/servlets/support/src/com/untangle/uvm/AdvancedSupportHandler.java
+++ b/uvm/servlets/support/src/com/untangle/uvm/AdvancedSupportHandler.java
@@ -26,7 +26,7 @@ public class AdvancedSupportHandler extends HttpServlet
 {
     private final Logger logger = Logger.getLogger(this.getClass());
 
-    private static final String OEM_SUPPORT_HANDLER_SCRIPT = System.getProperty("uvm.conf.dir") + "/oem-support-handler";
+    private static final String ADVANCED_SUPPORT_HANDLER_SCRIPT = System.getProperty("uvm.conf.dir") + "/advanced-support-handler";
 
     /**
      * Perform HTTP GET operation
@@ -75,9 +75,9 @@ public class AdvancedSupportHandler extends HttpServlet
      */
     private void requestHandler(String method, HttpServletRequest request, HttpServletResponse response) throws IOException
     {
-        File script = new File(OEM_SUPPORT_HANDLER_SCRIPT);
+        File script = new File(ADVANCED_SUPPORT_HANDLER_SCRIPT);
 
-        // first make sure the OEM handler script exists
+        // first make sure the advanced support handler script exists
         if (!script.exists() || !script.canExecute()) {
             response.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED);
         }
@@ -98,7 +98,7 @@ public class AdvancedSupportHandler extends HttpServlet
 
         // call the handler script with the method and parameters
         UvmContext uvmContext = UvmContextFactory.context();
-        String output = uvmContext.execManager().execOutput(OEM_SUPPORT_HANDLER_SCRIPT + " " + method + " " + parmstr);
+        String output = uvmContext.execManager().execOutput(ADVANCED_SUPPORT_HANDLER_SCRIPT + " " + method + " " + parmstr);
 
         // write the script output as the response
         response.setContentType("text/html");

--- a/uvm/servlets/support/src/com/untangle/uvm/AdvancedSupportHandler.java
+++ b/uvm/servlets/support/src/com/untangle/uvm/AdvancedSupportHandler.java
@@ -1,0 +1,108 @@
+/**
+ * $Id: AdvancedSupportHandler.java 1 2021-08-07 15:51:00Z mahotz $
+ */
+package com.untangle.uvm;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Base64;
+import java.util.Enumeration;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.json.JSONObject;
+import org.json.JSONString;
+import org.apache.log4j.Logger;
+
+import com.untangle.uvm.UvmContextFactory;
+
+/**
+ * AdvancedSupport http servelet class
+ */
+@SuppressWarnings("serial")
+public class AdvancedSupportHandler extends HttpServlet
+{
+    private final Logger logger = Logger.getLogger(this.getClass());
+
+    private static final String OEM_SUPPORT_HANDLER_SCRIPT = System.getProperty("uvm.conf.dir") + "/oem-support-handler";
+
+    /**
+     * Perform HTTP GET operation
+     *
+     * @param request
+     *        HTTP request
+     * @param response
+     *        HTTP response
+     * @throws ServletException
+     * @throws IOException
+     */
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+    {
+        requestHandler("GET", request, response);
+    }
+
+    /**
+     * Perform HTTP POST operation
+     *
+     * @param request
+     *        HTTP request
+     * @param response
+     *        HTTP response
+     * @throws ServletException
+     * @throws IOException
+     */
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+    {
+        requestHandler("POST", request, response);
+    }
+
+    /**
+     * Main request handler for GET and POST methods. Extracts the parameters
+     * from the request and stores them in a JSONObject. The object is then
+     * converted to a String and formatted with Base64 and then passed along
+     * with the request method to the external handler script. The script output
+     * should be a raw HTML page which is used as the response.
+     *
+     * @param method
+     *        The request method (GET or POST)
+     * @param request
+     *        HTTP request
+     * @param response
+     *        HTTP response
+     * @throws IOException
+     */
+    private void requestHandler(String method, HttpServletRequest request, HttpServletResponse response) throws IOException
+    {
+        File script = new File(OEM_SUPPORT_HANDLER_SCRIPT);
+
+        // first make sure the OEM handler script exists
+        if (!script.exists() || !script.canExecute()) {
+            response.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED);
+        }
+
+        // put all of the request parameter names and values into a JSON object
+        JSONObject object = new JSONObject();
+        Enumeration<String> params = request.getParameterNames();
+        while (params.hasMoreElements()) {
+            String name = params.nextElement();
+            try {
+                object.put(name, request.getParameter(name));
+            } catch (Exception exn) {
+            }
+        }
+
+        // convert the JSON to a string in Base64 format that can be passed to the script
+        String parmstr = Base64.getEncoder().encodeToString(object.toString().getBytes());
+
+        // call the handler script with the method and parameters
+        UvmContext uvmContext = UvmContextFactory.context();
+        String output = uvmContext.execManager().execOutput(OEM_SUPPORT_HANDLER_SCRIPT + " " + method + " " + parmstr);
+
+        // write the script output as the response
+        response.setContentType("text/html");
+        PrintWriter writer = response.getWriter();
+        writer.print(output);
+    }
+}


### PR DESCRIPTION
Our partner wants support for managing a simple daemon that provides remote access for their engineering support team via their existing infrastructure. To make this work, I have added a new servlet that is available at https://server_ip_address/support using the same authentication mechanism as our own admin UI. When GET and POST requests are received, the parameters are extracted and stored in a simple JSON object that is serialized using base64 and then passed to an external Python script along with the request method. The script processes the request and generates the HTML page that is returned to the client. This mechanism is a generic enhancement to our core platform. All of the vendor specific branding and functionality is handled in the new oem-support-handler script that will be part of the vendor specific package.
