### PR TITLE
ngfw-13739: NGFW sending incorrect startTrial request

### DIFF
--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -450,12 +450,10 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
          * We do all these different calls so that the product supports any version of the license server
          */
         String libitemName = "untangle-libitem-" + appName;
-        String urlStr  = licenseUrl + "?action=startTrial" + "&node=" + appName + "&" + getServerParams();
-        String urlStr2 = licenseUrl + "?action=startTrial" + "&libitem=" + libitemName + "&" + getServerParams();
+        String urlStr = licenseUrl + "?action=startTrial" + "&libitem=" + libitemName + "&" + getServerParams();
 
         String oldName = null;
-        String urlStr3 = null;
-        String urlStr4 = null;
+        String urlStr1 = null;
         
         switch ( appName ) {
         case License.DIRECTORY_CONNECTOR:
@@ -491,8 +489,7 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
         }
         if ( oldName != null ) {
             String oldLibitemName = "untangle-libitem-" + oldName;
-            urlStr3 = licenseUrl + "?action=startTrial" + "&node=" + oldName + "&" + getServerParams();
-            urlStr4 = licenseUrl + "?action=startTrial" + "&libitem=" + oldLibitemName + "&" + getServerParams();
+            urlStr1 = licenseUrl + "?action=startTrial" + "&libitem=" + oldLibitemName + "&" + getServerParams();
         }
         
         CloseableHttpClient httpClient = HttpClients.custom().build();
@@ -507,25 +504,9 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
             response = httpClient.execute(get);
             if ( response != null ) { response.close(); response = null; }
             
-            if ( urlStr2 != null ) {
-                logger.info("Requesting Trial: " + urlStr2);
-                url = new URL(urlStr2);
-                get = new HttpGet(url.toString());
-                response = httpClient.execute(get);
-                if ( response != null ) { response.close(); response = null; }
-            }
-
-            if ( urlStr3 != null ) {
-                logger.info("Requesting Trial: " + urlStr3);
-                url = new URL(urlStr3);
-                get = new HttpGet(url.toString());
-                response = httpClient.execute(get);
-                if ( response != null ) { response.close(); response = null; }
-            }
-
-            if ( urlStr4 != null ) {
-                logger.info("Requesting Trial: " + urlStr4);
-                url = new URL(urlStr4);
+            if ( urlStr1 != null ) {
+                logger.info("Requesting Trial: " + urlStr1);
+                url = new URL(urlStr1);
                 get = new HttpGet(url.toString());
                 response = httpClient.execute(get);
                 if ( response != null ) { response.close(); response = null; }


### PR DESCRIPTION
Testing Steps


 Do a fresh install of NGFW, add ngfw in ETM, trial license should be applied
 change log level for license app from WARN to INFO

  nano /usr/share/untangle/conf/log4j.xml
   
<category name="com.untangle.uvm.license">
    <priority value="INFO"/>
  </category>

 restart uvm
  /etc/init.d/untangle-vm restart
  
 install spam-blocker app

verify that there will be entries for &node=spam-blocker &node=spamblocker (2 entries with &node for spam-blocker and spamblocker)
in /var/log/uvm/app-1.log

grep -R "node=spam" /var/log/uvm/app-1.log 

![Screenshot from 2024-02-12 11-21-31](https://github.com/untangle/ngfw_src/assets/154513962/0e44e75d-7fb2-4cee-b4ec-a64cf86f7509)

Apply the patch


install wan-failover app
verify that there will be no  entries for &node=wan-failover &node=faild (0 entries with &node for wan-failover and faild) in
/var/log/uvm/app-1.log

 grep -R "node=wan" /var/log/uvm/app-1.log 

![Screenshot from 2024-02-12 11-20-59](https://github.com/untangle/ngfw_src/assets/154513962/9a62c90b-db9d-45d3-bfd5-17a1710189f1)

 After test revert back original Log settings
 change log level for license app from INFO to WARN
nano /usr/share/untangle/conf/log4j.xml
<category name="com.untangle.uvm.license">
    <priority value="WARN"/>
  </category>
  
  restart uvm
/etc/init.d/untangle-vm restart