### PR TITLE
ngfw-14198 Not allowing 0.0.0.0/0 for interface ipv4 addresses

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -526,7 +526,7 @@ Ext.define('Ung.util.Util', {
         }).show();
     },
 
-    getV4NetmaskList: function(includeNull) {
+    getV4NetmaskList: function(includeNull, excludeZero) {
         var data = [];
         if (includeNull) {
             data.push( [null,'\u00a0'] );
@@ -563,7 +563,9 @@ Ext.define('Ung.util.Util', {
         data.push( [3,'/3 - 224.0.0.0'] );
         data.push( [2,'/2 - 192.0.0.0'] );
         data.push( [1,'/1 - 128.0.0.0'] );
-        data.push( [0,'/0 - 0.0.0.0'] );
+        if(!excludeZero) {
+            data.push( [0,'/0 - 0.0.0.0'] );
+        }
 
         return data;
     },

--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -160,6 +160,11 @@ Ext.define('Ung.overrides.form.field.VTypes', {
     },
     ip4AddressText: 'Invalid IPv4 Address.'.t(),
 
+    ip4AddExcldDflt: function (val) {
+        return this.ip4Address(val) && (val != '0.0.0.0');
+    },
+    ip4AddExcldDfltText: 'Invalid IPv4 Address, Default route not allowed'.t(),
+
     ip4AddressList:  function (v) {
         var addr = v.split(','), i;
         for (i = 0 ; i < addr.length ; i += 1) {

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -239,7 +239,7 @@ Ext.define('Ung.config.network.Interface', {
                             value: '{intf.v4AutoAddressOverride}',
                             emptyText: '{intf.v4Address}'
                         },
-                        vtype: 'ip4Address',
+                        vtype: 'ip4AddExcldDflt',
                     }, {
                         xtype: 'displayfield',
                         margin: '0 5',
@@ -270,7 +270,7 @@ Ext.define('Ung.config.network.Interface', {
                         },
                         editable: false,
                         fieldLabel: 'Netmask Override'.t(),
-                        store: Util.getV4NetmaskList(true),
+                        store: Util.getV4NetmaskList(true, true),
                         queryMode: 'local'
                     }, {
                         xtype: 'displayfield',
@@ -404,7 +404,7 @@ Ext.define('Ung.config.network.Interface', {
                     fieldLabel: 'Address'.t(),
                     allowBlank: false,
                     blankText: 'Address must be specified.'.t(),
-                    vtype: 'ip4Address',
+                    vtype: 'ip4AddExcldDflt',
                     validator: function(value) {
                         var intfName = this.up('window').down('#iterfacename').getValue(),
                             intfStore = this.up('config-network').getViewModel().getStore('interfaces'),
@@ -437,7 +437,7 @@ Ext.define('Ung.config.network.Interface', {
                     fieldLabel: 'Netmask'.t(),
                     allowBlank: false,
                     editable: false,
-                    store: Util.getV4NetmaskList(false),
+                    store: Util.getV4NetmaskList(false, true),
                     queryMode: 'local'
                 }, {
                     // static gateway
@@ -1080,14 +1080,14 @@ Ext.define('Ung.config.network.Interface', {
                     xtype: 'textfield',
                     bind: '{intf.dhcpGatewayOverride}',
                     fieldLabel: 'Gateway Override'.t(),
-                    vtype: 'ip4Address',
+                    vtype: 'ip4AddExcldDflt',
                 }, {
                     // netmask override
                     xtype: 'combo',
                     bind: '{intf.dhcpPrefixOverride}',
                     fieldLabel: 'Netmask Override'.t(),
                     editable: false,
-                    store: Util.getV4NetmaskList(false),
+                    store: Util.getV4NetmaskList(false, true),
                     queryMode: 'local'
                 }, {
                     // dns override


### PR DESCRIPTION
Not allowing 0.0.0.0/0 for interface IPv4 address fields at

- Interfaces --> Add/Edit Interface --> IPv4 Configuration --> Static
- Interfaces --> Add/Edit Interface --> IPv4 Configuration --> Auto (DHCP)
- Interfaces --> Add/Edit Interface --> DHCP Configuration

![Screenshot from 2024-02-28 23-48-12](https://github.com/untangle/ngfw_src/assets/154422821/f13d2ca0-dbe1-4fcc-ab57-39abcb5c2b97)

![Screenshot from 2024-02-28 23-48-53](https://github.com/untangle/ngfw_src/assets/154422821/4b3d96f3-8556-4403-9e84-09ca00153ac2)

![Screenshot from 2024-02-28 23-49-25](https://github.com/untangle/ngfw_src/assets/154422821/1f6dad3e-1e81-4df4-b6fd-c2b95f359430)


