### PR TITLE
NGFW-13434: Interface names are able to be the same as another interface

### DIFF
--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -40,21 +40,13 @@ Ext.define('Ung.config.network.Interface', {
                 bind: '{intf.name}',
                 validator: function(value) {
                     var store = this.up('tabpanel').getViewModel().getStore('interfaces');
-                    var title = this.up('window').title;
                     var currentInterfaceName = this.up('window').getViewModel().get('intf.name');
                 
                     // Check if a record with the same name exists in the store
                     var isNameUnique = store.findBy(function(record) {
                         return record.get('name') === value;
                     }) === -1;
-                
-                    // If the title indicates it's adding a VLAN interface, simply check for uniqueness
-                    if (title === 'Add VLAN Interface') {
-                        return isNameUnique ? true : 'Interface name already exists.'.t();
-                    } else {
-                        // If it's editing an existing interface, ensure that the new name is either unique or matches the current interface name
-                        return (value === currentInterfaceName || isNameUnique) ? true : 'Interface name already exists.'.t();
-                    }
+                    return (value === currentInterfaceName || isNameUnique) ? true : 'Interface name already exists.'.t();
                 }      
             }, {
                 xtype: 'container',

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -40,20 +40,22 @@ Ext.define('Ung.config.network.Interface', {
                 bind: '{intf.name}',
                 validator: function(value) {
                     var store = this.up('tabpanel').getViewModel().getStore('interfaces');
-                    var title = this.up('window').getConfig().title;
-                    //To check new VLAN interface creation
-                    if(title === 'Add VLAN Interface')
-                    {
-                        //To validate unique interface name
-                        var index = store.findBy(function(record){
-                            return record.get('name') === value;
-                        });
-                        return (index === -1 ) ? true : 'Interface name already exists.'.t();
+                    var title = this.up('window').title;
+                    var currentInterfaceName = this.up('window').getViewModel().get('intf.name');
+                
+                    // Check if a record with the same name exists in the store
+                    var isNameUnique = store.findBy(function(record) {
+                        return record.get('name') === value;
+                    }) === -1;
+                
+                    // If the title indicates it's adding a VLAN interface, simply check for uniqueness
+                    if (title === 'Add VLAN Interface') {
+                        return isNameUnique ? true : 'Interface name already exists.'.t();
+                    } else {
+                        // If it's editing an existing interface, ensure that the new name is either unique or matches the current interface name
+                        return (value === currentInterfaceName || isNameUnique) ? true : 'Interface name already exists.'.t();
                     }
-                    else{
-                        return true;
-                    }
-                }
+                }      
             }, {
                 xtype: 'container',
                 layout: { type: 'hbox' },

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -37,7 +37,23 @@ Ext.define('Ung.config.network.Interface', {
                 allowOnlyWhitespace: false,
                 regex: /^[^!#$%^&]+$/,
                 regexText: 'This field can have alphanumerics or special characters other than ! # $ % ^ &'.t(),
-                bind: '{intf.name}'
+                bind: '{intf.name}',
+                validator: function(value) {
+                    var store = this.up('tabpanel').getViewModel().getStore('interfaces');
+                    var title = this.up('window').getConfig().title;
+                    //To check new VLAN interface creation
+                    if(title === 'Add VLAN Interface')
+                    {
+                        //To validate unique interface name
+                        var index = store.findBy(function(record){
+                            return record.get('name') === value;
+                        });
+                        return (index === -1 ) ? true : 'Interface name already exists.'.t();
+                    }
+                    else{
+                        return true;
+                    }
+                }
             }, {
                 xtype: 'container',
                 layout: { type: 'hbox' },


### PR DESCRIPTION
**ISSUE:** Interface name should not be same 

**FIX:**  Adding validation to check uniqueness of interface name while creating VLAN interface

**TEST:**  
Tested below case:
1- While adding new VLAN Interface

![Screenshot from 2024-02-20 20-35-44](https://github.com/untangle/ngfw_src/assets/155290371/2ae5eb5e-c52f-46b5-80c4-11ee18c31701)

2- While updating existing VLAN Interface

 a. Trying to update interface name with already existing name.
![Screenshot from 2024-02-20 20-35-22](https://github.com/untangle/ngfw_src/assets/155290371/24491e83-f882-4583-a3f1-c6a71932dda0)

  b.Trying to update other filed in edit form
![Screenshot from 2024-02-20 20-35-11](https://github.com/untangle/ngfw_src/assets/155290371/19751dcf-2f3e-4c9a-b61d-1388a4e18be0)

