### PR TITLE
ngfw-13541 validation added for Lan ipv4 netmask

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -568,6 +568,15 @@ Ext.define('Ung.util.Util', {
         return data;
     },
 
+    getV4NetmaskMap: function(includeNull) {
+        var map = {}, data = this.getV4NetmaskList(includeNull);
+        
+        data.forEach(function(element) {
+            map[element[0]] = element[1];
+        });
+        return map;
+    },
+
     validateForms: function (view) {
         var invalidFields = [];
 

--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -568,11 +568,10 @@ Ext.define('Ung.util.Util', {
         return data;
     },
 
-    getV4NetmaskMap: function(includeNull) {
-        var map = {}, data = this.getV4NetmaskList(includeNull);
-        
+    getV4NetmaskMap: function() {
+        var map = {}, data = this.getV4NetmaskList();
         data.forEach(function(element) {
-            map[element[0]] = element[1];
+            map[element[0]] = element[1].split('-')[1].trim();
         });
         return map;
     },

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -397,7 +397,25 @@ Ext.define('Ung.config.network.Interface', {
                     allowBlank: false,
                     editable: false,
                     store: Util.getV4NetmaskList(false),
-                    queryMode: 'local'
+                    queryMode: 'local',
+                    validator: function(value) {
+                        var isWan = this.up('window').down('#isWanCk').getValue(),
+                            intfName = this.up('window').down('#iterfacename').getValue();
+
+                        if(!isWan) {
+                            var intfStore = this.up('config-network').getViewModel().getStore('interfaces'),
+                                intfRecName;                       
+                            var index = intfStore.findBy(function(intfRecord) {  
+                                
+                                intfRecName = intfRecord.get('name');
+                                if(intfName == intfRecName) return false;
+
+                                return !intfRecord.get('isWan') && (value != Util.getV4NetmaskMap()[intfRecord.get('v4StaticPrefix')]);
+                            });
+                            return index === -1 ? true : "Conflicting Netmask for Interfaces ".t() + intfName + " and ".t() + intfRecName;
+                        } 
+                        else return true;
+                    }
                 }, {
                     // static gateway
                     xtype: 'textfield',

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -408,7 +408,7 @@ Ext.define('Ung.config.network.Interface', {
                             network = Util.getNetwork(v4StaticAddress, netMask);
                             return Util.ipMatchesNetwork(value, network, netMask);
                         });
-                        return index === -1 ? true : Ext.String.format('Conflicting Netmask for Interfaces {0} and {1}'.t(), intfName, intfRecName);
+                        return index === -1 ? true : Ext.String.format('Conflicting Network for IP Addresses in Interfaces {0} and {1}'.t(), intfName, intfRecName);
                     }
                 }, {
                     // static netmask

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -408,7 +408,7 @@ Ext.define('Ung.config.network.Interface', {
                             network = Util.getNetwork(v4StaticAddress, netMask);
                             return Util.ipMatchesNetwork(value, network, netMask);
                         });
-                        return index === -1 ? true : Ext.String.format('Conflicting Network for IP Addresses in Interfaces {0} and {1}'.t(), intfName, intfRecName);
+                        return index === -1 ? true : Ext.String.format('Conflicting networks between interfaces {0} and {1}'.t(), intfName, intfRecName);
                     }
                 }, {
                     // static netmask


### PR DESCRIPTION
Added a validator for IPv4 Address Field for ADDRESSED and STATIC Interface configurations such that conflicting IPv4 addresses can't be saved.

Local Testing Screenshots

If user tries to enter the address conflicting with any of the ADDRESSED and STATIC configured IPv4 Interface, error message will be shown - `Conflicting Netmask for Interfaces {interface1} and {interface2}` 

![Screenshot from 2024-02-27 10-55-24](https://github.com/untangle/ngfw_src/assets/154422821/9501b4dd-5949-4398-99d0-fe0c7e399b65)

![Screenshot from 2024-02-27 10-57-25](https://github.com/untangle/ngfw_src/assets/154422821/2ae6b090-cea4-4700-836e-31dbae658dbe)


![Screenshot from 2024-02-27 11-00-44](https://github.com/untangle/ngfw_src/assets/154422821/16683ef4-cf61-4591-bd7d-7d98a84e639d)

![Screenshot from 2024-02-27 11-01-13](https://github.com/untangle/ngfw_src/assets/154422821/6974ed4e-48d5-4b39-9d77-f626d901de09)

![Screenshot from 2024-02-27 11-01-42](https://github.com/untangle/ngfw_src/assets/154422821/041f0266-5d38-45f3-837c-39db212acb00)




