### PR TITLE
ngfw-13910 updating help link and using uri manager to access it

### DIFF
--- a/buildtools/uri-analyzer.py
+++ b/buildtools/uri-analyzer.py
@@ -83,7 +83,7 @@ class UriAnalyzer():
         "https://www.edge.arista.com/favicon.ico",
         "https://edge.arista.com/legal",
 
-        "http://wiki.edge.arista.com/get.php",
+        "https://wiki.edge.arista.com/get.php",
         "https://edge.arista.com/feedback",
 
         # From test_network.py

--- a/uvm/api/com/untangle/uvm/UriManagerSettings.java
+++ b/uvm/api/com/untangle/uvm/UriManagerSettings.java
@@ -16,7 +16,7 @@ import org.json.JSONObject;
 @SuppressWarnings("serial")
 public class UriManagerSettings implements Serializable, JSONString
 {
-    private Integer version = 3;
+    private Integer version = 5;
     private List<UriTranslation> uriTranslations = new LinkedList<>();
 
     private String dnsTestHost = "updates.untangle.com";

--- a/uvm/impl/com/untangle/uvm/UriManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/UriManagerImpl.java
@@ -326,6 +326,10 @@ public class UriManagerImpl implements UriManager
         uriTranslation.setUri("https://launchpad.edge.arista.com/");
         uriTranslations.add(uriTranslation);
 
+        uriTranslation = new UriTranslation();
+        uriTranslation.setUri("https://wiki.edge.arista.com/get.php");
+        uriTranslations.add(uriTranslation);
+
         settings.setUriTranslations(uriTranslations);
 
         mergeOverrideSettings(settings);

--- a/uvm/impl/com/untangle/uvm/UriManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/UriManagerImpl.java
@@ -23,7 +23,7 @@ import com.untangle.uvm.SettingsManager;
  */
 public class UriManagerImpl implements UriManager
 {
-    private static final Integer SettingsCurrentVersion = 4;
+    private static final Integer SettingsCurrentVersion = 5;
 
     private static final String URIS_OVERRIDE_FILE_NAME = System.getProperty("uvm.conf.dir") + "/uris_override.js";
 
@@ -412,12 +412,8 @@ public class UriManagerImpl implements UriManager
         List<UriTranslation> uriTranslations = settings.getUriTranslations();
 
         UriTranslation uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://edge.arista.com/api/v1");
-        uriTranslations.add(uriTranslation);
-
-        uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://launchpad.edge.arista.com/");
-        uriTranslations.add(uriTranslation);
+        uriTranslation.setUri("https://wiki.edge.arista.com/get.php");
+        uriTranslations.add(uriTranslation);        
 
         settings.setUriTranslations(uriTranslations);
 

--- a/uvm/impl/com/untangle/uvm/UvmContextImpl.java
+++ b/uvm/impl/com/untangle/uvm/UvmContextImpl.java
@@ -71,7 +71,7 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
     private static final String PROPERTY_CMD_URL = "uvm.cmd.url";
     private static final String DEFAULT_CMD_URL = "https://launchpad.edge.arista.com/";
     private static final String PROPERTY_HELP_URL = "uvm.help.url";
-    private static final String DEFAULT_HELP_URL = "http://wiki.edge.arista.com/get.php";
+    private static final String DEFAULT_HELP_URL = "https://wiki.edge.arista.com/get.php";
     private static final String PROPERTY_FEEDBACK_URL = "uvm.feedback.url";
     private static final String DEFAULT_FEEDBACK_URL = "https://edge.arista.com/feedback";
     private static final String PROPERTY_LEGAL_URL = "uvm.legal.url";
@@ -1194,7 +1194,7 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
         String url = System.getProperty(PROPERTY_HELP_URL);
         if (url == null)
             url = DEFAULT_HELP_URL;
-        return url;
+        return uriManager.getUri(url);
     }
 
     /**


### PR DESCRIPTION
1. Help linked modified to use HTTPS.
2. Using `UriManager` to store link and get the link.
3. Updated `untangle-region-eu` Package,  Added help base url `https://wiki.edge.arista.com/get.php` in uris_override.js file 
    [PR ngfw_pkgs](https://github.com/untangle/ngfw_pkgs/pull/92)


Local Testing:

- Built the updated package `untangle-region-eu` using command `PACKAGE=untangle-region-eu FORCE=1 VERBOSE=1 UPLOAD=local docker compose -f docker-compose.build.yml run build`.

- Installed the package on local NGFW

- Added logs to track whether `UriTranslations` is getting correctly updated.

![Screenshot from 2024-02-14 13-23-39](https://github.com/untangle/ngfw_src/assets/154422821/df87bf7d-3bbf-42aa-9ce6-f87b8dfda975)
![Screenshot from 2024-02-14 13-22-58](https://github.com/untangle/ngfw_src/assets/154422821/cf2add9e-ce75-4802-b2e4-1d0ae0f4e88e)

- Built the changes in local and tested help button on UI

![Screenshot from 2024-02-14 13-31-09](https://github.com/untangle/ngfw_src/assets/154422821/05ae4f96-64b4-4f26-a4c8-e111139c0d55)

- Verified url in logs using `/var/log/uvm/uvm.log` file.

![Screenshot from 2024-02-14 13-26-11](https://github.com/untangle/ngfw_src/assets/154422821/07ea07a4-d3dc-4d3c-b709-df36d73e04da)
![Screenshot from 2024-02-14 13-25-34](https://github.com/untangle/ngfw_src/assets/154422821/7fda68dc-748b-488b-bdf5-a1b0a803e6d8)

- Removed logs added for testing
