### PR TITLE
ngfw-13410 portMatcher VType modified for ip port validation bug

### DIFF
--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -25,7 +25,7 @@ Ext.define('Ung.overrides.form.field.VTypes', {
 
     isSinglePortValid: function(val) {
         /* check for values between 0 and 65536 */
-        if (val < 0 || val > 65536) { return false; }
+        if (val < 1 || val > 65535) { return false; }
         /* verify its an integer (not a float) */
         if (!/^\d{1,5}$/.test(val)) { return false; }
         return true;
@@ -243,11 +243,11 @@ Ext.define('Ung.overrides.form.field.VTypes', {
         case 'any':
             return true;
         default:
-            if (val.indexOf('>') !== -1 && val.indexOf(',') === -1) {
-                return this.isSinglePortValid( val.substring( val.indexOf('>') + 1 ));
+            if (val.indexOf('>=') !== -1 && val.indexOf(',') === -1) {
+                return this.isSinglePortValid( val.substring( val.indexOf('>=') + 2 ));
             }
-            if (val.indexOf('<') !== -1 && val.indexOf(',') === -1) {
-                return this.isSinglePortValid( val.substring( val.indexOf('<') + 1 ));
+            if (val.indexOf('<=') !== -1 && val.indexOf(',') === -1) {
+                return this.isSinglePortValid( val.substring( val.indexOf('<=') + 2 ));
             }
             if (val.indexOf('-') === -1 && val.indexOf(',') === -1) {
                 return this.isSinglePortValid(val);

--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -249,6 +249,12 @@ Ext.define('Ung.overrides.form.field.VTypes', {
             if (val.indexOf('<=') !== -1 && val.indexOf(',') === -1) {
                 return this.isSinglePortValid( val.substring( val.indexOf('<=') + 2 ));
             }
+            if (val.indexOf('>') !== -1 && val.indexOf(',') === -1) {
+                return this.isSinglePortValid( /^(\s*)$/.test( val.substring( val.indexOf('>') + 1 ) ) ? 0 : Number( val.substring( val.indexOf('>') + 1 ) ) + 1 );
+            }
+            if (val.indexOf('<') !== -1 && val.indexOf(',') === -1) {
+                return this.isSinglePortValid( val.substring( val.indexOf('<') + 1 ) -1 );
+            }
             if (val.indexOf('-') === -1 && val.indexOf(',') === -1) {
                 return this.isSinglePortValid(val);
             }


### PR DESCRIPTION
Currently in NGFW router rules like NAT, Bypass and filter rules IP address port numbers 0 and 65536 are accepted.
Modified validation function to limit the range to **1-65536**.

While doing analysis found validation passing for `<1` and `>65535` inputs though these are invalid inputs. hence changed portMatcher function to accept only valid inputs like `<=1`(only one value is valid i.e. 1) and '>=65535' (only one value is valid i.e. 65535).

Local Testing Screenshots

![Screenshot from 2024-02-08 18-52-23](https://github.com/untangle/ngfw_src/assets/154422821/14281ab8-4bcd-4823-84bf-687aae2b7c3b)

![Screenshot from 2024-02-08 18-50-37](https://github.com/untangle/ngfw_src/assets/154422821/916ffca8-0df1-42e1-b72a-f5a77f88e4e6)

![Screenshot from 2024-02-08 18-56-11](https://github.com/untangle/ngfw_src/assets/154422821/4c11a702-9a70-4650-8569-3faa0e26a2b8)

![Screenshot from 2024-02-08 18-56-27](https://github.com/untangle/ngfw_src/assets/154422821/4d0a559c-6ca6-4b9b-a5b6-a71a8b9b4739)

![Screenshot from 2024-02-08 18-57-29](https://github.com/untangle/ngfw_src/assets/154422821/aad39a25-4cec-442b-a5c4-e7875a271ead)


![Screenshot from 2024-02-08 18-57-13](https://github.com/untangle/ngfw_src/assets/154422821/125042bf-1f4f-4575-bcb6-fde2917fdad2)




