### PR TITLE
ngfw-13290 : Removed auth-type default column for captive portal events

### DIFF
--- a/captive-portal/hier/usr/share/untangle/lib/captive-portal/reports/captive-portal-admin-logout.json
+++ b/captive-portal/hier/usr/share/untangle/lib/captive-portal/reports/captive-portal-admin-logout.json
@@ -10,7 +10,7 @@
             "value": "ADMIN_LOGOUT"
         }
     ],
-    "defaultColumns": ["time_stamp","client_addr","login_name","event_info","auth_type"],
+    "defaultColumns": ["time_stamp","client_addr","login_name","event_info"],
     "description": "Sessions logged off by the admin.",
     "displayOrder": 1026,
     "javaClass": "com.untangle.app.reports.ReportEntry",

--- a/captive-portal/hier/usr/share/untangle/lib/captive-portal/reports/captive-portal-idle-timeout.json
+++ b/captive-portal/hier/usr/share/untangle/lib/captive-portal/reports/captive-portal-idle-timeout.json
@@ -10,7 +10,7 @@
             "value": "INACTIVE"
         }
     ],
-    "defaultColumns": ["time_stamp","client_addr","login_name","event_info","auth_type"],
+    "defaultColumns": ["time_stamp","client_addr","login_name","event_info"],
     "description": "Sessions that reached the idle timeout.",
     "displayOrder": 1024,
     "javaClass": "com.untangle.app.reports.ReportEntry",

--- a/captive-portal/hier/usr/share/untangle/lib/captive-portal/reports/captive-portal-session-timeout.json
+++ b/captive-portal/hier/usr/share/untangle/lib/captive-portal/reports/captive-portal-session-timeout.json
@@ -10,7 +10,7 @@
             "value": "TIMEOUT"
         }
     ],
-    "defaultColumns": ["time_stamp","client_addr","login_name","event_info","auth_type"],
+    "defaultColumns": ["time_stamp","client_addr","login_name","event_info"],
     "description": "Sessions that reached the session timeout.",
     "displayOrder": 1023,
     "javaClass": "com.untangle.app.reports.ReportEntry",

--- a/captive-portal/hier/usr/share/untangle/lib/captive-portal/reports/captive-portal-user-logout.json
+++ b/captive-portal/hier/usr/share/untangle/lib/captive-portal/reports/captive-portal-user-logout.json
@@ -10,7 +10,7 @@
             "value": "USER_LOGOUT"
         }
     ],
-    "defaultColumns": ["time_stamp","client_addr","login_name","event_info","auth_type"],
+    "defaultColumns": ["time_stamp","client_addr","login_name","event_info"],
     "description": "All user logout events.",
     "displayOrder": 1025,
     "javaClass": "com.untangle.app.reports.ReportEntry",


### PR DESCRIPTION
before :
![image](https://github.com/untangle/ngfw_src/assets/154496583/afbd8dba-e420-4cbf-9f7f-ae5d490bd98b)

after :
![Screenshot from 2024-03-12 15-37-55](https://github.com/untangle/ngfw_src/assets/154496583/52db3d78-f5fe-4d93-a615-e30940a5664b)
