### PR TITLE
NGFW-14069 : UI discrepancy in NGFW Interface Status

### DIFF
--- a/uvm/js/common/ungrid/RecordDetailsController.js
+++ b/uvm/js/common/ungrid/RecordDetailsController.js
@@ -5,7 +5,7 @@ Ext.define('Ung.cmp.RecordDetailsController', {
 
     onBeforeRender: function (view) {
         var me = this, masterGrid = view.up().down('grid'), sourceConfig = {};
-
+        
         masterGrid.getView().on('select', me.masterGridSelect, me);
 
         Ext.Array.each(masterGrid.getColumns(), function (column) {
@@ -17,7 +17,7 @@ Ext.define('Ung.cmp.RecordDetailsController', {
 
             sourceConfig[column.dataIndex] = {
                 displayName: displayName,
-                renderer: column.renderer || null
+                renderer: Column.renderer || null
             };
         });
 
@@ -30,23 +30,24 @@ Ext.define('Ung.cmp.RecordDetailsController', {
      */
     masterGridSelect: function (grid, record) {
         var me = this, recordData, data = {}, category;
-
-        if (!record) { return; }
+       
 
         recordData = record.getData();
-
+        
+        if (recordData.name == 'name' || recordData.name == 'value') { return; }
+        
         // delete extra non relevant attributes
         delete recordData._id;
         delete recordData.javaClass;
         delete recordData.state;
         delete recordData.attachments;
         delete recordData.tags;
-
-        Ext.Object.each(recordData, function(key, value) {
-            data[key] = value;
-        });
-        me.getView().setSource(data, me.sourceConfig);
-    },
+           
+            Ext.Object.each(recordData, function(key, value) {
+                data[key] = value;
+            });
+            me.getView().setSource(data, me.sourceConfig);
+              },
 
     /**
      * Used for extra column actions which can be added to the grid but are very specific to that context

--- a/uvm/js/common/ungrid/RecordDetailsController.js
+++ b/uvm/js/common/ungrid/RecordDetailsController.js
@@ -32,23 +32,23 @@ Ext.define('Ung.cmp.RecordDetailsController', {
      */
     masterGridSelect: function (grid, record) {
         var me = this, recordData, data = {}, category;
-        
+
         if (!record) { return; }
 
         recordData = record.getData();
-                
+
         // delete extra non relevant attributes
         delete recordData._id;
         delete recordData.javaClass;
         delete recordData.state;
         delete recordData.attachments;
         delete recordData.tags;
-           
+
         Ext.Object.each(recordData, function(key, value) {
             data[key] = value;
         });
         me.getView().setSource(data, me.sourceConfig);
-            },
+    },
 
     /**
      * Used for extra column actions which can be added to the grid but are very specific to that context

--- a/uvm/js/common/ungrid/RecordDetailsController.js
+++ b/uvm/js/common/ungrid/RecordDetailsController.js
@@ -5,23 +5,25 @@ Ext.define('Ung.cmp.RecordDetailsController', {
 
     onBeforeRender: function (view) {
         var me = this, masterGrid = view.up().down('grid'), sourceConfig = {};
-        
-        masterGrid.getView().on('select', me.masterGridSelect, me);
 
-        Ext.Array.each(masterGrid.getColumns(), function (column) {
-            if (!column.dataIndex) { return; }
-            var displayName = column.text;
-            if (column.ownerCt.text) {
-                displayName = column.ownerCt.text + ' ' + displayName;
-            }
+        if(me.getView() != masterGrid){
+            masterGrid.getView().on('select', me.masterGridSelect, me);
 
-            sourceConfig[column.dataIndex] = {
-                displayName: displayName,
-                renderer: Column.renderer || null
-            };
-        });
+            Ext.Array.each(masterGrid.getColumns(), function (column) {
+                if (!column.dataIndex) { return; }
+                var displayName = column.text;
+                if (column.ownerCt.text) {
+                    displayName = column.ownerCt.text + ' ' + displayName;
+                }
 
-        me.sourceConfig = sourceConfig;
+                sourceConfig[column.dataIndex] = {
+                    displayName: displayName,
+                    renderer: column.renderer || null
+                };
+            });
+
+            me.sourceConfig = sourceConfig;
+        }
     },
 
     /**
@@ -30,12 +32,11 @@ Ext.define('Ung.cmp.RecordDetailsController', {
      */
     masterGridSelect: function (grid, record) {
         var me = this, recordData, data = {}, category;
-       
+        
+        if (!record) { return; }
 
         recordData = record.getData();
-        
-        if (recordData.name == 'name' || recordData.name == 'value') { return; }
-        
+                
         // delete extra non relevant attributes
         delete recordData._id;
         delete recordData.javaClass;
@@ -43,11 +44,11 @@ Ext.define('Ung.cmp.RecordDetailsController', {
         delete recordData.attachments;
         delete recordData.tags;
            
-            Ext.Object.each(recordData, function(key, value) {
-                data[key] = value;
-            });
-            me.getView().setSource(data, me.sourceConfig);
-              },
+        Ext.Object.each(recordData, function(key, value) {
+            data[key] = value;
+        });
+        me.getView().setSource(data, me.sourceConfig);
+            },
 
     /**
      * Used for extra column actions which can be added to the grid but are very specific to that context


### PR DESCRIPTION
**Issue:** 
This issue comprises two separate issues:

This issue is also persisted in config->Advanced->networkCards.

1. The value field for each datum is blank as shown in video.
2. Each row can be selected multiple times because onBeforeRender is calling each time while selecting the field.
https://github.com/untangle/ngfw_src/blob/c9cd422718f7b3075292fefc0a46aececd3050e9/uvm/js/common/ungrid/RecordDetailsController.js#L45


**Note:**
As per discussion with @cblaise-untangle the filed should not be selectable once rendered in Grid. So done the changes and testing as per suggestion.

**Fix:**
- Put a condition to render mastergrid only once.

**Test:**
Testing of this fix includes multiple forms:
1.  Config-> Interface -> status
2.  Advanced -> networkCards ->status
3. Devices
4. Hosts
5. Users
6. Sessions

All has been tested locally and everything working as expected in JIRA.


