### PR TITLE
NGFW-13849: Fixed the regex to validate CIDR entry

### DIFF
--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -18,7 +18,7 @@ Ext.define('Ung.overrides.form.field.VTypes', {
         domainNameRe: /^[a-zA-Z0-9\-_.]+$/,
         urlAddrRe: /^(([^:\/?#]+:)?(?:\/\/((?:([^\/?#:]*):([^\/?#:]*)@)?([^\/?#:]*)(?::([^\/?#:]*))?)))?([^?#]*)(\?[^#]*)?(#.*)?$/,
         cidrAddrRe: /^([0-9]{1,3}\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[1-9])(\/([0-9]|[1-2][0-9]|3[0-2]))?$/,
-        cidrBlockRe: /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$/,
+        cidrBlockRe: /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))$/,
         cidrBlockOnlyRangeRe: /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-1]))$/,
         hostNameRe: /^[a-zA-Z0-9\-_.]+$/
     },
@@ -212,7 +212,7 @@ Ext.define('Ung.overrides.form.field.VTypes', {
     domainNameText: 'A domain can only contain numbers, letters, dashes and periods, and must not start with a period.'.t(),
 
     cidrBlock:  function (v) {
-        return (this.mask.cidrBlockRe.test(v));
+                return (this.mask.cidrBlockRe.test(v));
     },
     cidrBlockText: 'Must be a network in CIDR format.'.t() + ' ' + '(192.168.123.0/24)',
 

--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -212,7 +212,7 @@ Ext.define('Ung.overrides.form.field.VTypes', {
     domainNameText: 'A domain can only contain numbers, letters, dashes and periods, and must not start with a period.'.t(),
 
     cidrBlock:  function (v) {
-                return (this.mask.cidrBlockRe.test(v));
+        return (this.mask.cidrBlockRe.test(v));
     },
     cidrBlockText: 'Must be a network in CIDR format.'.t() + ' ' + '(192.168.123.0/24)',
 


### PR DESCRIPTION
**ISSUE:**  Fields which supposed to have CIDR notation, can be saved without CIDR notation.

**FIX:** Fixed the regex to make CIDR notation mandate.

**TEST:** This change will apply to multiple apps.
Below fields needs to be tested:
1. Apps>OpenVPN>Server>Exported Networks>Add>Network Field
2. Apps>IpsecVPN>GreNetworks>GRE Address Pool Field
3. Apps>IpsecVPN>IpsecTunnels>Local Network Field
4. Apps>IpsecVPN>IpsecTunnels>Remote Network Field
5. Apps>IpsecVPN> VpnConfig>virtual Address Pool Field
6. Apps>WireGuardVPN>Setting>Network Address Field
7. Apps>WireGuardVPN>Tunnels>Remote Networks Field

![Screenshot from 2024-02-27 15-28-49](https://github.com/untangle/ngfw_src/assets/155290371/43cca1b7-feb1-4e32-b2e3-23996d8c1b06)

