### PR TITLE
NGFW-13500 Fixed openssl remote clients backend exception

### DIFF
--- a/openvpn/js/view/Server.js
+++ b/openvpn/js/view/Server.js
@@ -289,6 +289,7 @@ Ext.define('Ung.apps.openvpn.cmp.RemoteClientsGrid', {
     }, {
         xtype: 'textfield',
         fieldLabel: 'Remote Networks'.t(),
+        emptyText: '[Enter comma separated list of networks in CIDR format]'.t(),
         bind: {
             value: '{record.exportNetwork}',
             disabled: '{!record.export}',

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.BufferedReader;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.apache.log4j.Logger;
 
@@ -1234,10 +1235,10 @@ public class OpenVpnAppImpl extends AppBase
         // add reservation for all exported networks in configured remote clients        
         for (OpenVpnRemoteClient client : remoteClients) {
             if (client.getExport()) {
-                String networks = client.getExportNetwork();
-                for (String network : networks.split(",")) {
-                    if (network.length() == 0) continue;
-                    nsmgr.registerNetworkBlock(NETSPACE_OWNER, NETSPACE_REMOTE, networks);
+                String networksCsv = client.getExportNetwork();
+                for (String network : networksCsv.split(",")) {
+                    if (StringUtils.isBlank(network)) continue;
+                    nsmgr.registerNetworkBlock(NETSPACE_OWNER, NETSPACE_REMOTE, network);
                 }
             }
         }


### PR DESCRIPTION
Fixed backend parameter to register the remote client network. We are now able to save remote client network addresses.
![image](https://github.com/untangle/ngfw_src/assets/154527616/1c1c6593-fb13-4998-91d2-0f14a66d1f00)

Added emptyText to the field
![image](https://github.com/untangle/ngfw_src/assets/154527616/0d21d97d-d9e9-47b9-b3df-6ddad3f8b3e4)
