### PR TITLE
ngfw-13720: Failed connection page after setup wizard refers to App Store

### DIFF
--- a/uvm/servlets/admin/app/view/main/Offline.js
+++ b/uvm/servlets/admin/app/view/main/Offline.js
@@ -22,8 +22,8 @@ Ext.define('Ung.view.main.Offline', {
         }, {
             xtype: 'component',
             html: '<h3>' + 'Welcome!'.t() + '</h3>' +
-                '<p>' + 'The installation is complete and ready for deployment. The next step are registration and installing apps from the App Store.'.t() + '</p>' +
-                '<p style="color: red;">' + 'Unfortunately, Your server was unable to contact the App Store.'.t() + '</p>' +
+                '<p>' + 'The installation is complete and ready for deployment. The next steps are registration and installing apps from the APPS menu.'.t() + '</p>' +
+                '<p style="color: red;">' + 'Unfortunately, Your server was unable to connect to the internet.'.t() + '</p>' +
                 '<p>' + 'Before Installing apps, this must be resolved.'.t() + '</p>' +
                 '<p><strong>' + 'Possible Resolutions'.t() + '</strong></p>' +
                 '<ol><li>' + 'Verify the network settings are correct and the Connectivity Test succeeds.'.t() + '</li>' +


### PR DESCRIPTION
Testing Steps
Set up NGFW without Internet access and refer to the final step after saying yes to connecting to Command Center.

Expected:

- The next steps are registration and installing apps from the APPS menu.
- Your server was unable to connect to the internet.

Actual:

- The next step are registration and installing apps from the App Store.
- Your server was unable to contact the App Store.

Before making changes, PFA screenshot:
<img width="693" alt="Screen Shot 2021-04-22 at 3 16 10 PM" src="https://github.com/untangle/ngfw_src/assets/154513962/8b4ab3c4-5b77-48ad-8319-8326656dad72">



After making changes , PFA  screenshot
![Screenshot from 2024-02-16 16-58-56](https://github.com/untangle/ngfw_src/assets/154513962/981f9f53-3863-4d28-ae3b-5ea0b0e84741)

@cblaise-untangle "installing apps from the APPS menu."  APPS menu is fine or something else should be used here.


