### PR TITLE
NGFW-14379: Revoking the update for log fields

### DIFF
--- a/ipsec-vpn/js/view/IpsecLog.js
+++ b/ipsec-vpn/js/view/IpsecLog.js
@@ -16,6 +16,7 @@ Ext.define('Ung.apps.ipsecvpn.view.IpsecLog', {
 
     items: [{
         xtype: 'textarea',
+        readOnly: true,
         itemId: 'ipsecSystemLog',
         spellcheck: false,
         padding: 0,

--- a/ipsec-vpn/js/view/IpsecPolicy.js
+++ b/ipsec-vpn/js/view/IpsecPolicy.js
@@ -16,6 +16,7 @@ Ext.define('Ung.apps.ipsecvpn.view.IpsecPolicy', {
 
     items: [{
         xtype: 'textarea',
+        readOnly: true,
         itemId: 'ipsecPolicyInfo',
         spellcheck: false,
         padding: 0,

--- a/ipsec-vpn/js/view/IpsecState.js
+++ b/ipsec-vpn/js/view/IpsecState.js
@@ -16,6 +16,7 @@ Ext.define('Ung.apps.ipsecvpn.view.IpsecState', {
 
     items: [{
         xtype: 'textarea',
+        readOnly: true,
         itemId: 'ipsecStateInfo',
         spellcheck: false,
         padding: 0,

--- a/ipsec-vpn/js/view/L2tpLog.js
+++ b/ipsec-vpn/js/view/L2tpLog.js
@@ -16,6 +16,7 @@ Ext.define('Ung.apps.ipsecvpn.view.L2tpLog', {
 
     items: [{
         xtype: 'textarea',
+        readOnly: true,
         itemId: 'ipsecVirtualLog',
         spellcheck: false,
         padding: 0,

--- a/tunnel-vpn/js/view/Log.js
+++ b/tunnel-vpn/js/view/Log.js
@@ -16,6 +16,7 @@ Ext.define('Ung.apps.ipsecvpn.view.Log', {
 
     items: [{
         xtype: 'textarea',
+        readOnly: true,
         itemId: 'tunnelLog',
         spellcheck: false,
         padding: 0,


### PR DESCRIPTION

**Issue:** Log form fields in IPsec Vpn and Tunnel VPN are editable which should be read only.

**Fixed:** Added UI level restriction to make these fields readonly.

**Dev Tests:** 
1. Checked  all log form ipsec state, ipsec policy, ipsec log and L2TP log, after the fix these are not editable.
2. Also checked the log form of tunnel log, this is not editable.

**Before:**
![Screenshot from 2024-02-01 00-11-02](https://github.com/untangle/ngfw_src/assets/155290371/b600ec5f-f618-4a37-a587-3c2ed37c9a02)
**After:**
![Screenshot from 2024-02-01 00-08-33](https://github.com/untangle/ngfw_src/assets/155290371/b27aeb9a-b98e-4f91-93f7-abb7d2f4ce16)