### PR TITLE
NGFW-14005 Handling IllegalArgumentException while downloading licenses

### DIFF
--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -704,7 +704,7 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
         } catch (SettingsManager.SettingsException e) {
             logger.error("Unable to read license file: ", e );
             return success;
-        } catch (ClassCastException e) {
+        } catch (IllegalArgumentException | ClassCastException e) {
             logger.error("downloadLicenses returned unexpected response",e);
             return success;
         }


### PR DESCRIPTION
Although we do check for the connectivity before downloading the licenses, there may be a possibility that the connectivity is lost after our test. To allow reading licenses from the local file we must catch IllegalArgumentException that is being thrown from `loadUrl()` method.