### PR TITLE
ngfw-13407 static ip validation on configure internet page

### DIFF
--- a/uvm/servlets/setup/app/Application.js
+++ b/uvm/servlets/setup/app/Application.js
@@ -34,7 +34,13 @@ Ext.define('Ung.Setup', {
                 var pass_original = Ext.getCmp(field.comparePasswordField);
                 return val === pass_original.getValue();
             },
-            passwordConfirmCheckText: 'Passwords do not match'.t()
+            passwordConfirmCheckText: 'Passwords do not match'.t(),
+
+            ip4Address: function (val) {
+                return val.match(this.ip4AddressRegex);
+            },
+            ip4AddressText: 'Invalid IPv4 Address.'.t(),
+            ip4AddressRegex: /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
         });
     }
 });

--- a/uvm/servlets/setup/app/view/step/Internet.js
+++ b/uvm/servlets/setup/app/view/step/Internet.js
@@ -76,7 +76,7 @@ Ext.define('Ung.Setup.Internet', {
                     msgTarget: 'side',
                     validationEvent: 'blur',
                     maskRe: /(\d+|\.)/,
-                    vtype: 'ipAddress',
+                    vtype: 'ip4Address',
                     disabled: true,
                     bind: {
                         disabled: '{wan.v4ConfigType !== "STATIC"}'
@@ -95,7 +95,8 @@ Ext.define('Ung.Setup.Internet', {
                     value: 24,
                     bind: { value: '{wan.v4StaticPrefix}' },
                     editable: false,
-                    allowBlank: false
+                    allowBlank: false,
+                    vtype: 'ipAddress'
                 }, {
                     fieldLabel: 'Gateway'.t(),
                     allowBlank: false,


### PR DESCRIPTION
1. Added V-Type `ip4Address` in `Application.js` to validate Static IP fields on Configure Internet Connection Page.
2. Changed the default validation for STATIC container from  `ipAddress` to `ip4Address` and overwritten validation for Netmask Field to `ipAddress`.


Local Testing Screenshots
![Screenshot from 2024-02-13 14-32-06](https://github.com/untangle/ngfw_src/assets/154422821/1ad2c1be-5885-4021-93ad-15eceadc443f)
![Screenshot from 2024-02-13 14-31-15](https://github.com/untangle/ngfw_src/assets/154422821/68c97a01-fae5-428f-a3d8-aade5a60b517)
