### PR TITLE
ngfw-13322: WireGuard should not be monitoring roaming clients

### DIFF
--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -218,6 +218,9 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         layout: {
             type: 'vbox'
         },
+        bind: {
+            hidden: '{record.endpointDynamic}'
+        },
         defaults: {
             labelWidth: 170,
             labelAlign: 'right'


### PR DESCRIPTION
Root Cause: In the code, stats is written in generateTunnelStatistics method of WireGuardVpnMonitor, where as healthcheck and connection closure is done in handleTunnelPingCheck method.

The handleTunnelPingCheck is not applicable to roaming clients as they neither have roaming address not pingable interval
```
if (tunnel.getPingInterval() == 0) return;
if (tunnel.getPingAddress() == null) return;
```

Above code returns which is expected behaviour. Moreover WireGuard peers don't notify each other on disconnection, only the latest handshake time is known, hence it becomes difficult to figure out whether client has disconnected or not.
Ideally we could have checked for client status before logging stats for the tunnel, due to above point , this cannot be done.

0  InBytes and 148 bytes outBytes appear in the tunnel statistics,


- https://lekensteyn.nl/files/pwu-wireguard-thesis-final.pdf
- https://www.mail-archive.com/wireguard@lists.zx2c4.com/msg06788.html
- https://www.procustodibus.com/blog/2023/05/troubleshooting-wireguard-with-tcpdump/#b1

After debugging and reading above documentation, following can be concluded  

Wireguard has handshake mechanism in which it sends 148 bytes for initiation if it is successful , 92 bytes are received
in case of failure after a delay of 15 seconds (Rekey-Timeout+Keepalive-Timeout), we observe that WireGuard sends new Handshake initiation attempts every 5 seconds (Rekey-Timeout) for Rekey-After-Time duration 120 seconds.  This gets triggered if client gets disconnected abruptly,

This results in sending 20 messages each at 5 seconds for  (Rekey-After-Time -  Delay - Rekey-Timeout ) seconds which comes out to be 100 seconds hence 20 messages can be seen in Tunnel stats after disconnection.

One more point to be noted : after adding few debug messages the size of messages had become in multiples of 148 hence the check 
`if ((inBytes == 0) && (outBytes % 148 == 0)) 
 `
Testing instructions:
1. Create a roaming client in wireguard
2. Install wireguard in mobile, scan QR code from clicking on Remote Client field and selecting Type QR code

![Screenshot from 2024-03-04 20-26-53](https://github.com/untangle/ngfw_src/assets/154513962/011fc253-08d1-4476-a88d-d08a628e0dfe)
4. Connect the VPN , it should get connected, if successful last handshake time should be updated as following

![Screenshot from 2024-03-04 20-25-17](https://github.com/untangle/ngfw_src/assets/154513962/0b8f11a2-1758-4c4c-9ddf-ef6bf6803473)

6. try visiting youtube, stream some videos, verify in reports wireguard, tunnel traffic events, messages with InBytes nd OutBytes are getting generated, PFA

![Uploading Screenshot from 2024-03-04 20-36-05.png…]()

7. Switch to airplane mode , this will result in abrupt connection loss.
8. Go to Reports wireguard, tunnel traffic events, messages with InBytes as 0 and OutBytes as 148, should be present., refer screenshot

![148](https://github.com/untangle/ngfw_src/assets/154513962/28ad37aa-ebab-4bf5-965e-5efbf2550105)

Evidence for multiples of 148, following has 296 as OutBytes

![296](https://github.com/untangle/ngfw_src/assets/154513962/32378232-634d-40cd-b306-f3cec09a5528)


Apply this patch upgrade and repeat the above testing instuctions, message InBytes as 0 and OutBytes as 148, should be absent

Note:
As per acceptance criteria, Monitor section for roaming clients should be hidden
Add a roaming client and verify Monitor section is not present
![Screenshot from 2024-03-05 14-10-20](https://github.com/untangle/ngfw_src/assets/154513962/8440e41f-bc2b-471b-bbd2-7c55f9407fd3)


