### PR TITLE
ngfw-13568: change password to passed

### DIFF
--- a/firewall/src/com/untangle/app/firewall/FirewallEvent.java
+++ b/firewall/src/com/untangle/app/firewall/FirewallEvent.java
@@ -69,7 +69,7 @@ public class FirewallEvent extends LogEvent
         if ( getBlocked() )
             action = I18nUtil.marktr("blocked");
         else
-            action = I18nUtil.marktr("password");
+            action = I18nUtil.marktr("passed");
             
         String summary = "Firewall " + action + " " + sessionEvent.toSummaryString();
         return summary;


### PR DESCRIPTION
Acceptance criteria:
      The event Summary field should begin with "Firewall passed ..." instead of "Firewall password"
      
Made required changes in FirewallEvent.java , 
During testing added firewall rule in firewall app to  unblock 13.59.216.148 80 port and it is being captured in firewall reports,
Firewall rule, note the rule id

![Screenshot from 2024-02-08 15-02-10](https://github.com/untangle/ngfw_src/assets/154513962/6bb54d3e-7bbb-4e0b-a80f-262f67341d3b)


Add alert rule in config/alerts as following
select class as  FirewallEvent and  for conditon select rule id, and value as obtained in above and save

![Screenshot from 2024-02-08 15-50-22](https://github.com/untangle/ngfw_src/assets/154513962/e5274ee8-23a4-4fef-a858-d9b1070f66af)

From test machine run following command
telnet 13.59.216.148 80 

Firewall rule executed
![Screenshot from 2024-02-08 15-02-37](https://github.com/untangle/ngfw_src/assets/154513962/46007b49-b03d-416f-b320-0a9cd6264516)

Event summary changed to passed instead of password

![Screenshot from 2024-02-08 15-36-41](https://github.com/untangle/ngfw_src/assets/154513962/d646e226-6bb5-4a05-b43a-cf1420c02008)


