### PR TITLE
Add exists check for thermal directory

### DIFF
--- a/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
@@ -1076,6 +1076,11 @@ public class ConfigManagerImpl implements ConfigManager
         File thermalZonePath = new File("/sys/devices/virtual/thermal");
         String discoveryFile = null;
 
+        // NGFW-13936 - Make sure the directory actually exists
+        if (!thermalZonePath.exists()) {
+            return discoveryFile;
+        }
+
         for (File zone : thermalZonePath.listFiles()) {
             if (discoveryFile != null) {
                 return discoveryFile;


### PR DESCRIPTION
Added a check to make sure the /sys/devices/virtual/thermal directory exists before doing the file search to solve a null pointer exception during startup if the directory is missing.
