### PR TITLE
ngfw-14476 updated feedback url

### DIFF
--- a/buildtools/uri-analyzer.py
+++ b/buildtools/uri-analyzer.py
@@ -85,6 +85,7 @@ class UriAnalyzer():
         "https://www.untangle.com/legal",
 
         "http://wiki.edge.arista.com/get.php",
+        "https://edge.arista.com/feedback",
 
         # From test_network.py
         "http://1.2.3.4/test/testPage1.html",

--- a/uvm/api/com/untangle/uvm/UvmContext.java
+++ b/uvm/api/com/untangle/uvm/UvmContext.java
@@ -504,6 +504,7 @@ public interface UvmContext
     String getStoreUrl();
     String getCmdUrl();
     String getHelpUrl();
+    String getFeedbackUrl();
     String getLegalUrl();
 
     /**

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -1204,5 +1204,10 @@ class UvmTests(NGFWTestCase):
         assert "TLSv1.1:" not in results, "TLS v1.1 not allowed"
         assert "TLSv1.2:" in results, "TLS v1.2 allowed"
 
+    # Checks that feedback link is under arista
+    def test_300_feedback_link(self):
+        feeddback_url = uvmContext.getFeedbackUrl()
+        match = re.search('^https://edge.arista.com/feedback$', feeddback_url)
+        assert(match)
 
 test_registry.register_module("uvm", UvmTests)

--- a/uvm/impl/com/untangle/uvm/UvmContextImpl.java
+++ b/uvm/impl/com/untangle/uvm/UvmContextImpl.java
@@ -72,6 +72,8 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
     private static final String DEFAULT_CMD_URL = "https://launchpad.edge.arista.com/";
     private static final String PROPERTY_HELP_URL = "uvm.help.url";
     private static final String DEFAULT_HELP_URL = "http://wiki.edge.arista.com/get.php";
+    private static final String PROPERTY_FEEDBACK_URL = "uvm.feedback.url";
+    private static final String DEFAULT_FEEDBACK_URL = "https://edge.arista.com/feedback";
     private static final String PROPERTY_LEGAL_URL = "uvm.legal.url";
 
     private static final String DEFAULT_REGION_NAME = "world";
@@ -1196,6 +1198,18 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
     }
 
     /**
+     * getFeedbackUrl - get the feedback URL for the UI
+     * @return String
+     */
+    public String getFeedbackUrl()
+    {
+        String url = System.getProperty(PROPERTY_FEEDBACK_URL);
+        if (url == null)
+            url = DEFAULT_FEEDBACK_URL;
+        return url;
+    }
+
+    /**
      * getLegalUrl - get the URL for legal information in the UI
      * @return String
      */
@@ -1410,6 +1424,7 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
             json.put("regionName", this.getRegionName());
             json.put("storeUrl", this.getStoreUrl());
             json.put("helpUrl", this.getHelpUrl());
+            json.put("feedbackUrl", this.getFeedbackUrl());
             json.put("isRegistered", this.isRegistered());
             json.put("isExpertMode", this.isExpertMode());
             json.put("supportEnabled", this.systemManager().getSettings().getSupportEnabled());

--- a/uvm/servlets/admin/app/view/main/MainController.js
+++ b/uvm/servlets/admin/app/view/main/MainController.js
@@ -120,7 +120,7 @@ Ext.define('Ung.view.main.MainController', {
     },
 
     suggestHandler: function (btn) {
-        var suggestUrl = Rpc.directData('rpc.helpUrl') + '?fragment=feedback&' + Util.getAbout();
+        var suggestUrl = Rpc.directData('rpc.feedbackUrl');
         window.open(suggestUrl);
     },
 


### PR DESCRIPTION
As part of the Untangle rebranding to Arista we need to update the feedback link in NGFW so that it points to edge.arista.com/feedback. Same has been changed in this PR.

Refer below screenshots regarding the change, tested locally.

![Screenshot from 2024-01-30 12-53-42](https://github.com/untangle/ngfw_src/assets/154422821/75ab51e2-2f0c-42c6-b401-cae9efca7f93)

On clicking Suggest Idea button in nav bar user will be redirected to edge.arista.com/feedback and eventually to feedback page

![Screenshot from 2024-01-30 12-54-02](https://github.com/untangle/ngfw_src/assets/154422821/c38fffed-3393-4cb4-810c-6c5e91a6a3f4)

![Screenshot from 2024-01-30 12-54-17](https://github.com/untangle/ngfw_src/assets/154422821/a3ec0a8b-265e-40b4-8a7f-8aa12525aa1e)
