### PR TITLE
Always check for MFA on VPN connections

### DIFF
--- a/openvpn/hier/usr/share/untangle/bin/openvpn-auth-user-pass
+++ b/openvpn/hier/usr/share/untangle/bin/openvpn-auth-user-pass
@@ -38,7 +38,7 @@ if password.startswith("SCRV1:"):
     otp = int(base64.b64decode(parts[2]))
     result = openvpnApp.userAuthenticate(username, password, otp)
 else:
-    result = openvpnApp.userAuthenticate(username, password)
+    result = openvpnApp.userAuthenticate(username, password, 0)
 
 sys.exit(result)
 


### PR DESCRIPTION
We always want to use the mfa authentication method for VPN users. If a use in the local directory do not have MFA enabled, we default back to just checking username and password.