### PR TITLE
ngfw-14530: New WebFilter Categories need to be in report libary

### DIFF
--- a/uvm/js/common/util/Renderer.js
+++ b/uvm/js/common/util/Renderer.js
@@ -671,7 +671,11 @@ Ext.define('Ung.util.Renderer', {
         79: "Fashion and Beauty",
         80: "Recreation and Hobbies",
         81: "Motor Vehicles",
-        82: "Web Hosting"
+        82: "Web Hosting",
+        85: "Self Harm",
+        86: "DNS Over HTTPS",
+        87: "Low-THC Cannabis Products",
+        88: "Generative AI"
     },
     webCategory: function(value, row, record){
         if(value == Renderer.listKey){

--- a/uvm/js/common/util/_Map.js
+++ b/uvm/js/common/util/_Map.js
@@ -1672,7 +1672,11 @@ Ext.define('Ung.util.Map', {
         79: 'Fashion and Beauty',
         80: 'Recreation and Hobbies',
         81: 'Motor Vehicles',
-        82: 'Web Hosting'
+        82: 'Web Hosting',
+        85: "Self Harm",
+        86: "DNS Over HTTPS",
+        87: "Low-THC Cannabis Products",
+        88: "Generative AI"
     },
 
     protocols: {


### PR DESCRIPTION
Acceptance criteria: 
Add New WebFilter Categories, for report library

85, "Self Harm
86, "DNS Over HTTPS"
87, "Low-THC Cannabis Products"
88, "Generative AI"

Testing steps:


1. Block and flag  access to DNS Over HTTPS, Generative AI,  Alcohol and Tobacco from App web filter categories tab
![Screenshot from 2024-02-28 15-59-11](https://github.com/untangle/ngfw_src/assets/154513962/7d7425d4-f175-414e-8be1-33ddc60b3b31)

2. Search for this site which is  related to DNS Over Https in browser (https://cloudflare-dns.com/dns-query?name=example.com&type=A) from client behind NGFW

Ideally Webfilter should block this site, however NGFW's bright cloud definitions classify it under web category Proxy Avoidance and Anonymizers, which might be due to bright cloud definitions not being updated, unless they are not updated it will not be classified.

Verified this site (https://cloudflare-dns.com/dns-query?name=example.com&type=A) on https://www.brightcloud.com/tools/url-ip-lookup.php which gives category as DNS Over Https


![Screenshot from 2024-02-28 16-59-11](https://github.com/untangle/ngfw_src/assets/154513962/6ab7b3ea-6539-4e5c-8d42-c0f67cbff289)


Testing steps
3. Search for https://www.marlboro.com/ in browser  from client behind NGFW

-   Webfilter should block this site

-   Inorder to verify whether newly created categories are visible in report library manually updated record entries webfilter_category_id (76, Alcohol and Tobacco in db to above ids (88, 86, 85,88), 
- newly added categories should be seen in the reports library

Database commands : 
Note: change table name as applicable
login into db using password as per applicable, change user if required

```
psql -U postgres

 \c uvm;

select web_filter_category_id from reports.http_events_2024_02_28 where web_filter_blocked is TRUE;
   
update reports.http_events_2024_02_28 set web_filter_category_id=88 where web_filter_blocked is TRUE and web_filter_category_id=76;
```

![Screenshot from 2024-02-28 16-56-57](https://github.com/untangle/ngfw_src/assets/154513962/b22af03d-836f-4fa7-b71e-556d7123ae22)

webfilter category Generative AI, DNS Over HTTPS can be seen in above screenshot

