### PR TITLE
ngfw-13690: syslog Syslog SClientAddr != conditional filter doesn't work

### DIFF
--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -1299,7 +1299,8 @@ public class EventManagerImpl implements EventManager
             if ( ! rule.getEnabled() ){
                 continue;
             }
-            if ( ! rule.isMatch( jsonObject ) ){
+            //use jsonSendObject instead of jsonObject as ip addresses start with /
+            if ( ! rule.isMatch( jsonSendObject ) ){
                 continue;
             }
 


### PR DESCRIPTION
Issue: NGFW events with SClientAddr != <specified ip > should not be sent to syslog reciever 

RCA:
In EventManagerImpl class, runSyslogRules method for LogEvent object is converted to  two JSONObjects,
jsonObject and jsonSendObject, the jsonSendObject is further sanitized using cleanupJsonObject method,

During syslog rule validation  jsonObject is used presently, so the value of SClientAddr starts with "/" i.e. "/192.168.1.100" 
during matching/validation it is compared with syslog rule which has  value "192.168.1.100" and condition as "!=" for SClientAddr,
which never matches and logs are sent to syslog reciever to irrespective of the rule.

PFA debugging screenshot without fix, refer "valueStr" and "fieldValue" of compared jsonobject and rule object respectively
match is shown as false

![Screenshot from 2024-02-15 17-39-43](https://github.com/untangle/ngfw_src/assets/154513962/07a93b53-e7bd-48f0-8fe5-c718ba793087)


Inorder to fix this sanitized jsonSendObject (LogEvent)  shoud be passed in isMatch() method instead of jsonObject
After fix snapshot, match is true as both "valueStr" and "fieldValue" are equal
![Screenshot from 2024-02-15 17-53-30](https://github.com/untangle/ngfw_src/assets/154513962/91215692-1faf-4118-8021-ea5d18be4c6e)


Configuration steps:
1. Set up syslogserver reciever in a new debian box in the same network as NGFW
Refer this document https://www.linuxtechi.com/setup-rsyslog-server-on-debian/
2.  Enable Config>Events>Syslog>"Enable Remote Syslog" and configure the NGFW to send syslog to the appropriate syslog receiver.
3. Add a rule similar to screenshot.
![image](https://github.com/untangle/ngfw_src/assets/154513962/fff371e5-098a-412f-aed8-7e1ddadc6a77)
in above case ip is 192.168.1.100, which happens to be NGFW ip. 
After configuration is complete , logs should reach syslog server


Testing steps:

Before Upgrade events with SClientAddr!=192.168.1.00 will be sent to syslog server. This can be verified by following command, 

`tail -f /var/log/syslog | grep '"SClientAddr":"192.168.1.100"'`

After Upgrade events with SClientAddr!=192.168.1.00 will be stopped being sent to syslog server. This can be verified by following command, no output should be seen.

`tail -f /var/log/syslog | grep '"SClientAddr":"192.168.1.100"'`