### PR TITLE
ngfw-13495: remove snort files

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -2401,6 +2401,28 @@ class NetworkTests(NGFWTestCase):
         residual_files = find_files(dir_path, search_string)
         assert len(residual_files) == 0
 
+    def test_702_remove_snort_files(self):
+        """
+        Removing snort files
+        """
+        snort_file_name = '740-snort'
+        dir_path = '/etc/untangle/iptables-rules.d/'
+        search_string = '*-snort*'
+        # creating files with *-snort* extension
+        with open(dir_path + snort_file_name, "w") as f:
+            f.write("snort file test")
+
+        #*-snort* extension files are present
+        snort_files = find_files(dir_path, search_string)
+        print(snort_files)
+        assert len(snort_files) > 0
+        # Set settings forces sync-settings call
+        # Restore original settings to return to initial settings
+        uvmContext.networkManager().setNetworkSettings(orig_netsettings)
+        #sync settings should cleanup *-snort* extension files
+        snort_files = find_files(dir_path, search_string)
+        assert len(snort_files) == 0
+
 
     @classmethod
     def final_extra_tear_down(cls):


### PR DESCRIPTION
Problem: iptables rules for snort still exist, and these should be removed and the ips postinst updated to not have those. We use suricata now.

Changes:
The fix is addressed in PR https://github.com/untangle/sync-settings/pull/703
After changes are merged and built, follow the steps mentioned in above pr.

This PR adds a test case which will create a 740-snort ext file and runs sync settings which removes the snort file
![Screenshot from 2024-02-05 18-20-53](https://github.com/untangle/ngfw_src/assets/154513962/105c74e6-e39d-40f2-b61e-a22b4c881988)
