### PR TITLE
Fix for apps auto-installed with no license server connectivity

### DIFF
--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -497,14 +497,11 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                 if ( response != null ) { response.close(); response = null; }
             }
         } catch ( java.net.UnknownHostException e ) {
-            logger.warn("Exception requesting trial license:" + e.toString());
-            throw ( new Exception( "Unable to fetch trial license: DNS lookup failed.", e ) );
+            logger.warn("DNS failure requesting trial license:" + e.toString());
         } catch ( java.net.ConnectException e ) {
-            logger.warn("Exception requesting trial license:" + e.toString());
-            throw ( new Exception( "Unable to fetch trial license: Connection timeout.", e ) );
+            logger.warn("Connection timeout requesting trial license:" + e.toString());
         } catch ( Exception e ) {
-            logger.warn("Exception requesting trial license:" + e.toString());
-            throw ( new Exception( "Unable to fetch trial license: " + e.toString(), e ) );
+            logger.warn("Exception requesting trial license:", e);
         } finally {
             try { if ( response != null ) response.close(); } catch (Exception e) { logger.warn("close",e); }
             try { httpClient.close(); } catch (Exception e) { logger.warn("close",e); }
@@ -977,7 +974,7 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
             }
         }
         if(!appManager.isRestartingUnloaded()) {
-            appManager.shutdownAppsWithInvalidLicense();
+            appManager.harmonizeAppManagerWithLicenseManager();
         }
     }
     

--- a/uvm/api/com/untangle/uvm/app/AppManager.java
+++ b/uvm/api/com/untangle/uvm/app/AppManager.java
@@ -189,9 +189,9 @@ public interface AppManager
     AppsView[] getAppsViews();
 
     /**
-     * Shutdown any running apps that have an invalid license
+     * Starts and stops apps based on license status
      */
-    void shutdownAppsWithInvalidLicense();
+    void harmonizeAppManagerWithLicenseManager();
 
     /**
      * Returns true if apps are to be auto installed


### PR DESCRIPTION
Two issues were addressed. First, when installing an app when the license server is not available, we log an error and throw a second exception, which prevents the app from being installed. I removed the secondary throw clauses so the install is successful but the app will remain in the INITIALIZED state until a valid license is received. Second, I changed shutdownAppsWithInvalidLicense to harmonizeAppManagerWithLicenseManager and added additional logic to transition licensed apps from INITIALIZED to RUNNING.
