### PR TITLE
ngfw-13806: remove old license settings files

### DIFF
--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 
 import org.apache.log4j.Logger;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -64,7 +65,8 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
     private static final int    LIENENCY_CONSTANT = 5; /* the enforced seat limit is the license seat limit PLUS this value */
     private static final String LIENENCY_GIFT_FILE = System.getProperty("uvm.conf.dir") + "/gift"; /* the file that defines the gift value */
     private static final int    LIENENCY_GIFT = getLienencyGift(); /* and extra lienency constant */
-    
+    private static final int    LICENSE_FILES_COUNT = 5; /* no of License files to keep */
+
     public static final String DIRECTORY_CONNECTOR_OLDNAME = "adconnector";
     public static final String BANDWIDTH_CONTROL_OLDNAME = "bandwidth";
     public static final String CONFIGURATION_BACKUP_OLDNAME = "boxbackup";
@@ -1010,10 +1012,33 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                     _saveSettings(this.settings);
                 }
             }
+            _cleanLicenseFiles();
             _runAppManagerSync();
         }
 
         logger.info("Reloading licenses... done" );
+    }
+
+    /**
+     * Pruning old license files, keeping last 5 license files.
+     */
+    private void _cleanLicenseFiles() {
+        logger.info ("Cleaning old license files...");
+        File licenseDirectory = new File(System.getProperty("uvm.conf.dir") + "/licenses/");
+        try {
+            if (licenseDirectory.isDirectory()) {
+                File[] files = licenseDirectory.listFiles();
+                if (files != null && files.length > LICENSE_FILES_COUNT) {
+                    Arrays.stream(files)
+                          .sorted((f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()))
+                          .skip(LICENSE_FILES_COUNT)
+                          .forEach(File::delete);
+                }
+                logger.info ("Cleaning old license files... Done");
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to prune license files",e);
+        }
     }
 
     /**

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -16,6 +16,7 @@ import unittest
 import urllib.request, urllib.error, urllib.parse
 import urllib
 import urllib3
+import fnmatch
 
 from tests.common import NGFWTestCase
 from tests.global_functions import uvmContext
@@ -119,6 +120,12 @@ def check_javascript_exceptions(errors):
         pid = subprocess.check_output(f"ps -p $(cat /var/run/uvm.pid) -o pid=", shell=True).decode("utf-8")
         assert pid != "", "uvm running"
 
+def find_files(dir_path, search_string):
+    license_files = []
+    for root, dirs, files in os.walk(dir_path):
+        for filename in fnmatch.filter(files, search_string):
+            license_files.append(os.path.join(root, filename))
+    return license_files
 
 class TestTotp:
     """
@@ -1209,6 +1216,16 @@ class UvmTests(NGFWTestCase):
         feeddback_url = uvmContext.getFeedbackUrl()
         match = re.search('^https://edge.arista.com/feedback$', feeddback_url)
         assert(match)
+
+    def test_302_cleanup_license_files(self):
+        """
+        Ensure that last 5 license files are present
+        """
+        # This should prune no of license files to 5
+        uvmContext.licenseManager().reloadLicenses(False)
+        license_files = find_files("/usr/share/untangle/conf/licenses/", "*licenses.js*")
+        # verify pruned no of license files to <=5
+        assert len(license_files) <= 5
 
     def test_310_system_logs(self):
         subprocess.call(global_functions.build_wget_command(log_file="/dev/null", output_file="/tmp/system_logs.zip", post_data="type=SystemSupportLogs", uri="http://localhost/admin/download"), shell=True)

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -1217,12 +1217,17 @@ class UvmTests(NGFWTestCase):
         match = re.search('^https://edge.arista.com/feedback$', feeddback_url)
         assert(match)
 
+    @pytest.mark.slow
     def test_302_cleanup_license_files(self):
         """
         Ensure that last 5 license files are present
         """
+        if runtests.quick_tests_only:
+            raise unittest.SkipTest('Skipping a time consuming test')
         # This should prune no of license files to 5
-        uvmContext.licenseManager().reloadLicenses(False)
+        # Executing  reload license 6 times
+        for _ in range(6):
+            uvmContext.licenseManager().reloadLicenses(False)
         license_files = find_files("/usr/share/untangle/conf/licenses/", "*licenses.js*")
         # verify pruned no of license files to <=5
         assert len(license_files) <= 5


### PR DESCRIPTION
Acceptance Criteria: 
Keep last 5 days license files in (/usr/share/untangle/conf/licenses) and prune rest of them

This will prune number of license files to 5
Added test case to support this change.
PFA screenshot

![Screenshot from 2024-02-12 17-35-40](https://github.com/untangle/ngfw_src/assets/154513962/d033c3cf-164d-41f0-b20d-c62fd9f5a6af)

Initally no of files are > 5, after upgrade no of files is <=5 
![Screenshot from 2024-02-12 16-54-36](https://github.com/untangle/ngfw_src/assets/154513962/75597f3f-c22c-4866-93d9-8828efe6772d)

Testing steps:
1. Before upgrade
    cd /usr/share/untangle/conf/licenses
    ls -ltr    (number of license files > 5)
3. After Upgrade the ngfw with these changes 
     ls -ltr    (number of license files <= 5)

