### PR TITLE
ngfw-14288 update static DHCP data on save settings

### DIFF
--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -144,6 +144,14 @@ Ext.define('Ung.config.network.MainController', {
             vm.set('settings.interfaces.list', Ext.Array.pluck(interfacesStore.getRange(), 'data'));
         }
 
+        // update static DHCP data
+        var dhcpStore = view.down('#dhcpEntries').getStore();
+        if(dhcpStore.getModifiedRecords().length > 0 ||
+            dhcpStore.getNewRecords().length > 0 ||
+            dhcpStore.getRemovedRecords().length > 0) {
+            vm.set('settings.staticDhcpEntries.list', Ext.Array.pluck(dhcpStore.getRange(), 'data'));
+        }
+
         // used to update all tabs data
         view.query('ungrid').forEach(function (grid) {
             var store = grid.getStore();
@@ -290,7 +298,7 @@ Ext.define('Ung.config.network.MainController', {
         var v = this.getView();
         var vm = this.getViewModel();
         var me = this;
-
+        
         // !!! on writes, set interface list.
 
         /**


### PR DESCRIPTION
Resolved the bug [NGFW-14288](https://awakesecurity.atlassian.net/browse/NGFW-14288)
Added code to update network settings object while saving settings in case static dhcp entries are modified, deleted or added.

Below are the screenshots for local testing.

Added two duplicate DHCP entries (Config --> Network --> DHCP Server). On clicking save we get error prompt.
![Screenshot from 2024-02-06 11-56-01](https://github.com/untangle/ngfw_src/assets/154422821/c7fe6541-ae2d-45e3-b8b7-17b7cadffe53)

After deleting one of the duplicate entry user is able to save the settings.
![Screenshot from 2024-02-06 11-56-16](https://github.com/untangle/ngfw_src/assets/154422821/90b21af3-e19b-4b5b-8b39-e1cf7dfc9924)

![Screenshot from 2024-02-06 11-56-22](https://github.com/untangle/ngfw_src/assets/154422821/b3d62a1e-7a5c-4db8-b4a6-cb8b6265d472)




[NGFW-14288]: https://awakesecurity.atlassian.net/browse/NGFW-14288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ