### PR TITLE
ngfw-13472 added validator for staticAddress field in Alias IPv4

### DIFF
--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -520,7 +520,7 @@ Ext.define('Ung.config.network.Interface', {
                 listProperty: 'v4Aliases',
                 maxHeight: 140,
                 emptyRow: {
-                    staticAddress: '1.2.3.4',
+                    staticAddress: '',
                     staticPrefix: '24',
                     javaClass: 'com.untangle.uvm.network.InterfaceSettings$InterfaceAlias'
                 },
@@ -534,29 +534,32 @@ Ext.define('Ung.config.network.Interface', {
                         emptyText: '[enter IPv4 address]'.t(),
                         allowBlank: false,
                         validator: function(value) {
-                            // Check for default IP Address    
-                            if(value == '1.2.3.4') return "Deafult address, Modify IPv4 address".t();
+                            if(this.dirty) {
+                                // Check if current value is eqaul to original value
+                                if(this.value === this.originalValue) return true;
 
-                            var aliasStore = this.up('grid').getStore(),
-                                intfStore = this.up('config-network').getViewModel().getStore('interfaces'),
-                                intfName = this.up('window').down('#iterfacename').getValue();
+                                var aliasStore = this.up('grid').getStore(),
+                                    intfStore = this.up('config-network').getViewModel().getStore('interfaces'),
+                                    intfName = this.up('window').down('#iterfacename').getValue();
 
-                            // Check for duplicate IP Address in same interface
-                            var duplicateAliases = aliasStore.findBy(function(aliasRecord){
-                                return aliasRecord.get('staticAddress') == value;
-                            });
-                            if(duplicateAliases !== -1) return "Duplicate IPv4 alias address".t();
-                            
-                            // Check for duplicate IP Address in other interfaces
-                            var index = intfStore.findBy(function(intfRecord) {      
-                                if(intfRecord.get('name') != intfName) {
-                                    duplicateAliases = intfRecord.get('v4Aliases').list.filter(function(alias) {
-                                        return alias.staticAddress == value;
-                                    });
-                                    return duplicateAliases.length > 0;
-                                }                   
-                            });
-                            return index === -1 ? true : "Interface with this alias IPv4 address already exists".t();
+                                // Check for duplicate IP Address in same interface
+                                var duplicateAliases = aliasStore.findBy(function(aliasRecord){
+                                    return aliasRecord.get('staticAddress') == value;
+                                });
+                                if(duplicateAliases !== -1) return "Duplicate IPv4 alias address".t();
+                                
+                                // Check for duplicate IP Address in other interfaces
+                                var index = intfStore.findBy(function(intfRecord) {      
+                                    if(intfRecord.get('name') != intfName) {
+                                        duplicateAliases = intfRecord.get('v4Aliases').list.filter(function(alias) {
+                                            return alias.staticAddress == value;
+                                        });
+                                        return duplicateAliases.length > 0;
+                                    }                   
+                                });
+                                return index === -1 ? true : "Interface with this alias IPv4 address already exists".t();
+                            }   
+                            else return true;                          
                         }
                     }
                 }, {

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -33,6 +33,7 @@ Ext.define('Ung.config.network.Interface', {
                 xtype: 'textfield',
                 fieldLabel: 'Interface Name'.t(),
                 width: 400,
+                itemId: 'iterfacename',
                 name: 'interfaceName',
                 allowOnlyWhitespace: false,
                 regex: /^[^!#$%^&]+$/,
@@ -531,7 +532,32 @@ Ext.define('Ung.config.network.Interface', {
                         xtype: 'textfield',
                         vtype: 'ip4Address',
                         emptyText: '[enter IPv4 address]'.t(),
-                        allowBlank: false
+                        allowBlank: false,
+                        validator: function(value) {
+                            // Check for default IP Address    
+                            if(value == '1.2.3.4') return "Deafult address, Modify IPv4 address".t();
+
+                            var aliasStore = this.up('grid').getStore(),
+                                intfStore = this.up('config-network').getViewModel().getStore('interfaces'),
+                                intfName = this.up('window').down('#iterfacename').getValue();
+
+                            // Check for duplicate IP Address in same interface
+                            var duplicateAliases = aliasStore.findBy(function(aliasRecord){
+                                return aliasRecord.get('staticAddress') == value;
+                            });
+                            if(duplicateAliases !== -1) return "Duplicate IPv4 alias address".t();
+                            
+                            // Check for duplicate IP Address in other interfaces
+                            var index = intfStore.findBy(function(intfRecord) {      
+                                if(intfRecord.get('name') != intfName) {
+                                    duplicateAliases = intfRecord.get('v4Aliases').list.filter(function(alias) {
+                                        return alias.staticAddress == value;
+                                    });
+                                    return duplicateAliases.length > 0;
+                                }                   
+                            });
+                            return index === -1 ? true : "Interface with this alias IPv4 address already exists".t();
+                        }
                     }
                 }, {
                     header: 'Netmask / Prefix'.t(),

--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -1385,6 +1385,9 @@ Ext.define('Ung.config.network.MainController', {
                 store.getNewRecords().length > 0 ||
                 store.getRemovedRecords().length > 0) {
                 store.each(function (record) {
+                    if(record.get('staticAddress') == '') {
+                        record.set('markedForDelete', true);
+                    }
                     if (record.get('markedForDelete')) {
                         record.drop();
                     }


### PR DESCRIPTION
Added a validation function to _IPv4 Aliases_ tab In _Add/Edit VLAN Interface_ window.

1. default alias address is set to  blank string `''`. If user does not change it he will be shown validation error `This field is required`. If he still continues with default address the record will be dropped on clicking `Done` button.

![Screenshot from 2024-02-22 18-34-49](https://github.com/untangle/ngfw_src/assets/154422821/1437fd5e-7ff2-4d30-aaaa-c704ca2bc926)



2. Validator checks for duplicate alias address in same Interface. If found it returns error string `Duplicate IPv4 alias address` and won't allow user to add duplicate address.

![Screenshot from 2024-02-22 18-35-18](https://github.com/untangle/ngfw_src/assets/154422821/b5c1389f-08a9-43b2-96fe-a1f8d020aee8)



3. Validator checks for duplicate alias address in other all interfaces. If found it returns error string `Interface with this alias IPv4 address already exists` and won't allow user to add duplicate address.

![Screenshot from 2024-02-22 18-37-36](https://github.com/untangle/ngfw_src/assets/154422821/10071d32-f531-4a9a-ae49-e232452eec84)



