### PR TITLE
Test language removed and rsync added

### DIFF
--- a/.vscode/vsbuild.sh
+++ b/.vscode/vsbuild.sh
@@ -95,7 +95,8 @@ for target_address in "${TARGET_ADDRESSES[@]}"; do
     rsync -a -e "ssh -p $port" dist/usr/share/java/uvm/* root@$target_address:/usr/share/java/uvm
     rsync -a -e "ssh -p $port" dist/usr/share/untangle/bin root@$target_address:/usr/share/untangle
     rsync -a -e "ssh -p $port" dist/usr/share/untangle/lib root@$target_address:/usr/share/untangle
-    rsync -a -e "ssh -p $port"  dist/usr/share/untangle/web root@$target_address:/usr/share/untangle
+    rsync -a -e "ssh -p $port" dist/usr/share/untangle/web root@$target_address:/usr/share/untangle
+    rsync -a -e "ssh -p $port" dist/usr/share/untangle/lang/lang.cfg root@$target_address:/usr/share/untangle/lang
 
     ssh -p $port root@$target_address "systemctl daemon-reload"
 

--- a/uvm/hier/usr/share/untangle/lang/lang.cfg
+++ b/uvm/hier/usr/share/untangle/lang/lang.cfg
@@ -179,7 +179,6 @@ vo	Volapük
 wa	Walloon
 wo	Wolof
 xh	Xhosa
-xx      Test
 yi	Yiddish
 yo	Yoruba
 za	Zhuang


### PR DESCRIPTION
**Issue** : Extra test entry present in the language file.

**Fix** : 
1) Removed extra entry, also added rsync for that file.
2) Restart the UVM : /etc/init.d/untangle-vm restart

before :
![Screenshot from 2024-02-15 11-14-41](https://github.com/untangle/ngfw_src/assets/154496583/35b5cf01-9437-45c6-93b4-95df319a11bf)

after :
![Screenshot from 2024-02-15 11-26-11](https://github.com/untangle/ngfw_src/assets/154496583/3dd898ce-23f6-4c28-89d7-a95190e51013)