### PR TITLE
ngfw-14524 copyModify property added for wireguard-vpn tunnels

### DIFF
--- a/uvm/js/common/ungrid/GridController.js
+++ b/uvm/js/common/ungrid/GridController.js
@@ -104,7 +104,10 @@ Ext.define('Ung.cmp.GridController', {
 
         if(v.copyModify){
             v.copyModify.forEach(function(kv){
-                newRecord.set(kv['key'], kv['value']);
+                if(kv.value instanceof Function) 
+                    newRecord.set(kv['key'], kv['value']());
+                else
+                    newRecord.set(kv['key'], kv['value']);
             });
         }
 

--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -885,6 +885,23 @@ Ext.define('Ung.util.Util', {
     },
 
     /**
+     * Loop through the stored records to see if the passed ip address is already used
+     * @param  string ip      IP address to be checked.
+     * @param  int store      ExtJs store of records
+     * @param  int dataIndex  ExtJs dataIndex property of records
+     * @return boolean        Returns true if ip already present in dataIndex field of store record.
+     */
+    isAddrUsed: function(ip, store, dataIndex) {
+        var ret = false;
+        store.each(function(record,idx) {
+            if( record.get(dataIndex) == ip ){
+                ret = true;
+            }
+        });
+        return ret;
+    },
+
+    /**
      * From the specified store, get modified records and sort any into
      * a changes object that tracks added/deleted records using the specified
      * idField.  Also uses enabledField value to determine.

--- a/wireguard-vpn/js/MainController.js
+++ b/wireguard-vpn/js/MainController.js
@@ -300,6 +300,22 @@ Ext.define('Ung.apps.wireguard-vpn.MainController', {
         },function(ex){
             Util.handleException(ex);
         });
+    },
+
+    getNextUnusedPoolAddr: function() {
+        var me = this,
+            vm = me.getViewModel(),
+            addressPool = vm.get('settings.addressPool'),
+            store = vm.getStore('tunnels'),
+            pool = addressPool.split("/")[0];
+
+        // Assume the first pool address is used by the wg interface
+        var nextPoolAddr = Util.incrementIpAddr(pool, 2);
+        while (Util.isAddrUsed(nextPoolAddr, store, 'peerAddress')) {
+            nextPoolAddr = Util.incrementIpAddr(nextPoolAddr, 1);
+        }
+
+        return nextPoolAddr;
     }
 });
 
@@ -385,18 +401,6 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
         remoteToRecordTask.delay( 150 );
     },
 
-    // Loop through the stored records to see if the passed ip
-    // address is already used
-    isAddrUsed: function(ip, store) {
-        var ret = false;
-        store.each(function(record,idx) {
-            if( record.get('peerAddress') == ip ){
-                ret = true;
-            }
-        });
-        return ret;
-    },
-
     // get next pool address
     getNextUnusedPoolAddr: function(){
         var me = this,
@@ -407,7 +411,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
 
         // Assume the first pool address is used by the wg interface
         var nextPoolAddr = Util.incrementIpAddr(pool, 2);
-        while (me.isAddrUsed(nextPoolAddr, store)) {
+        while (Util.isAddrUsed(nextPoolAddr, store, 'peerAddress')) {
             nextPoolAddr = Util.incrementIpAddr(nextPoolAddr, 1);
         }
 

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -31,6 +31,19 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
 
     recordActions: ['edit', 'copy', 'delete'],
     copyAppendField: 'description',
+    copyModify: [{
+        key: 'publicKey',
+        value: '',
+    },{
+        key: 'peerAddress',
+        value: function() {
+            var wirgrdVpnCmp = Ext.ComponentQuery.query('[alias=widget.app-wireguard-vpn]')[0];
+            if(wirgrdVpnCmp)
+                return wirgrdVpnCmp.getController().getNextUnusedPoolAddr();
+            else return '';
+        }
+    }],
+
     listProperty: 'settings.tunnels.list',
     emptyRow: {
         'javaClass': 'com.untangle.app.wireguard_vpn.WireGuardVpnTunnel',


### PR DESCRIPTION
Changes:
1. for `recordAction` `copy` - Modified `copyModify` functionality to support functions .
2. Added copyModify property to Wireguard VPN --> Tunnels grid.

When user will click on copy action on `Tunnels` page then record will be copied and new unused ip address will be assigned to `Remote Peer IP Address` field. `Remote Public Key` will be changed to blank string.

![Screenshot from 2024-03-01 13-23-29](https://github.com/untangle/ngfw_src/assets/154422821/6baacb44-898d-4b5c-b4d6-7ff4588eee8d)

On saving the settings private and public key will be assigned to record and same will be visible in `Remote Public Key` field
(Already existing functionality)

![Screenshot from 2024-03-01 13-23-41](https://github.com/untangle/ngfw_src/assets/154422821/bd4a380f-9f17-4522-b586-9847098ac584)


