### PR TITLE
NGFW-13435: Added validator To Have Unique VlanTag Under SameParent Device

### DIFF
--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -89,23 +89,21 @@ Ext.define('Ung.config.network.Interface', {
                     validator: function(value) {
                         var store = this.up('tabpanel').getViewModel().getStore('interfaces');
                         var currentViewModel = this.up('window').getViewModel();
-
-                            // Convert value to integer
-                            var intValue = parseInt(value, 10);
-
-                            // Find records matching both vlanTag and vlanParent
-                            var matchedRecords = store.queryBy(function(record) {
-                                return record.get('vlanTag') === intValue && record.get('vlanParent') === currentViewModel.get('intf.vlanParent');
-                            });
-
-                            if (matchedRecords.getCount() > 0) {
-                                var matchedRecord = matchedRecords.first(); 
-                                if (matchedRecord.get('name') !== currentViewModel.get('intf.name')) {
-                                    return 'VLAN Tag ' + value + ' is already matched with interface ' + matchedRecord.get('name');
-                                }
+                                        
+                        // Find records matching both vlanTag and vlanParent
+                        var matchedRecords = store.queryBy(function(record) {
+                            var recordVlanTag = Ext.String.format("{0}", record.get('vlanTag'));
+                            return recordVlanTag === value && record.get('vlanParent') === currentViewModel.get('intf.vlanParent');
+                        });
+                    
+                        if (matchedRecords.getCount() > 0) {
+                            var matchedRecord = matchedRecords.first(); 
+                            if (matchedRecord.get('name') !== currentViewModel.get('intf.name')) {
+                                return Ext.String.format('VLAN Tag {0} is already matched with interface {1}'.t(), value, matchedRecord.get('name'));
                             }
+                        }
                         return true; 
-                    }
+                    }                                        
                 }]
             }, {
                 // config type

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -85,7 +85,27 @@ Ext.define('Ung.config.network.Interface', {
                     },
                     minValue: 1,
                     maxValue: 4094,
-                    allowBlank: false
+                    allowBlank: false,
+                    validator: function(value) {
+                        var store = this.up('tabpanel').getViewModel().getStore('interfaces');
+                        var currentViewModel = this.up('window').getViewModel();
+
+                            // Convert value to integer
+                            var intValue = parseInt(value, 10);
+
+                            // Find records matching both vlanTag and vlanParent
+                            var matchedRecords = store.queryBy(function(record) {
+                                return record.get('vlanTag') === intValue && record.get('vlanParent') === currentViewModel.get('intf.vlanParent');
+                            });
+
+                            if (matchedRecords.getCount() > 0) {
+                                var matchedRecord = matchedRecords.first(); 
+                                if (matchedRecord.get('name') !== currentViewModel.get('intf.name')) {
+                                    return 'VLAN Tag ' + value + ' is already matched with interface ' + matchedRecord.get('name');
+                                }
+                            }
+                        return true; 
+                    }
                 }]
             }, {
                 // config type


### PR DESCRIPTION
**ISSUE:** Vlan Tag can be created with same name.

**FIX:** Added validator to allow unique VlanTag under same parent device.

**TESTING STEPS:**  

1. Go to : Config>Network>Interface
2. Validate that no two devices which have the same parent device can have the same VLAN tag.
3.  Validate if the parent is different, then devices can have the same tag attached.
![Screenshot from 2024-02-26 17-04-57](https://github.com/untangle/ngfw_src/assets/155290371/6287723a-a8bf-4e29-85b5-381d7cdedf07)
![Screenshot from 2024-02-26 17-02-24](https://github.com/untangle/ngfw_src/assets/155290371/292667dd-c7dc-4af6-8ce1-cae75cb0a4fa)
![Screenshot from 2024-02-26 17-01-52](https://github.com/untangle/ngfw_src/assets/155290371/4360e551-8b8c-4623-b60c-81f9ea4c7bcd)
![Screenshot from 2024-02-26 16-44-18](https://github.com/untangle/ngfw_src/assets/155290371/b3b42d26-970c-4c4b-972a-b7fbeed287b4)

