### PR TITLE
ngfw:14414: Q4 Units do not show unit serial number under Config

### DIFF
--- a/uvm/impl/com/untangle/uvm/UvmContextImpl.java
+++ b/uvm/impl/com/untangle/uvm/UvmContextImpl.java
@@ -1349,7 +1349,7 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
                     reader = new BufferedReader(new FileReader(serialNumberFile));
                     serialNumber = reader.readLine().replaceAll("[\\-]","");
                 }
-                if((serialNumber != null ) && (serialNumber.length() == 14 || serialNumber.length() == 13) && !serialNumber.contains(" ")){
+                if((serialNumber != null ) && !serialNumber.contains(" ")){
                     UvmContextImpl.serialNumber = serialNumber;
                 }
             } catch (IOException x) {


### PR DESCRIPTION
Q4 units were not showing unit serial number due to validation check referring to previous untangle format,
where as Arista SN looks like: CTW23050243

Removed length validation checks , added a Test caseby using bind mount bind into /sys/devices/virtual/dmi/id/product_serial and reverting back with original value.

Following is the test output
![Screenshot from 2024-03-06 01-37-16](https://github.com/untangle/ngfw_src/assets/154513962/3e791299-4f36-477f-870b-3e93a69595c2)

Testing steps:
Upgrade the NGFW with this PR and restart NGFW, serial number for Q4 should be visible under config about
PFA screenshot
![Screenshot from 2024-03-06 01-49-40](https://github.com/untangle/ngfw_src/assets/154513962/f6de2576-5e0a-498d-bd0f-c97d5b393458)
