### PR TITLE
travis: do not build PRs for bullseye

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
 script:
 - docker-compose -f docker-compose.build.yml run pkgtools
 - docker-compose -f docker-compose.build.yml run build
+if: NOT (type = pull_request AND env(REPOSITORY) = bullseye)
 
 notifications:
   email: false


### PR DESCRIPTION
Even though the bullseye builds succeed on feature branches, they
systematically fail on the corresponding PR for a reason yet to be
determined.