### PR TITLE
NGFW-14380 Allowing specific characters for file type in virus blocker apps

### DIFF
--- a/virus-blocker-lite/js/view/Advanced.js
+++ b/virus-blocker-lite/js/view/Advanced.js
@@ -73,6 +73,8 @@ Ext.define('Ung.apps.virusblockerlite.view.Advanced', {
             fieldLabel: 'File Type'.t(),
             emptyText: '[enter file type]'.t(),
             allowBlank: false,
+            regex: RegExp("[\\?\\^\\w~!@#$-]+"),
+            regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # and $ only',
             width: 400
         }, {
             xtype: 'checkbox',

--- a/virus-blocker-lite/js/view/Advanced.js
+++ b/virus-blocker-lite/js/view/Advanced.js
@@ -74,7 +74,7 @@ Ext.define('Ung.apps.virusblockerlite.view.Advanced', {
             emptyText: '[enter file type]'.t(),
             allowBlank: false,
             regex: RegExp("[\\?\\^\\w~!@#$-]+"),
-            regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # and $ only',
+            regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # $ and - only',
             width: 400
         }, {
             xtype: 'checkbox',

--- a/virus-blocker/js/view/Advanced.js
+++ b/virus-blocker/js/view/Advanced.js
@@ -106,7 +106,7 @@ Ext.define('Ung.apps.virusblocker.view.Advanced', {
                 emptyText: '[enter file type]'.t(),
                 allowBlank: false,
                 regex: RegExp("[\\?\\^\\w~!@#$-]+"),
-                regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # and $ only',
+                regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # $ and - only',
                 width: 400
             }, {
                 xtype: 'checkbox',

--- a/virus-blocker/js/view/Advanced.js
+++ b/virus-blocker/js/view/Advanced.js
@@ -105,6 +105,8 @@ Ext.define('Ung.apps.virusblocker.view.Advanced', {
                 fieldLabel: 'File Type'.t(),
                 emptyText: '[enter file type]'.t(),
                 allowBlank: false,
+                regex: RegExp("[\\?\\^\\w~!@#$-]+"),
+                regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # and $ only',
                 width: 400
             }, {
                 xtype: 'checkbox',


### PR DESCRIPTION
- Using RegEx to allow alphanumeric and ^ ~ ! @ # $ - _ ? special characters only at the beginning of the file type extension for Virus Blocker and Virus Blocker Lite apps.
- Shows message for invalid character,
![Screenshot from 2024-02-01 19-23-09](https://github.com/untangle/ngfw_src/assets/154527616/f54e05fd-db2f-45c3-96d0-652ef86ae746)

![Screenshot from 2024-02-01 19-24-29](https://github.com/untangle/ngfw_src/assets/154527616/b0c84afc-e4b7-4c02-acd5-8cda97b7b713)


Ref: http://libs.gisi.ru/ext-6.2.0-docs/extjs/6.2.0/classic/Ext.form.field.Text.html#cfg-regex