### PR TITLE
ngfw-13983 skipping vpn ping for tunnels with remote any

### DIFF
--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -809,7 +809,7 @@ class IPsecTests(NGFWTestCase):
 
         # Configure local tunnel with remote any
         ipsec_settings = self._app.getSettings()
-        ipsec_settings["tunnels"]["list"] = [build_ipsec_tunnel(remote_ip="%any", remote_lan="192.168.57.0/24" , local_ip="active_wan_address", local_lan_ip="192.168.2.1", local_lan_range="192.168.2.0/24")]
+        ipsec_settings["tunnels"]["list"] = [build_ipsec_tunnel(remote_ip="%any", remote_lan="192.168.57.100/24" , local_ip="active_wan_address", local_lan_ip="192.168.2.1", local_lan_range="192.168.2.1/24")]
         self._app.setSettings(ipsec_settings)
 
         # Configure IPSec on remote NGFW
@@ -823,15 +823,15 @@ class IPsecTests(NGFWTestCase):
         remote_app.start()
 
         remote_ipsec_settings = remote_app.getSettings()
-        remote_ipsec_settings["tunnels"]["list"] = [build_ipsec_tunnel(remote_ip="192.168.1.6", remote_lan="192.168.2.0/24" , local_ip="active_wan_address", local_lan_ip="192.168.57.100", local_lan_range="192.168.57.0/24")]
+        remote_ipsec_settings["tunnels"]["list"] = [build_ipsec_tunnel(remote_ip="192.168.1.6", remote_lan="192.168.2.1/24" , local_ip="active_wan_address", local_lan_ip="192.168.57.100", local_lan_range="192.168.57.100/24")]
         remote_app.setSettings(remote_ipsec_settings)
+        time.sleep(10)
 
-        time.sleep(3)
         # Add pingAddress in local NGFW tunnel
         ipsec_settings["tunnels"]["list"][0]["pingAddress"] = "192.168.57.100"
         self._app.setSettings(ipsec_settings)
+        time.sleep(40)
 
-        time.sleep(10)
         # Check for events logged
         events = global_functions.get_events("IPsec VPN",'Tunnel Connection Events',None,5)
         found = global_functions.check_events( events.get('list'), 5, 

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
@@ -109,6 +109,7 @@ public class IpsecVpnPingTimer extends TimerTask
             if (tunnel.getActive() == false) continue;
             if (tunnel.getPingAddress() == null) continue;
             if (tunnel.getPingAddress().length() == 0) continue;
+            if (tunnel.getRight().equals("%any")) continue;
 
             String leftAddress = app.getManager().resolveLeftAddress(tunnel.getLeft());
 
@@ -220,6 +221,7 @@ public class IpsecVpnPingTimer extends TimerTask
         if (tunnel == null) return (false);
         if (tunnel.getPingAddress() == null) return (false);
         if (tunnel.getPingAddress().length() == 0) return (false);
+        if (tunnel.getRight().equals("%any")) return (false);
 
         try {
             InetAddress target = InetAddress.getByName(tunnel.getPingAddress());


### PR DESCRIPTION
Issue: 
After setting up site-to-site IPsec tunnel between two servers (Host Server and Remote Server) such that right tunnel allows any remote, Multiple unnecessary _Tunnel Connection Events_ are logged in report.

Root Cause:
When ping address was added to right tunnel ping was failing and hence _VPN Ping Timer_ functionality was failing and creating multiple events with type _UNREACHABLE_ and _RESTART_ in loop

Changes: 
Skipping ping check if right remote address is any
Added test case to verify unnecessary events are not  created.

Testing Instruction:
1. Create two NGFW on two different networks
2. Configure IPsec tunnel on on of the NGFW (Local Server) to allow any remote.

![Screenshot from 2024-03-07 17-35-45](https://github.com/untangle/ngfw_src/assets/154422821/416aecd0-57fd-4764-a34d-368586b09833)

Tunnel C to D
![Screenshot from 2024-03-07 17-34-59](https://github.com/untangle/ngfw_src/assets/154422821/b2355da7-019c-4255-a821-f0bd45311ae4)


3. Configure IPsec tunnel on Other NGFW (Remote Server)
![Screenshot from 2024-03-07 17-37-19](https://github.com/untangle/ngfw_src/assets/154422821/3e44609d-371a-4460-b21c-0c723b4b2cb2)

Tunnel D to C
![Screenshot from 2024-03-07 17-36-39](https://github.com/untangle/ngfw_src/assets/154422821/3338e72d-76f0-4a4b-aadd-01347cb130c9)

4. Once connection is established try to ping remote server from local server. ping should succeed.
5. Edit Tunnel on Local Server (C to D) and add pingAddress in it.
6. Check if any UNREACHABLE/RESTART events are created in _Tunnel Connection Events_ report after step 5. There should be no such event logged.


Unit Test Report: 
![Screenshot from 2024-03-07 13-31-06](https://github.com/untangle/ngfw_src/assets/154422821/f7a2c638-08bd-4cae-a061-79d74bbc42cd)
