### PR TITLE
ngfw-13479 validator added for wiregurad vpn - Network Space

### DIFF
--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -127,6 +127,12 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                         value: '{settings.addressPool}',
                         disabled: '{settings.autoAddressAssignment}',
                         editable: '{!settings.autoAddressAssignment}'
+                    },
+                    validator: function(value) {
+                        if(this.dirty) {
+                            var ntwkSpace = rpc.UvmContext.netspaceManager().isNetworkAvailable('wireguard-vpn', value.trim());   
+                            return !ntwkSpace ? true : "Address pool conflict".t();
+                        } else return true;
                     }
                 },
                 {


### PR DESCRIPTION
Added validator for Network Space on Page - WireGuard VPN --> Settings.

If user enters conflicting ip address with network address pool then below error will be shown and user won't be able to save settings.

![Screenshot from 2024-02-27 23-47-28](https://github.com/untangle/ngfw_src/assets/154422821/3b0ecbad-13a6-455a-8f5d-c4a23fd95255)

![Screenshot from 2024-02-27 23-47-56](https://github.com/untangle/ngfw_src/assets/154422821/5b131855-c7cf-4c2b-8866-48f97aa0e81f)

![Screenshot from 2024-02-27 23-54-13](https://github.com/untangle/ngfw_src/assets/154422821/3b8d22a3-9119-4096-8f45-4c9f65591543)


