### PR TITLE
Increase pulse interval when no internet during startup and deferred autoinstall logic

### DIFF
--- a/license/hier/usr/share/untangle/lib/license/appProperties.json
+++ b/license/hier/usr/share/untangle/lib/license/appProperties.json
@@ -5,6 +5,7 @@
         "displayName" : "License Manager",
         "type" : "SERVICE",
         "invisible" : True,
-        "autoLoad" : True
+        "autoLoad" : True,
+        "autoStart": True
 }
 

--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -316,10 +316,6 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
     @Override
     public final boolean isLicenseValid(String identifier)
     {
-        /**
-         * The router, ftp, and license services are core components of the
-         * platform and should always be allowed to install and run.
-         */
         License lic = getLicense(identifier);
         if (lic == null)
             return false;

--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -959,23 +959,21 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                         }
                     }
 
-                    // if no message about connection exists, then add it
+                    // if no message about connection exists, then add it and save settings
                     if (noMessage) {
                         UserLicenseMessage noLicenseConnection = new UserLicenseMessage(NO_LICENSE_SERVER_CONNECTION_MESSAGE,
                                                                         false,
                                                                         UserLicenseMessage.UserLicenseMessageType.ALERT);
                         this.settings.getUserLicenseMessages().add(noLicenseConnection);
+                        _saveSettings(this.settings);
                     }
                 }
             } else {
+                // download succeeded so save settings and map licenses
+                _saveSettings(this.settings);
                 _mapLicenses();
             }
-
-            // set settings if download was successful and to get UserLicense messages about disconnection
-            _saveSettings(this.settings);
-
             _runAppManagerSync();
-
         }
 
         logger.info("Reloading licenses... done" );
@@ -1000,6 +998,7 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                 appManager.doAutoInstall();
             }
         }
+
         if(!appManager.isRestartingUnloaded()) {
             appManager.shutdownAppsWithInvalidLicense();
         }
@@ -1028,6 +1027,12 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                 pulse.stop();
                 pulse = new Pulse("uvm-license", task, TIMER_DELAY);
                 pulse.start();
+
+                AppManager appManager = UvmContextFactory.context().appManager();
+                if (appManager.isAutoInstallAppsFlag()) {
+                    logger.info("Finishing deferred auto install");
+                    appManager.finishDeferredAutoInstall();
+                }
             }
         }
     }

--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -320,10 +320,6 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
          * The router, ftp, and license services are core components of the
          * platform and should always be allowed to install and run.
          */
-        if (identifier.equals("router")) return true;
-        if (identifier.equals("ftp")) return true;
-        if (identifier.equals("license")) return true;
-
         License lic = getLicense(identifier);
         if (lic == null)
             return false;

--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -969,9 +969,9 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                     }
                 }
             } else {
-                // download succeeded so save settings and map licenses
-                _saveSettings(this.settings);
+                // download succeeded so map licenses and save settings
                 _mapLicenses();
+                _saveSettings(this.settings);
             }
             _runAppManagerSync();
         }

--- a/router/hier/usr/share/untangle/lib/router/appProperties.json
+++ b/router/hier/usr/share/untangle/lib/router/appProperties.json
@@ -6,6 +6,7 @@
         "type" : "SERVICE",
         "invisible" : True,
         "autoLoad" : True,
+        "autoStart" : True,
         "parents" : {
             "javaClass": "java.util.LinkedList",
             "list": [

--- a/uvm/api/com/untangle/uvm/app/AppManager.java
+++ b/uvm/api/com/untangle/uvm/app/AppManager.java
@@ -27,11 +27,6 @@ public interface AppManager
     public void doAutoInstall();
 
     /**
-     * Finish deferred auto install
-     */
-    public void finishDeferredAutoInstall();
-
-    /**
      * Get <code>App</code>s of all instantiated apps.
      *
      * @return list of all app ids.
@@ -206,6 +201,13 @@ public interface AppManager
     boolean isAutoInstallAppsFlag();
 
     /**
+     * Returns true if apps auto intall was deferred
+     *
+     * @return a <code>boolean</code> value
+     */
+    boolean isAutoInstallDeferredFlag();
+
+    /**
      * Returns true is apps are being loaded
      * 
      * @return a boolean value
@@ -224,6 +226,12 @@ public interface AppManager
      * @param enabled   If true, remove the flag.  If false, create it.
      */
     void setAutoInstallAppsFlag(boolean enabled);
+
+    /**
+     * Set/unset deferred auto install flag.
+     * @param enabled   If true, remove the flag.  If false, create it.
+     */
+    void setAutoInstallDeferredFlag(boolean enabled);
 
     /**
      * Syncs the license server state with local state

--- a/uvm/api/com/untangle/uvm/app/AppManager.java
+++ b/uvm/api/com/untangle/uvm/app/AppManager.java
@@ -27,6 +27,11 @@ public interface AppManager
     public void doAutoInstall();
 
     /**
+     * Finish deferred auto install
+     */
+    public void finishDeferredAutoInstall();
+
+    /**
      * Get <code>App</code>s of all instantiated apps.
      *
      * @return list of all app ids.

--- a/uvm/impl/com/untangle/uvm/AppManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/AppManagerImpl.java
@@ -1609,9 +1609,6 @@ public class AppManagerImpl implements AppManager
 
         AppManagerSettings newSettings = new AppManagerSettings();
         this._setSettings(newSettings);
-
-        // first run so create the auto install flag
-        setAutoInstallAppsFlag(true);
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/AppManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/AppManagerImpl.java
@@ -899,7 +899,7 @@ public class AppManagerImpl implements AppManager
                                                        * left hand nav
                                                        */
         }
-        if (!UvmContextFactory.context().isDevel()) {
+        if (!UvmContextFactory.context().isDevel() && lm.getLicenseServerConnectivity()) {
             License webFilterLicense = lm.getLicense(License.WEB_FILTER);
             if (webFilterLicense != null && webFilterLicense.getValid() && !webFilterLicense.getTrial()) {
                 installableAppsMap.remove("Web Monitor"); /*
@@ -921,7 +921,7 @@ public class AppManagerImpl implements AppManager
                                                              * hand nav
                                                              */
         }
-        if (!UvmContextFactory.context().isDevel()) {
+        if (!UvmContextFactory.context().isDevel() && lm.getLicenseServerConnectivity()) {
             License spamBlockerLicense = lm.getLicense(License.SPAM_BLOCKER);
             if (spamBlockerLicense != null && spamBlockerLicense.getValid() && !spamBlockerLicense.getTrial()) {
                 installableAppsMap.remove("Spam Blocker Lite"); /*
@@ -1188,6 +1188,13 @@ public class AppManagerImpl implements AppManager
 
         LicenseManager lm = UvmContextFactory.context().licenseManager();
 
+        // if there is no license server connectivity return now leaving the
+        // auto install flag set so we can try again later
+        if (lm.getLicenseServerConnectivity() == false) {
+            logger.info("Deferring auto install pending license server connectivity");
+            return;
+        }
+
         List<AppProperties> appPropsToInstall = getAllAppProperties();
 
         if (lm.isRestricted()) {
@@ -1235,6 +1242,15 @@ public class AppManagerImpl implements AppManager
         setAutoInstallAppsFlag(false);
 
         logger.info("Finished auto install");
+    }
+
+    /**
+     * Called to finish auto install that was deferred due to missing license connectivity
+     */
+    public void finishDeferredAutoInstall()
+    {
+        startAutoLoad();
+        doAutoInstall();
     }
 
     /**
@@ -1593,6 +1609,9 @@ public class AppManagerImpl implements AppManager
 
         AppManagerSettings newSettings = new AppManagerSettings();
         this._setSettings(newSettings);
+
+        // first run so create the auto install flag
+        setAutoInstallAppsFlag(true);
     }
 
     /**


### PR DESCRIPTION
Added logic to increase the retry frequency during startup when the license server is not accessible. When the initial license download is completed, the pulse is reset to use the standard interval.
