### PR TITLE
ngfw-14204 updating store list if records are removed

### DIFF
--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -170,9 +170,11 @@ Ext.define('Ung.config.network.MainController', {
 
             /**
              * Important!
-             * update custom grids only if are modified records or it was reordered via drag/drop
+             * update custom grids only if are modified/deleted records or it was reordered via drag/drop
              */
-            if (store.getModifiedRecords().length > 0 || store.isReordered) {
+            if (store.getModifiedRecords().length > 0 || 
+                    store.getRemovedRecords().length > 0 ||
+                    store.isReordered) {
                 store.each(function (record) {
                     if (record.get('markedForDelete')) {
                         record.drop();


### PR DESCRIPTION
Changes:
Updating store list if records are removed from grid store.

Testing Instructions:
1. If user enters conflicting network while adding/modifying Static route, it should show error message as shown below.

![Screenshot from 2024-03-11 13-39-13](https://github.com/untangle/ngfw_src/assets/154422821/7d7a8c05-520b-422a-a6a1-58438036d308)


2. On deleting the conflicting address user should be able to save the settings.

![Screenshot from 2024-03-11 14-46-04](https://github.com/untangle/ngfw_src/assets/154422821/98f6899c-d79a-43bc-8436-6290d0b134b3)



