### PR TITLE
NGFW-13482: Added validation for Wireguard VPN Tunnel form

### DIFF
--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -110,6 +110,9 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         allowBlank: false,
         bind: {
             value: '{record.description}'
+        },
+        validator: function(value) {
+            return isUnique(value, 'description', this);
         }
     }, {
         xtype: 'textfield',
@@ -118,6 +121,9 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         fieldLabel: 'Remote Public Key'.t(),
         bind: {
             value: '{record.publicKey}'
+        },
+        validator: function(value) {
+            return isUnique(value, 'publicKey', this);
         }
     }, {
         xtype: 'fieldset',
@@ -177,6 +183,9 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         allowBlank: false,
         bind: {
             value: '{record.peerAddress}'
+        },
+        validator: function(value) {
+            return isUnique(value, 'peerAddress', this);
         }
     }, {
         xtype: 'textarea',
@@ -235,3 +244,20 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         }]
     }]
 });
+
+function isUnique(value, field, component) {
+    var currentRecord = component.up('window').getViewModel().data.record.get(field);
+    var grid = Ext.ComponentQuery.query('app-wireguard-vpn-server-tunnels-grid')[0];
+    var store = grid.getStore();
+
+    var isNameUnique = store.findBy(function(record) {
+        return record.get(field) === value;
+    }) === -1;
+    
+    if (value === currentRecord || isNameUnique) {
+        return true;
+    } else {
+        var capitalizedField = field.charAt(0).toUpperCase() + field.slice(1);
+        return Ext.String.format('{0} already exists.'.t(), capitalizedField);
+    }
+    }

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -247,6 +247,11 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
 
 function isUnique(value, field, component) {
     var currentRecord = component.up('window').getViewModel().data.record.get(field);
+    
+    if (value === currentRecord) {
+        return true;
+    }
+    
     var grid = Ext.ComponentQuery.query('app-wireguard-vpn-server-tunnels-grid')[0];
     var store = grid.getStore();
 
@@ -254,10 +259,5 @@ function isUnique(value, field, component) {
         return record.get(field) === value;
     }) === -1;
     
-    if (value === currentRecord || isNameUnique) {
-        return true;
-    } else {
-        var capitalizedField = field.charAt(0).toUpperCase() + field.slice(1);
-        return Ext.String.format('{0} already exists.'.t(), capitalizedField);
-    }
-    }
+    return isNameUnique? true : Ext.String.format('A tunnel with this {0} already exists.'.t(), field);
+}


### PR DESCRIPTION
**ISSUE:** Able to add multiple wireguard VPN client tunnels with same data.

**FIX:**  Added validation to check uniqueness of Description, Peer IP Address and Public key fields.

**TEST:** 
1. Go to App>WireGaurdVPN>Tunnel
2. Check validation for  Description, Peer IP Address and Public key fields by adding same value present in existing record.

![Screenshot from 2024-02-29 15-10-22](https://github.com/untangle/ngfw_src/assets/155290371/4fc40339-eb66-46da-ad87-f64db6a2458e)
![Screenshot from 2024-02-29 14-50-26](https://github.com/untangle/ngfw_src/assets/155290371/7d484626-ba86-46b2-9430-9e79d2484a8b)
![Screenshot from 2024-02-29 14-49-53](https://github.com/untangle/ngfw_src/assets/155290371/d309781c-1283-4ad1-ba7a-048cb7108776)

