### PR TITLE
travis: temporarily turn on verbose+debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
       PACKAGE_SERVER_IP: 52.2.228.218
       PKGTOOLS_COMMIT: origin/${TRAVIS_BRANCH}
       UPLOAD: scp
+      VERBOSE: 1
+      DEBUG: 1
   jobs:
     - REPOSITORY: bullseye
       ARCHITECTURE: amd64


### PR DESCRIPTION
This is just a test, to troubleshoot recent issue in travis' attempts to
build from PRs (while the corresponding branch builds succeed).