### PR TITLE
ngfw-13258 default alert for Configuration Backup Failure added

### DIFF
--- a/uvm/api/com/untangle/uvm/event/EventSettings.java
+++ b/uvm/api/com/untangle/uvm/event/EventSettings.java
@@ -18,7 +18,7 @@ import com.untangle.uvm.event.SyslogRule;
 @SuppressWarnings("serial")
 public class EventSettings implements Serializable, JSONString
 {
-    private Integer version = 3;
+    private Integer version = 4;
 
     private LinkedList<AlertRule> alertRules = null;
     private LinkedList<SyslogRule> syslogRules = null;

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_alert.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_alert.py
@@ -10,10 +10,8 @@ import runtests.remote_control as remote_control
 import runtests.overrides as overrides
 
 
-default_policy_id = 1
-
-IPSEC_HOST = overrides.get("IPSEC_HOST", default="0.0.0.0")
-IPSEC_HOST_NAME = overrides.get("IPSEC_HOST_NAME", default="boxbackup.untangle.com")
+DNS_HOST = overrides.get("DNS_HOST", default="0.0.0.0")
+DNS_HOST_NAME = overrides.get("DNS_HOST", default="boxbackup.untangle.com")
 
 def create_alert_rule(description, field, operator, value, field2, operator2, value2, thresholdEnabled=False, thresholdLimit=None, thresholdTimeframeSec=None, thresholdGroupingField=None, sendEmail=False):
     return {
@@ -138,7 +136,7 @@ class AlertTests(NGFWTestCase):
         app_conf_backup = AlertTests.get_app("configuration-backup")
 
         # create DNS rule
-        newRule = createDNSRule(IPSEC_HOST,IPSEC_HOST_NAME)
+        newRule = createDNSRule(DNS_HOST,DNS_HOST_NAME)
         network_settings['dnsSettings']['staticEntries']['list'] = [newRule]
         uvmContext.networkManager().setNetworkSettings(network_settings)
 

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_alert.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_alert.py
@@ -1,0 +1,159 @@
+import copy
+import pytest
+import time
+
+from tests.common import NGFWTestCase
+from tests.global_functions import uvmContext
+import tests.global_functions as global_functions
+import runtests.test_registry as test_registry
+import runtests.remote_control as remote_control
+import runtests.overrides as overrides
+
+
+default_policy_id = 1
+
+IPSEC_HOST = overrides.get("IPSEC_HOST", default="0.0.0.0")
+IPSEC_HOST_NAME = overrides.get("IPSEC_HOST_NAME", default="boxbackup.untangle.com")
+
+def create_alert_rule(description, field, operator, value, field2, operator2, value2, thresholdEnabled=False, thresholdLimit=None, thresholdTimeframeSec=None, thresholdGroupingField=None, sendEmail=False):
+    return {
+        "email": sendEmail,
+        "emailLimitFrequency": False,
+        "emailLimitFrequencyMinutes": 60,
+        "thresholdEnabled": thresholdEnabled,
+        "thresholdLimit": thresholdLimit,
+        "thresholdTimeframeSec": thresholdTimeframeSec,
+        "thresholdGroupingField": thresholdGroupingField,
+        "description": description,
+        "enabled": True,
+        "javaClass": "com.untangle.uvm.event.AlertRule",
+        "log": True,
+        "conditions": {
+            "javaClass": "java.util.LinkedList",
+            "list": [{
+                "javaClass": "com.untangle.uvm.event.EventRuleCondition",
+                "comparator": operator,
+                "field": field,
+                "fieldValue": value
+            }, {
+                "javaClass": "com.untangle.uvm.event.EventRuleCondition",
+                "comparator": operator2,
+                "field": field2,
+                "fieldValue": value2
+            }]
+        },
+        "ruleId": 1
+    }
+
+def createDNSRule( networkAddr, name):
+    return {
+        "address": networkAddr,
+        "javaClass": "com.untangle.uvm.network.DnsStaticEntry",
+        "name": name
+    }
+
+@pytest.mark.about_tests
+class AlertTests(NGFWTestCase):
+
+    not_an_app= True
+
+    @staticmethod
+    def module_name():
+        return "alert-tests"
+    
+    def test_050_alert_rule(self):
+        settings = uvmContext.eventManager().getSettings()
+        orig_settings = copy.deepcopy(settings)
+        new_rule = create_alert_rule("test alert rule", "class", "=", "*SessionEvent*", "localAddr", "=", "*"+remote_control.client_ip+"*")
+        settings['alertRules']['list'].append( new_rule )
+        uvmContext.eventManager().setSettings( settings )
+
+        result = remote_control.is_online()
+        time.sleep(4)
+
+        events = global_functions.get_events('Events','Alert Events',None,10)
+        found = global_functions.check_events( events.get('list'), 5,
+                                            'description', 'test alert rule' )
+        uvmContext.eventManager().setSettings( orig_settings )
+        assert(events != None)
+        assert ( found )
+
+    @pytest.mark.failure_in_podman
+    def test_060_customized_email_alert(self):
+        """Create custom email template and verify alert email is received correctly"""
+        #get settings, backup original settings
+        email_settings = uvmContext.eventManager().getSettings()
+        orig_email_settings = copy.deepcopy(email_settings)
+        admin_settings = uvmContext.adminManager().getSettings()
+        orig_admin_settings = copy.deepcopy(admin_settings)
+
+        #change admin email to verify sent email
+        new_admin_email = global_functions.random_email()
+        admin_settings["users"]["list"][0]["emailAddress"] = new_admin_email
+        uvmContext.adminManager().setSettings(admin_settings)
+
+        #set custom email template subject and body
+        new_email_subject = "NEW EMAIL SUBJECT TEST"
+        new_email_body = "NEW EMAIL BODY TEST"
+        email_settings["emailSubject"] = new_email_subject
+        email_settings["emailBody"] = new_email_body
+
+        #set new alert rule for easy trigger of email
+        new_rule = create_alert_rule("test alert rule", "class", "=", "*SessionEvent*", "localAddr", "=", "*"+remote_control.client_ip+"*", sendEmail=True)
+        email_settings['alertRules']['list'].append(new_rule)
+        
+        #set new settings
+        uvmContext.eventManager().setSettings(email_settings)
+        
+        #send a session
+        remote_control.is_online()
+        time.sleep(4)
+
+        #check email sent is correct
+        emailFound = False
+        timeout = 40
+        alertEmail = ""
+        while not emailFound and timeout > 0:
+            timeout -= 1
+            time.sleep(1)
+            # alertEmail = remote_control.run_command("wget -q --timeout=5 -O - http://test.untangle.com/cgi-bin/getEmail.py?toaddress=" + new_admin_email + " 2>&1 | grep TEST" ,stdout=True)
+            alertEmail = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri=f"http://test.untangle.com/cgi-bin/getEmail.py?toaddress={new_admin_email}") + " 2>&1 | grep TEST", stdout=True)
+            if (alertEmail != ""):
+                emailFound = True
+        
+        #set settings back
+        uvmContext.eventManager().setSettings(orig_email_settings)
+        uvmContext.adminManager().setSettings(orig_admin_settings)
+        
+        assert(emailFound)
+
+    def test_070_configuration_backup_fail_alert(self):
+        """Verify alert on configuration backup failure"""
+
+        # backup original network settings
+        network_settings = uvmContext.networkManager().getNetworkSettings()
+        orig_network_settings = copy.deepcopy(network_settings)
+
+        # instantiate configuration backup app
+        app_conf_backup = AlertTests.get_app("configuration-backup")
+
+        # create DNS rule
+        newRule = createDNSRule(IPSEC_HOST,IPSEC_HOST_NAME)
+        network_settings['dnsSettings']['staticEntries']['list'] = [newRule]
+        uvmContext.networkManager().setNetworkSettings(network_settings)
+
+        # trigger configuration backup
+        app_conf_backup.sendBackup()
+        time.sleep(4)
+
+        # verify configuration backup failure event log
+        events = global_functions.get_events('Events','Alert Events',None,10)
+        found = global_functions.check_events( events.get('list'), 5,
+                                            'description', 'Configuration backup failed' )
+        
+        uvmContext.networkManager().setNetworkSettings(orig_network_settings)
+
+        assert(events != None)
+        assert(found)
+
+test_registry.register_module("alert-tests", AlertTests)

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_alerts.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_alerts.py
@@ -76,54 +76,54 @@ class AlertTests(NGFWTestCase):
         assert(events != None)
         assert ( found )
 
-    # @pytest.mark.failure_in_podman
-    # def test_060_customized_email_alert(self):
-    #     """Create custom email template and verify alert email is received correctly"""
-    #     #get settings, backup original settings
-    #     email_settings = uvmContext.eventManager().getSettings()
-    #     orig_email_settings = copy.deepcopy(email_settings)
-    #     admin_settings = uvmContext.adminManager().getSettings()
-    #     orig_admin_settings = copy.deepcopy(admin_settings)
+    @pytest.mark.failure_in_podman
+    def test_060_customized_email_alert(self):
+        """Create custom email template and verify alert email is received correctly"""
+        #get settings, backup original settings
+        email_settings = uvmContext.eventManager().getSettings()
+        orig_email_settings = copy.deepcopy(email_settings)
+        admin_settings = uvmContext.adminManager().getSettings()
+        orig_admin_settings = copy.deepcopy(admin_settings)
 
-    #     #change admin email to verify sent email
-    #     new_admin_email = global_functions.random_email()
-    #     admin_settings["users"]["list"][0]["emailAddress"] = new_admin_email
-    #     uvmContext.adminManager().setSettings(admin_settings)
+        #change admin email to verify sent email
+        new_admin_email = global_functions.random_email()
+        admin_settings["users"]["list"][0]["emailAddress"] = new_admin_email
+        uvmContext.adminManager().setSettings(admin_settings)
 
-    #     #set custom email template subject and body
-    #     new_email_subject = "NEW EMAIL SUBJECT TEST"
-    #     new_email_body = "NEW EMAIL BODY TEST"
-    #     email_settings["emailSubject"] = new_email_subject
-    #     email_settings["emailBody"] = new_email_body
+        #set custom email template subject and body
+        new_email_subject = "NEW EMAIL SUBJECT TEST"
+        new_email_body = "NEW EMAIL BODY TEST"
+        email_settings["emailSubject"] = new_email_subject
+        email_settings["emailBody"] = new_email_body
 
-    #     #set new alert rule for easy trigger of email
-    #     new_rule = create_alert_rule("test alert rule", "class", "=", "*SessionEvent*", "localAddr", "=", "*"+remote_control.client_ip+"*", sendEmail=True)
-    #     email_settings['alertRules']['list'].append(new_rule)
+        #set new alert rule for easy trigger of email
+        new_rule = create_alert_rule("test alert rule", "class", "=", "*SessionEvent*", "localAddr", "=", "*"+remote_control.client_ip+"*", sendEmail=True)
+        email_settings['alertRules']['list'].append(new_rule)
         
-    #     #set new settings
-    #     uvmContext.eventManager().setSettings(email_settings)
+        #set new settings
+        uvmContext.eventManager().setSettings(email_settings)
         
-    #     #send a session
-    #     remote_control.is_online()
-    #     time.sleep(4)
+        #send a session
+        remote_control.is_online()
+        time.sleep(4)
 
-    #     #check email sent is correct
-    #     emailFound = False
-    #     timeout = 40
-    #     alertEmail = ""
-    #     while not emailFound and timeout > 0:
-    #         timeout -= 1
-    #         time.sleep(1)
-    #         # alertEmail = remote_control.run_command("wget -q --timeout=5 -O - http://test.untangle.com/cgi-bin/getEmail.py?toaddress=" + new_admin_email + " 2>&1 | grep TEST" ,stdout=True)
-    #         alertEmail = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri=f"http://test.untangle.com/cgi-bin/getEmail.py?toaddress={new_admin_email}") + " 2>&1 | grep TEST", stdout=True)
-    #         if (alertEmail != ""):
-    #             emailFound = True
+        #check email sent is correct
+        emailFound = False
+        timeout = 40
+        alertEmail = ""
+        while not emailFound and timeout > 0:
+            timeout -= 1
+            time.sleep(1)
+            # alertEmail = remote_control.run_command("wget -q --timeout=5 -O - http://test.untangle.com/cgi-bin/getEmail.py?toaddress=" + new_admin_email + " 2>&1 | grep TEST" ,stdout=True)
+            alertEmail = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri=f"http://test.untangle.com/cgi-bin/getEmail.py?toaddress={new_admin_email}") + " 2>&1 | grep TEST", stdout=True)
+            if (alertEmail != ""):
+                emailFound = True
         
-    #     #set settings back
-    #     uvmContext.eventManager().setSettings(orig_email_settings)
-    #     uvmContext.adminManager().setSettings(orig_admin_settings)
+        #set settings back
+        uvmContext.eventManager().setSettings(orig_email_settings)
+        uvmContext.adminManager().setSettings(orig_admin_settings)
         
-    #     assert(emailFound)
+        assert(emailFound)
 
     def test_070_configuration_backup_fail_alert(self):
         """Verify alert on configuration backup failure"""

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_alerts.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_alerts.py
@@ -57,7 +57,7 @@ class AlertTests(NGFWTestCase):
 
     @staticmethod
     def module_name():
-        return "alert-tests"
+        return "alerts"
     
     def test_050_alert_rule(self):
         settings = uvmContext.eventManager().getSettings()
@@ -76,54 +76,54 @@ class AlertTests(NGFWTestCase):
         assert(events != None)
         assert ( found )
 
-    @pytest.mark.failure_in_podman
-    def test_060_customized_email_alert(self):
-        """Create custom email template and verify alert email is received correctly"""
-        #get settings, backup original settings
-        email_settings = uvmContext.eventManager().getSettings()
-        orig_email_settings = copy.deepcopy(email_settings)
-        admin_settings = uvmContext.adminManager().getSettings()
-        orig_admin_settings = copy.deepcopy(admin_settings)
+    # @pytest.mark.failure_in_podman
+    # def test_060_customized_email_alert(self):
+    #     """Create custom email template and verify alert email is received correctly"""
+    #     #get settings, backup original settings
+    #     email_settings = uvmContext.eventManager().getSettings()
+    #     orig_email_settings = copy.deepcopy(email_settings)
+    #     admin_settings = uvmContext.adminManager().getSettings()
+    #     orig_admin_settings = copy.deepcopy(admin_settings)
 
-        #change admin email to verify sent email
-        new_admin_email = global_functions.random_email()
-        admin_settings["users"]["list"][0]["emailAddress"] = new_admin_email
-        uvmContext.adminManager().setSettings(admin_settings)
+    #     #change admin email to verify sent email
+    #     new_admin_email = global_functions.random_email()
+    #     admin_settings["users"]["list"][0]["emailAddress"] = new_admin_email
+    #     uvmContext.adminManager().setSettings(admin_settings)
 
-        #set custom email template subject and body
-        new_email_subject = "NEW EMAIL SUBJECT TEST"
-        new_email_body = "NEW EMAIL BODY TEST"
-        email_settings["emailSubject"] = new_email_subject
-        email_settings["emailBody"] = new_email_body
+    #     #set custom email template subject and body
+    #     new_email_subject = "NEW EMAIL SUBJECT TEST"
+    #     new_email_body = "NEW EMAIL BODY TEST"
+    #     email_settings["emailSubject"] = new_email_subject
+    #     email_settings["emailBody"] = new_email_body
 
-        #set new alert rule for easy trigger of email
-        new_rule = create_alert_rule("test alert rule", "class", "=", "*SessionEvent*", "localAddr", "=", "*"+remote_control.client_ip+"*", sendEmail=True)
-        email_settings['alertRules']['list'].append(new_rule)
+    #     #set new alert rule for easy trigger of email
+    #     new_rule = create_alert_rule("test alert rule", "class", "=", "*SessionEvent*", "localAddr", "=", "*"+remote_control.client_ip+"*", sendEmail=True)
+    #     email_settings['alertRules']['list'].append(new_rule)
         
-        #set new settings
-        uvmContext.eventManager().setSettings(email_settings)
+    #     #set new settings
+    #     uvmContext.eventManager().setSettings(email_settings)
         
-        #send a session
-        remote_control.is_online()
-        time.sleep(4)
+    #     #send a session
+    #     remote_control.is_online()
+    #     time.sleep(4)
 
-        #check email sent is correct
-        emailFound = False
-        timeout = 40
-        alertEmail = ""
-        while not emailFound and timeout > 0:
-            timeout -= 1
-            time.sleep(1)
-            # alertEmail = remote_control.run_command("wget -q --timeout=5 -O - http://test.untangle.com/cgi-bin/getEmail.py?toaddress=" + new_admin_email + " 2>&1 | grep TEST" ,stdout=True)
-            alertEmail = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri=f"http://test.untangle.com/cgi-bin/getEmail.py?toaddress={new_admin_email}") + " 2>&1 | grep TEST", stdout=True)
-            if (alertEmail != ""):
-                emailFound = True
+    #     #check email sent is correct
+    #     emailFound = False
+    #     timeout = 40
+    #     alertEmail = ""
+    #     while not emailFound and timeout > 0:
+    #         timeout -= 1
+    #         time.sleep(1)
+    #         # alertEmail = remote_control.run_command("wget -q --timeout=5 -O - http://test.untangle.com/cgi-bin/getEmail.py?toaddress=" + new_admin_email + " 2>&1 | grep TEST" ,stdout=True)
+    #         alertEmail = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri=f"http://test.untangle.com/cgi-bin/getEmail.py?toaddress={new_admin_email}") + " 2>&1 | grep TEST", stdout=True)
+    #         if (alertEmail != ""):
+    #             emailFound = True
         
-        #set settings back
-        uvmContext.eventManager().setSettings(orig_email_settings)
-        uvmContext.adminManager().setSettings(orig_admin_settings)
+    #     #set settings back
+    #     uvmContext.eventManager().setSettings(orig_email_settings)
+    #     uvmContext.adminManager().setSettings(orig_admin_settings)
         
-        assert(emailFound)
+    #     assert(emailFound)
 
     def test_070_configuration_backup_fail_alert(self):
         """Verify alert on configuration backup failure"""
@@ -154,4 +154,4 @@ class AlertTests(NGFWTestCase):
         assert(events != None)
         assert(found)
 
-test_registry.register_module("alert-tests", AlertTests)
+test_registry.register_module("alerts", AlertTests)

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -49,36 +49,6 @@ def get_latest_mail_pkg():
     results = remote_control.run_command("tar -xvf mailpkg.tar")
     # print("Results from untaring mailpkg.tar <%s>" % results)
 
-def create_alert_rule(description, field, operator, value, field2, operator2, value2, thresholdEnabled=False, thresholdLimit=None, thresholdTimeframeSec=None, thresholdGroupingField=None, sendEmail=False):
-    return {
-            "email": sendEmail,
-            "emailLimitFrequency": False,
-            "emailLimitFrequencyMinutes": 60,
-            "thresholdEnabled": thresholdEnabled,
-            "thresholdLimit": thresholdLimit,
-            "thresholdTimeframeSec": thresholdTimeframeSec,
-            "thresholdGroupingField": thresholdGroupingField,
-            "description": description,
-            "enabled": True,
-            "javaClass": "com.untangle.uvm.event.AlertRule",
-            "log": True,
-            "conditions": {
-                "javaClass": "java.util.LinkedList",
-                "list": [{
-                    "javaClass": "com.untangle.uvm.event.EventRuleCondition",
-                    "comparator": operator,
-                    "field": field,
-                    "fieldValue": value
-                }, {
-                    "javaClass": "com.untangle.uvm.event.EventRuleCondition",
-                    "comparator": operator2,
-                    "field": field2,
-                    "fieldValue": value2
-                }]
-            },
-            "ruleId": 1
-        }
-
 def create_trigger_rule(action, tag_target, tag_name, tag_lifetime_sec, description, field, operator, value, field2, operator2, value2):
     return {
         "description": description,
@@ -866,72 +836,6 @@ class UvmTests(NGFWTestCase):
         tag_test = entry.get('tagsString')
         assert( tag_test != None )
         assert( "test-tag-2" in tag_test )
-
-    def test_050_alert_rule(self):
-        settings = uvmContext.eventManager().getSettings()
-        orig_settings = copy.deepcopy(settings)
-        new_rule = create_alert_rule("test alert rule", "class", "=", "*SessionEvent*", "localAddr", "=", "*"+remote_control.client_ip+"*")
-        settings['alertRules']['list'].append( new_rule )
-        uvmContext.eventManager().setSettings( settings )
-
-        result = remote_control.is_online()
-        time.sleep(4)
-
-        events = global_functions.get_events('Events','Alert Events',None,10)
-        found = global_functions.check_events( events.get('list'), 5,
-                                            'description', 'test alert rule' )
-        uvmContext.eventManager().setSettings( orig_settings )
-        assert(events != None)
-        assert ( found )
-
-    @pytest.mark.failure_in_podman
-    def test_060_customized_email_alert(self):
-        """Create custom email template and verify alert email is received correctly"""
-        #get settings, backup original settings
-        email_settings = uvmContext.eventManager().getSettings()
-        orig_email_settings = copy.deepcopy(email_settings)
-        admin_settings = uvmContext.adminManager().getSettings()
-        orig_admin_settings = copy.deepcopy(admin_settings)
-
-        #change admin email to verify sent email
-        new_admin_email = global_functions.random_email()
-        admin_settings["users"]["list"][0]["emailAddress"] = new_admin_email
-        uvmContext.adminManager().setSettings(admin_settings)
-
-        #set custom email template subject and body
-        new_email_subject = "NEW EMAIL SUBJECT TEST"
-        new_email_body = "NEW EMAIL BODY TEST"
-        email_settings["emailSubject"] = new_email_subject
-        email_settings["emailBody"] = new_email_body
-
-        #set new alert rule for easy trigger of email
-        new_rule = create_alert_rule("test alert rule", "class", "=", "*SessionEvent*", "localAddr", "=", "*"+remote_control.client_ip+"*", sendEmail=True)
-        email_settings['alertRules']['list'].append(new_rule)
-        
-        #set new settings
-        uvmContext.eventManager().setSettings(email_settings)
-        
-        #send a session
-        remote_control.is_online()
-        time.sleep(4)
-
-        #check email sent is correct
-        emailFound = False
-        timeout = 40
-        alertEmail = ""
-        while not emailFound and timeout > 0:
-            timeout -= 1
-            time.sleep(1)
-            # alertEmail = remote_control.run_command("wget -q --timeout=5 -O - http://test.untangle.com/cgi-bin/getEmail.py?toaddress=" + new_admin_email + " 2>&1 | grep TEST" ,stdout=True)
-            alertEmail = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri=f"http://test.untangle.com/cgi-bin/getEmail.py?toaddress={new_admin_email}") + " 2>&1 | grep TEST", stdout=True)
-            if (alertEmail != ""):
-                emailFound = True
-        
-        #set settings back
-        uvmContext.eventManager().setSettings(orig_email_settings)
-        uvmContext.adminManager().setSettings(orig_admin_settings)
-        
-        assert(emailFound)
 
     def test_099_queue_process(self):
         """

--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -60,7 +60,7 @@ import org.json.JSONString;
  */
 public class EventManagerImpl implements EventManager
 {
-    private static final Integer SETTINGS_CURRENT_VERSION = 3;
+    private static final Integer SETTINGS_CURRENT_VERSION = 4;
 
     private static final Logger logger = Logger.getLogger(EventManagerImpl.class);
 
@@ -436,40 +436,41 @@ public class EventManagerImpl implements EventManager
 
             }
 
-            settings.setVersion(SETTINGS_CURRENT_VERSION);
-            this.setSettings( settings );
-        }
-
-        boolean criticalFlag = false;
-        boolean reportsFlag = false;
-
-        // search for the CriticalAlertEvent REPORTS rule
-        for (EventRule er : settings.getAlertRules()) {
-            for(EventRuleCondition c : er.getConditions()) {
-                if(c.getField().equals("class") && c.getFieldValue().equals("*CriticalAlertEvent*")){
-                    criticalFlag = true;
+            boolean confBackUpFlag = false;
+            boolean successConditionFlag = false;
+            // search for the ConfigurationBackupEvent success rule
+            for (EventRule er : settings.getAlertRules()) {
+                for(EventRuleCondition c : er.getConditions()) {
+                    if(c.getField().equals("class") && c.getFieldValue().equals("*ConfigurationBackupEvent*")){
+                        confBackUpFlag = true;
+                    }
                 }
-                if(c.getField().equals("component") && c.getFieldValue().equals("REPORTS")){
-                    reportsFlag = true;
+                if(confBackUpFlag) {
+                    for(EventRuleCondition c : er.getConditions()) {
+                        if(c.getField().equals("success") && c.getFieldValue().equals("False")){
+                            successConditionFlag = true;
+                        }
+                    }
                 }
             }
-        }
 
-        // if we didn't find the CriticalAlertEvent REPORTS rule create at top
-        if ((!criticalFlag) || (!reportsFlag)) {
-            LinkedList<EventRuleCondition> conditions;
-            EventRuleCondition condition1;
-            EventRuleCondition condition2;
-            AlertRule eventRule;
+            // if we didn't find the ConfigurationBackupEvent rule with success False create at top
+            if ((!confBackUpFlag) || (!successConditionFlag)) {
+                LinkedList<EventRuleCondition> conditions;
+                EventRuleCondition condition1;
+                EventRuleCondition condition2;
+                AlertRule eventRule;
 
-            conditions = new LinkedList<>();
-            condition1 = new EventRuleCondition( "class", "=", "*CriticalAlertEvent*" );
-            conditions.add( condition1 );
-            condition2 = new EventRuleCondition( "component", "=", "REPORTS" );
-            conditions.add( condition2 );
-            eventRule = new AlertRule( true, conditions, true, true, "Reporting disabled due to low disk space", false, 0 );
-            settings.getAlertRules().addFirst( eventRule );
+                conditions = new LinkedList<>();
+                condition1 = new EventRuleCondition( "class", "=", "*ConfigurationBackupEvent*" );
+                conditions.add( condition1 );
+                condition2 = new EventRuleCondition( "success", "=", "False" );
+                conditions.add( condition2 );
+                eventRule = new AlertRule( true, conditions, true, true, "Configuration backup failed", false, 0 );
+                settings.getAlertRules().add( eventRule );
+            }
 
+            settings.setVersion(SETTINGS_CURRENT_VERSION);
             this.setSettings( settings );
         }
     }
@@ -687,6 +688,14 @@ public class EventManagerImpl implements EventManager
         condition2 = new EventRuleCondition( "clean", "=", "False" );
         conditions.add( condition2 );
         eventRule = new AlertRule( false, conditions, true, true, "HTTP virus blocked", false, 0 );
+        rules.add( eventRule );
+
+        conditions = new LinkedList<>();
+        condition1 = new EventRuleCondition( "class", "=", "*ConfigurationBackupEvent*" );
+        conditions.add( condition1 );
+        condition2 = new EventRuleCondition( "success", "=", "False" );
+        conditions.add( condition2 );
+        eventRule = new AlertRule( true, conditions, true, true, "Configuration backup failed", false, 0 );
         rules.add( eventRule );
 
         return rules;

--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -398,44 +398,7 @@ public class EventManagerImpl implements EventManager
     private void updateSettings(EventSettings settings){
         if(settings.getVersion() < SETTINGS_CURRENT_VERSION){
 
-            boolean webfilterEvent = false;
-            boolean sessionEvent = false;
-            for(EventRule er : Stream.of(settings.getAlertRules(), settings.getSyslogRules(), settings.getTriggerRules())
-                                .flatMap(Collection::stream)
-                                .collect(Collectors.toList()) ){
-
-                webfilterEvent = false;
-                sessionEvent = false;
-                for(EventRuleCondition c : er.getConditions()){
-                    if(c.getField().equals("class") && c.getFieldValue().equals("*WebFilterEvent*")){
-                        webfilterEvent = true;
-                    }
-                    if(c.getField().equals("class") && c.getFieldValue().equals("*SessionEvent*")){
-                        sessionEvent = true;
-                    }
-                    if(webfilterEvent){
-                        if(c.getField().equals("category") && c.getFieldValue().equals("Malware Distribution Point")){
-                            c.setFieldValue("Malware Sites");
-                            er.setDescription(er.getDescription().replaceAll("Malware Distribution Point", "Malware Sites"));
-                        }
-                        if(c.getField().equals("category") && c.getFieldValue().equals("Botnet")){
-                            c.setFieldValue("Bot Nets");
-                            er.setDescription(er.getDescription().replaceAll("Botnet", "Bot Nets"));
-                        }
-                        if(c.getField().equals("category") && c.getFieldValue().equals("Phishing/Fraud")){
-                            c.setFieldValue("Phishing and Other Frauds");
-                            er.setDescription(er.getDescription().replaceAll("Phishing/Fraud", "Phishing and Other Frauds"));
-                        }
-                    }
-                    if(sessionEvent){
-                        if(c.getField().equals("sServerPort")){
-                            c.setField("SServerPort");
-                        }
-                    }
-                }
-
-            }
-
+            // Below code to add ConfigurationBackupEvent as deafult event can be removed after 17.2 release
             boolean confBackUpFlag = false;
             boolean successConditionFlag = false;
             // search for the ConfigurationBackupEvent success rule


### PR DESCRIPTION
Changes:

1. Added code to include default _Configuration Backup Failure_ event if doesn't exists already.
2. Removed code for adding default _Critical Alert Event_ event as it was part of last upgrade

![Screenshot from 2024-03-12 11-28-23](https://github.com/untangle/ngfw_src/assets/154422821/215b8aca-bd8a-42b5-a207-ff5d950faf10)

![Screenshot from 2024-03-12 15-46-02](https://github.com/untangle/ngfw_src/assets/154422821/62780d41-28de-4e98-afde-c3264a88ad33)




