### PR TITLE
NGFW-14335 If the hash is empty, we have at least one rule that wants…

### DIFF
--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -1096,7 +1096,7 @@ public class EventManagerImpl implements EventManager
         }else{
             EventsSeen.put(simpleName,EventsSeen.get(simpleName) + 1);
         }
-        if(!classesToProcess.containsKey(simpleName)){
+        if(classesToProcess.size() > 0 && !classesToProcess.containsKey(simpleName)){
             event = null;
         }else{
             try {


### PR DESCRIPTION
… everything, so don't null the event.