### PR TITLE
ngfw-14283: Offline setup with non admin password

### DIFF
--- a/uvm/servlets/setup/app/view/Main.js
+++ b/uvm/servlets/setup/app/view/Main.js
@@ -171,19 +171,24 @@ Ext.define('Ung.Setup.Main', {
                 if(Util.setRpcJsonrpc("admin") == true){
                     me.resetWizardContinue();
                 }else{
-                    var msg = Ext.create('Ext.window.MessageBox');
-                    msg.textField.inputType = 'password';
-
-                    msg.prompt(
-                        'Authentication required'.t(),
-                        'Please enter admin password'.t(), function(btn, p) {
-                            if (btn === 'ok') {
-                                Util.authenticate(p, function () {
-                                    me.resetWizardContinue();
-                                });
-                            }
+                    Util.authenticate("passwd", function (isNonDefaultPassword) {
+                        if (isNonDefaultPassword) {
+                            var msg = Ext.create('Ext.window.MessageBox');
+                            msg.textField.inputType = 'password';
+                            msg.prompt(
+                                'Authentication required'.t(),
+                                'Please enter admin password'.t(), function(btn, p) {
+                                    if (btn === 'ok') {
+                                        Util.authenticate(p, function (flag) {
+                                            me.resetWizardContinue();
+                                        });
+                                    }
+                                }
+                            );
+                        } else {
+                            me.resetWizardContinue();
                         }
-                    );
+                    });
                 }
             }else{
                 me.resetWizardContinue();

--- a/uvm/servlets/setup/app/view/Main.js
+++ b/uvm/servlets/setup/app/view/Main.js
@@ -171,9 +171,19 @@ Ext.define('Ung.Setup.Main', {
                 if(Util.setRpcJsonrpc("admin") == true){
                     me.resetWizardContinue();
                 }else{
-                    Util.authenticate("passwd", function () {
-                        me.resetWizardContinue();
-                    });
+                    var msg = Ext.create('Ext.window.MessageBox');
+                    msg.textField.inputType = 'password';
+
+                    msg.prompt(
+                        'Authentication required'.t(),
+                        'Please enter admin password'.t(), function(btn, p) {
+                            if (btn === 'ok') {
+                                Util.authenticate(p, function () {
+                                    me.resetWizardContinue();
+                                });
+                            }
+                        }
+                    );
                 }
             }else{
                 me.resetWizardContinue();

--- a/uvm/servlets/setup/app/view/Util.js
+++ b/uvm/servlets/setup/app/view/Util.js
@@ -31,8 +31,14 @@ Ext.define('Ung.Setup.Util', {
             success: function (response) {
                 // Ung.app.loading(false);
                 if (response.responseText && response.responseText.indexOf('loginPage') != -1) {
-                    Ext.MessageBox.alert('Authentication failed'.t(), 'Invalid password.'.t());
-                    return;
+                    //Check default password, if true callback otherwise existing flow
+                    if (password == "passwd") {
+                        cb(true);
+                        return;
+                    } else {
+                        Ext.MessageBox.alert('Authentication failed'.t(), 'Invalid password.'.t());
+                        return;
+                    }
                 }
 
                 Util.setRpcJsonrpc("admin");


### PR DESCRIPTION
If attempting to start the offline setup wizard on a device that already has an non admin password set, you will get an "Authentication failed" popup and will not be able to progress.

Steps to Reproduce: 
1. Add an NGFW to an ETMD account and configure an admin password for it.
2. Disconnect the WAN from the NGFW.
3. Navigate to Config > System > Support and press the "Launch Setup Wizard" option
4. attempt to complete the offline wizard.

Step 3 not present in UI

RCA:
if internet is not present on device and device has a non-default admin password,  then  Offline setup wizard cannot be started and error is shown as invalid password because, in that scenario in Main.js
following code is called, which has default admin password hardcoded
 ```
Util.authenticate("passwd", function () {
     me.resetWizardContinue();
 });

```
We can fix this by prompting for admin password, after which Offline setup wizard can be started successfully.

Testing steps:

1. Add an NGFW to an ETMD account and configure an admin password for it.
2. Disconnect the WAN from the NGFW.
3. attempt to complete the offline wizard.

- Bring up NGFW with these changes
- change NGFW password to a different password  (pass123), using following command

```
cd /usr/share/untangle/bin
python3 ut-set-admin-passwd.py pass123

```
Follow steps 1,2,3 

There are 2 possibilities here,  NGFW password may or may not get updated based on timing of execution of step 2 

- During step1 password update will happen after adding device from ETM account, in this case updated password can be used while setting up offline wizard.
- Password update may not happen depending upon the timing of disconnection of wan in that case use the password which was set using command line i.e (pass123)





