### PR TITLE
ngfw-14177 not allowing blank values in tunnel vpn provider creds

### DIFF
--- a/tunnel-vpn/js/view/Tunnels.js
+++ b/tunnel-vpn/js/view/Tunnels.js
@@ -174,11 +174,13 @@ Ext.define('Ung.apps.tunnel-vpn.view.Tunnels', {
             disabled: '{tunnelProviderSelected == false}',
             hidden: '{tunnelUsernameHidden == true}'
         },
+        regex: /^(?!\s).*[^\s]$/,
+        regexText: 'Invalid Username, whitespaces at beginning or end are not allowed'.t()
     }, {
         xtype: 'textfield',
         fieldLabel: 'Password'.t(),
         inputType: 'password',
-        allowBlank: false,
+        allowOnlyWhitespace: false,
         bind: {
             value: '{record.password}',
             disabled: '{tunnelProviderSelected == false}',

--- a/tunnel-vpn/js/view/Tunnels.js
+++ b/tunnel-vpn/js/view/Tunnels.js
@@ -168,6 +168,7 @@ Ext.define('Ung.apps.tunnel-vpn.view.Tunnels', {
     }, {
         xtype: 'textfield',
         fieldLabel: 'Username'.t(),
+        allowBlank: false,
         bind: {
             value: '{record.username}',
             disabled: '{tunnelProviderSelected == false}',
@@ -177,6 +178,7 @@ Ext.define('Ung.apps.tunnel-vpn.view.Tunnels', {
         xtype: 'textfield',
         fieldLabel: 'Password'.t(),
         inputType: 'password',
+        allowBlank: false,
         bind: {
             value: '{record.password}',
             disabled: '{tunnelProviderSelected == false}',


### PR DESCRIPTION
While adding tunnel in Tunnel VPN app using provider with username and password fields, was able to add tunnel without username and password.
Made Username and password fields mandatory.

Local testing Screenshots

![Screenshot from 2024-02-12 19-10-52](https://github.com/untangle/ngfw_src/assets/154422821/3074eb68-08b4-4ea6-873b-69c2e3dd23a0)

![Screenshot from 2024-02-12 19-10-36](https://github.com/untangle/ngfw_src/assets/154422821/ac237015-6f02-400a-b295-7660c88295c3)
