### PR TITLE
ngfw-13889 added instruction to test connectivity on Internet page

### DIFF
--- a/uvm/servlets/setup/app/view/step/Internet.js
+++ b/uvm/servlets/setup/app/view/step/Internet.js
@@ -12,6 +12,11 @@ Ext.define('Ung.Setup.Internet', {
 
     border: 1,
     items: [{
+        xtype: 'component',
+        margin: '0 0 10 0',
+        hidden: rpc.setup.getRemoteReachable(),
+        html: '<p>' + "No Internet Connection..! Click on 'Test Connectivity' to verify.".t() + '</p>'
+    }, {
         xtype: 'container',
         layout: {
             type: 'hbox',


### PR DESCRIPTION
If NGFW is offline, during the Internet connection step, there was no clear instructions that the user has to press test connectivity to proceed to the next step.
Added the instruction _No Internet Connection..! Click on 'Test Connectivity' to verify._  if there is no internet connection.

Configure Internet Connection page at installation start up.
![Screenshot from 2024-02-09 18-52-30](https://github.com/untangle/ngfw_src/assets/154422821/de5eae2d-e708-4313-ab80-f058ed2a6d7f)


Configure Internet Connection page in local set up wizard
![Screenshot from 2024-02-09 11-53-18](https://github.com/untangle/ngfw_src/assets/154422821/78535de8-3a9c-41d7-a65e-816067c285e9)
