### PR TITLE
ngfw-14514 OpenVPN Download client configuration verbiage updated

### DIFF
--- a/openvpn/js/MainController.js
+++ b/openvpn/js/MainController.js
@@ -381,7 +381,7 @@ Ext.define('Ung.apps.openvpn.SpecialGridController', {
                 },{
                   name: 'downloadGenericConfigurationFile',
                   type: 'ovpn',
-                  message: 'Click here to download this client\'s configuration as a single ovpn file with all certificates included inline (For use with OpenVPN Connect App).'.t()
+                  message: 'Click here to download this client\'s configuration as a single ovpn file with all certificates included inline (For use with OpenVPN Community Edition).'.t()
                 },{
                   name: 'downloadChromebookConfigurationFile',
                   type: 'onc',


### PR DESCRIPTION
Updated **Get Client Configuration** verbiage in OpenVPN App from `Click here to download this client\'s configuration as a single ovpn file with all certificates included inline (For use with OpenVPN Connect App).`  to `Click here to download this client\'s configuration as a single ovpn file with all certificates included inline (For use with OpenVPN Community Edition).`

Path - Apps --> OpenVPN --> Server --> Remote Clients --> Get Client Configuration

![Screenshot from 2024-02-23 12-02-43](https://github.com/untangle/ngfw_src/assets/154422821/39d23174-61ed-4372-bc71-2946631885e7)
