### PR TITLE
NGFW-13561 Regex validation for Keep Alive setting in Wireguard VPN

### DIFF
--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -29,6 +29,8 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
         bind: {
             value: '{settings.keepaliveInterval}'
         },
+        regex: RegExp("^[1-9]\\d*$"),
+        regexText: 'Only accepts valid positive integer.'.t(),
         allowBlank: false
     },{
         fieldLabel: 'MTU'.t(),


### PR DESCRIPTION
Validation for KeepAlive field,

Accepts: 50, 120, 50000
Rejects: -1, --1, 0, 00, 0120, 10-, 500000 (digits more than 5)

![image](https://github.com/untangle/ngfw_src/assets/154527616/e8954115-b8ba-4247-abef-d44f7dcf46e2)
