### PR TITLE
ngfw-14271: remove cloudhosted relay option

### DIFF
--- a/uvm/api/com/untangle/uvm/MailSettings.java
+++ b/uvm/api/com/untangle/uvm/MailSettings.java
@@ -17,7 +17,7 @@ public class MailSettings implements Serializable, JSONString
     public enum SendMethod { RELAY, DIRECT, CUSTOM } 
         
     private String fromAddress;
-    private SendMethod sendMethod = SendMethod.RELAY;
+    private SendMethod sendMethod = SendMethod.DIRECT;
     private String smtpHost;
     private int smtpPort = 25;
     private String authUser;

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_email.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_email.py
@@ -1,0 +1,46 @@
+import pytest
+import re
+import copy
+import time
+from tests.common import NGFWTestCase
+import tests.global_functions as global_functions
+import runtests
+import unittest
+import runtests.test_registry as test_registry
+
+@pytest.mark.email_tests
+class EmailTests(NGFWTestCase):
+
+    not_an_app= True
+
+    @staticmethod
+    def module_name():
+        return "email-tests"
+
+    @pytest.mark.slow
+    def test_010_mail_send_method_modes(self):
+        if runtests.quick_tests_only:
+            raise unittest.SkipTest('Skipping a time consuming test')
+
+        origMailsettings = global_functions.uvmContext.mailSender().getSettings()
+        #Default sendMethod Mode is DIRECT
+        assert (origMailsettings['sendMethod'] == 'DIRECT')
+
+        #Upgrade scenario simulating RELAY method 
+        newMailsettings = copy.deepcopy(origMailsettings)
+        newMailsettings['sendMethod'] = 'RELAY'
+
+        #Updating existing sendMethod mode to RELAY
+        global_functions.uvmContext.mailSender().setSettings(newMailsettings)
+        time.sleep(10) # give it time for exim to restart
+
+        #Upgrade method scenario is simulated, sendMethod mode set to RELAY
+        updatedMailSettings = global_functions.uvmContext.mailSender().getSettings()
+        assert (updatedMailSettings['sendMethod'] == 'RELAY')
+
+        #Restart UVM, this should set the sendMethod mode to DIRECT
+        uvmContext = global_functions.restart_uvm()
+        restartedMailSettings = uvmContext.mailSender().getSettings()
+        assert (restartedMailSettings['sendMethod'] == 'DIRECT')
+
+test_registry.register_module("email-tests", EmailTests)

--- a/uvm/impl/com/untangle/uvm/MailSenderImpl.java
+++ b/uvm/impl/com/untangle/uvm/MailSenderImpl.java
@@ -49,6 +49,7 @@ import com.untangle.uvm.MailSettings;
 import com.untangle.uvm.SettingsManager;
 import com.untangle.uvm.UvmContext;
 import com.untangle.uvm.UvmContextFactory;
+import com.untangle.uvm.MailSettings.SendMethod;
 import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.util.I18nUtil;
 
@@ -152,6 +153,14 @@ public class MailSenderImpl implements MailSender
 
             this.setSettings(settings);
         } else {
+            /**
+             * If the settings file  send method is RELAY then update it to DIRECT, re-sync
+            */
+            if (readSettings.getSendMethod() == MailSettings.SendMethod.RELAY) {
+                readSettings.setSendMethod(SendMethod.DIRECT);
+                this.setSettings(readSettings);
+                logger.info("Changing mail settings to Direct Settings: " + this.settings.toJSONString());
+            }
             this.settings = readSettings;
             logger.debug("Loading Settings: " + this.settings.toJSONString());
         }

--- a/uvm/servlets/admin/config/email/view/OutgoingServer.js
+++ b/uvm/servlets/admin/config/email/view/OutgoingServer.js
@@ -26,7 +26,6 @@ Ext.define('Ung.config.email.view.OutgoingServer', {
             columns: 1,
             vertical: true,
             items: [
-                { boxLabel: '<strong>' + 'Send email using the cloud hosted mail relay server'.t() + '</strong>', inputValue: 'RELAY' },
                 { boxLabel: '<strong>' + 'Send email directly'.t() + '</strong>', inputValue: 'DIRECT' },
                 { boxLabel: '<strong>' + 'Send email using the specified SMTP Server'.t() + '</strong>', inputValue: 'CUSTOM' }
             ]


### PR DESCRIPTION
@cblaise-untangle 

During investigation as per JIRA ticket
1. Mail relay through cloud hosted service is removed
     a. UI changes required: option removal from UI can be done in this file
          uvm/servlets/admin/config/email/view/OutgoingServer.js
     b. Backend changes
               /uvm/api/com/untangle/uvm/MailSettings.java:  this will require RELAY option to be changed to Direct
                /uvm/impl/com/untangle/uvm/MailSenderImpl.java  : 
                 email settings are saved in backed from UI using setSettings method in a local mail.js file at    /usr/share/untangle/settings/untangle- vm/mail.js. 
                there are some if conditions related to RELAY if (settings.getSendMethod() == MailSettings.SendMethod.RELAY) which needs to be removed along with other references
 2. On upgrades, if the user has this option selected it will switch to send directly
          query:  while upgrading, can we can update /usr/share/untangle/settings/untangle-vm/mail.js
 3.  On upgrades, if the user has this option enabled they receive the notice described above
       query: if we go with step 2 , tracking will be difficult as method is already updated to Direct. also here notice means notification ?  
       
For part 2 we will have make updates in following files
     /usr/share/untangle/settings/untangle-vm/mail.js, change RELAY to DIRECT
During setting of cloud hosted RELAY/DIRECT/CUSTOM options following files get modified
     1.     /etc/exim4/update-exim4.conf.conf
     2.     /etc/exim4/exim4.conf.template
Following fields get changed
      1. dc_eximconfig_configtype to satellite for RELAY option and internet for DIRECT option
      2. dc_smarthost to 127.0.0.2 for RELAY option and empty for DIRECT option
       3. port value changes to 2525 for RELAY and 25 for DIRECT option

 Approaches:
   1.  sync settings approach can be used, but new manager will be required and above 3 files needs to be modified. 
   2. MailSenderImpl since it is a singelton initialized during  created during init method of UVMContextimpl during startup,
         here we can look for existing settings during constructor creation and update if sendMethod is RELAY


I have tried out method 2 and this PR contains these changes. Please let me know your suggestions
After restarting the NGFW vm  PR changes have reflected


Regarding Tests:
There is mention of RELAY  in configure_mail_relay method of test_reports.py  in reports/hier/usr/lib/python3/dist-packages/tests. However on investigation an_relay is usually skipped if below function returns true, and all the methods are using DIRECT option as email.
can_relay = global_functions.send_test_email()
In above function definition smtb lib is being used to send email directly. It seems that testcases wont have any impact with this change, do we need to remove can_relay option in that case.







      



         `
       
       