### PR TITLE
NGFW- 13608 : Fixed IP range calculation to make it generic for all subnet mask

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -858,13 +858,23 @@ Ext.define('Ung.util.Util', {
     },
 
     isIPInRange: function (ip, network, netmask) {
-    
-        var networkInt = Util.convertIPIntoDecimal(network);
-        var netmaskInt = Util.convertIPIntoDecimal(netmask);
+        // Split the IP address into octets
+        var nextPoolOctets = ip.split('.');
+        var networkOctets = network.split('.');
+        var netMaskOctets = netmask.split('.');
+
+        // Convert octets to integers
+        var networkInt = networkOctets.map(function(octet) { return parseInt(octet, 10); });
+        var netmaskInt = netMaskOctets.map(function(octet) { return parseInt(octet, 10); });
+
+        // Calculate the the broadcast address
+        var broadcastAddr = networkInt.map(function(octet, index) { return (octet & netmaskInt[index]) | (~netmaskInt[index] & 255); }).join('.');
+
+        // Convert IP addresses to decimals
         var ipInt = Util.convertIPIntoDecimal(ip);
-    
-        var networkAddress = networkInt & netmaskInt;
-        var broadcastAddress = networkAddress | ~netmaskInt;
+        var broadcastAddress =  Util.convertIPIntoDecimal(broadcastAddr);
+        var networkAddress =  Util.convertIPIntoDecimal(network);
+
         return ipInt > networkAddress && ipInt < broadcastAddress;
     },
 

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -338,10 +338,10 @@ function isIPAddressUnderNWRange(value, component) {
     netMask = Util.getV4NetmaskMap()[subnet ? subnet: 32];
     network = Util.getNetwork(pool, netMask); 
     //Flag to check if IP address is reserved for WG Interface
-    isReservedForWGInterface = Util.convertIPIntoDecimal(value)<=Util.convertIPIntoDecimal(Util.incrementIpAddr(pool, 2));
+    isReservedForWGInterface = Util.convertIPIntoDecimal(value) < Util.convertIPIntoDecimal(Util.incrementIpAddr(pool, 2));
     if (unusedPoolAddr === '' &&  value === '') {
         return 'No more pool addresses are available in the address pool.'.t();
-    }else if(!Util.isIPInRange(value,network,netMask) ||  isReservedForWGInterface) {
+    }else if(!Util.isIPInRange(value, network, netMask) ||  isReservedForWGInterface) {
         return 'Please ensure that the entered IP address is within the specified subnet IP range.'.t();
     } else{
         return true;


### PR DESCRIPTION
**ISSUE**: In previous [PR](https://github.com/untangle/ngfw_src/pull/601) the calculation for broadcast address is failing in some scenarios. 

**FIX:** Implemented the generic range generation logic so it should work for all the subnets.

**TEST:**  Tested all the subnet mask given in https://www.subnet-calculator.com
          

**TEST:**
1. Go to App > WireGuard VPN > Settings.
2. Set the network space and save.
3. Go to App > WireGuard VPN > Tunnel.
4. Click "Add" to create a new tunnel. The peer IP address should be generated within the subnet IP range.
5. If the user adds a peer IP address outside of the subnet IP range or a restricted IP, an error will be displayed: "Please ensure that the entered IP address is within the specified subnet IP range."
6. For auto-assigned peer IP addresses, if the address pool reaches its maximum range, an error should be displayed: "No more pool addresses are available in the address pool."
7. Click on Copy button if all IP address under the range has been assigned to previous tunnels than clicking on peer address editable field will show an error  "No more pool addresses are available in the address pool." and value would not be saved.

![Screenshot from 2024-03-05 23-43-03](https://github.com/untangle/ngfw_src/assets/155290371/583d8b66-4fc7-4c6d-b0bb-38938cc83248)
![Screenshot from 2024-03-05 23-42-23](https://github.com/untangle/ngfw_src/assets/155290371/6e1097a0-d874-4373-a3f3-46ed0d9fa62f)
![Screenshot from 2024-03-05 23-41-57](https://github.com/untangle/ngfw_src/assets/155290371/5d5d4b6e-6578-45c7-9a50-75d885980c6e)
![Screenshot from 2024-03-08 17-35-31](https://github.com/untangle/ngfw_src/assets/155290371/ec7d172d-e9d9-4bd3-a755-8e2a31c992ff)
![Screenshot from 2024-03-08 17-35-21](https://github.com/untangle/ngfw_src/assets/155290371/9f3bda99-becf-48ef-98ac-d6735acd6411)

![Screenshot from 2024-03-08 17-34-53](https://github.com/untangle/ngfw_src/assets/155290371/3ca6b45f-4454-4003-b088-38c2ceb3e91b)
![Screenshot from 2024-03-08 17-34-43](https://github.com/untangle/ngfw_src/assets/155290371/3aedd2f8-4007-4f54-a12a-65ff2b93f18d)
