### PR TITLE
NGFW-14091 Cleared timestamp format translation for german and japanese

### DIFF
--- a/i18ntools/po/official/de/untangle-de.po
+++ b/i18ntools/po/official/de/untangle-de.po
@@ -5245,7 +5245,7 @@ msgstr "Gültigkeitsdatum"
 #: input:229 input:230 input:272 input:33 input:99 input:635 input:23
 #: /ngfw/build/uvm/js/common/util/Renderer.js:123 input:212
 msgid "timestamp_fmt"
-msgstr "timestamp_fmt"
+msgstr ""
 
 #: /ngfw/build/uvm/servlets/admin/config/administration/MainController.js:663
 #: /ngfw/build/uvm/servlets/admin/config/administration/view/Certificates.js:137

--- a/i18ntools/po/official/ja/untangle-ja.po
+++ b/i18ntools/po/official/ja/untangle-ja.po
@@ -5245,7 +5245,7 @@ msgstr "日付は有効"
 #: input:229 input:230 input:272 input:33 input:99 input:635 input:23
 #: /ngfw/build/uvm/js/common/util/Renderer.js:123 input:212
 msgid "timestamp_fmt"
-msgstr "timestamp_fmt"
+msgstr ""
 
 #: /ngfw/build/uvm/servlets/admin/config/administration/MainController.js:663
 #: /ngfw/build/uvm/servlets/admin/config/administration/view/Certificates.js:137


### PR DESCRIPTION
- `msgstr "timestamp_fmt"` format in german and japanese po files was causing timestamp not to render correctly. Since the value is cleared, it will use the default timestamp format `Y-m-d g:i:s a`