### PR TITLE
NGFW-14380 Updated file type regex for virus blocker apps

### DIFF
--- a/virus-blocker-lite/js/view/Advanced.js
+++ b/virus-blocker-lite/js/view/Advanced.js
@@ -74,7 +74,7 @@ Ext.define('Ung.apps.virusblockerlite.view.Advanced', {
             emptyText: '[enter file type]'.t(),
             allowBlank: false,
             regex: RegExp("^[\\?\\^\\w~!@#$-]+"),
-            regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # $ and - only',
+            regexText: 'File type can only start with an alphanumeric character or any one of those special characters ? ^ _ ~ ! @ # $ and -'.t(),
             width: 400
         }, {
             xtype: 'checkbox',

--- a/virus-blocker-lite/js/view/Advanced.js
+++ b/virus-blocker-lite/js/view/Advanced.js
@@ -73,7 +73,7 @@ Ext.define('Ung.apps.virusblockerlite.view.Advanced', {
             fieldLabel: 'File Type'.t(),
             emptyText: '[enter file type]'.t(),
             allowBlank: false,
-            regex: RegExp("[\\?\\^\\w~!@#$-]+"),
+            regex: RegExp("^[\\?\\^\\w~!@#$-]+"),
             regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # $ and - only',
             width: 400
         }, {

--- a/virus-blocker/js/view/Advanced.js
+++ b/virus-blocker/js/view/Advanced.js
@@ -105,7 +105,7 @@ Ext.define('Ung.apps.virusblocker.view.Advanced', {
                 fieldLabel: 'File Type'.t(),
                 emptyText: '[enter file type]'.t(),
                 allowBlank: false,
-                regex: RegExp("[\\?\\^\\w~!@#$-]+"),
+                regex: RegExp("^[\\?\\^\\w~!@#$-]+"),
                 regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # $ and - only',
                 width: 400
             }, {

--- a/virus-blocker/js/view/Advanced.js
+++ b/virus-blocker/js/view/Advanced.js
@@ -106,7 +106,7 @@ Ext.define('Ung.apps.virusblocker.view.Advanced', {
                 emptyText: '[enter file type]'.t(),
                 allowBlank: false,
                 regex: RegExp("^[\\?\\^\\w~!@#$-]+"),
-                regexText: 'File type can start with an alphanumeric character and any one of those special characters ? ^ _ ~ ! @ # $ and - only',
+                regexText: 'File type can only start with an alphanumeric character or any one of those special characters ? ^ _ ~ ! @ # $ and -'.t(),
                 width: 400
             }, {
                 xtype: 'checkbox',


### PR DESCRIPTION
- Restricting first character to be alphanumeric or any one of those special characters ? ^ _ ~ ! @ # $ and -
- Earlier it was accepting a value that starts with restricted character followed by some string (for ex., `%test`) 