### PR TITLE
ngfw-13247 removing copy action for Tunnel VPN - Tunnels

### DIFF
--- a/tunnel-vpn/js/view/Tunnels.js
+++ b/tunnel-vpn/js/view/Tunnels.js
@@ -35,9 +35,7 @@ Ext.define('Ung.apps.tunnel-vpn.view.Tunnels', {
 
     emptyText: 'No Tunnels defined'.t(),
 
-    recordActions: ['edit', 'copy', 'delete'],
-    copyId: 'tunnelId',
-    copyAppendField: 'name',
+    recordActions: ['edit', 'delete'],
     listProperty: 'settings.tunnels.list',
 
     bind: '{tunnels}',


### PR DESCRIPTION
Removing copy action from Apps --> Tunnel VPN --> Tunnels as every record should have separate configuration file and it should not be copied.

![Screenshot from 2024-02-22 11-42-51](https://github.com/untangle/ngfw_src/assets/154422821/5856df73-188b-404a-a16c-28d4d969e06b)
