### PR TITLE
ngfw-13953: Strip trailing spaces in uploaded certificates

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
@@ -1,28 +1,41 @@
 import pytest
 import unittest
-
+import json
+import os
+from glob import glob
+from os.path import join, getctime
 from tests.common import NGFWTestCase
 import tests.global_functions as global_functions
 import runtests.test_registry as test_registry
 import runtests.remote_control as remote_control
+import runtests.overrides as overrides
+import requests
+import re
 
+invalid_certificate_payload={"certData": "-----BEGIN CERTIFICATE----\n-----END CERTIFICATE-----\n", "keyData": "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"}
+username = overrides.get("Login_username", default="admin")
+password = overrides.get("Login_password", default="passwd")
 @pytest.mark.administration_tests
 class AdministrationTests(NGFWTestCase):
     not_an_app = True
-    
+
     @staticmethod
     def module_name():
         return "administration-tests"
-    
+
+    @staticmethod
+    def appName():
+        return "administration-tests"
+
     def test_010_client_is_online(self):
         result = remote_control.is_online()
         assert (result == 0)
-        
+
     # Tests Certificate information in Config > Administration > Certificates
     def test_020_certificate_authority_info(self):
         cert_manager = global_functions.uvmContext.certificateManager()
         root_cert_info = cert_manager.getRootCertificateInformation()
-        
+
         # Checks for CN=[Arista Site], O=Arista, and L=Santa Clara
         cert_subjects = root_cert_info["certSubject"].split(", ")
         cn_found, o_found, l_found = False, False, False
@@ -38,5 +51,234 @@ class AdministrationTests(NGFWTestCase):
                 l_found = True
                 assert(subject in ["L=Sunnyvale","L=Santa Clara"])
         assert(cn_found and o_found and l_found)
-    
+
+
+    #Test to validate import certificate or key with trailing spaces and new line and Upload Cerificate 
+    def test_021_validate_import_server_certificate(self):
+
+        certificates_dir = '/usr/share/untangle/settings/untangle-certificates'
+        initial_certificates_list = global_functions.uvmContext.certificateManager().getServerCertificateList()
+        isDir = os.path.exists(certificates_dir)
+        isFile = os.path.exists(f"{certificates_dir}/apache.pem")
+        if not isDir and not isFile:
+            pytest.skip('%s certificate directory or certificate not present' % self.appName())
+        url = global_functions.get_http_url()
+        headers = {'accept': 'application/json',}
+        output_file_path = '/tmp/uploadcertificate.pem'
+
+        with open(f"{certificates_dir}/apache.pem", 'r') as input_file:
+            lines = input_file.readlines()
+
+        # Add trailing spaces to each line
+        lines_with_spaces = [line.rstrip() + ' ' + '\n' for line in lines]
+
+        with open(output_file_path, 'w') as output_file:
+            output_file.writelines(lines_with_spaces)
+
+        files = {
+            'type': (None, 'certificate_upload'),
+            'argument': (None, 'upload_server'),
+            'filename': ('uploadcert.pem', open(f"{output_file_path}", 'rb') , 'application/x-x509-ca-cert')
+        }
+        rpc_url = f"{url}/admin/upload"
+        s = requests.Session()
+        # Log in
+        response = s.post(
+            f"{url}/auth/login?url=/admin&realm=Administrator",
+            data=f"fragment=&username={username}&password={password}",
+            verify=False
+        )
+        # Upload pem file containing cert and key files
+        response = s.post(
+            f"{rpc_url}",
+            headers=headers,
+            files=files
+
+        )
+        certificate_upload_response = json.loads(response.text)
+        files_list = []
+        cert_upload_json = json.loads(certificate_upload_response.get('msg', None))
+        if (cert_upload_json.get("certData", None)):
+            uploaded_response = global_functions.uvmContext.certificateManager().uploadCertificate("SERVER", cert_upload_json.get("certData"), cert_upload_json.get("keyData"), "" )
+            assert "Certificate successfully uploaded" in uploaded_response.get("output", None)
+
+            for file in glob(join(certificates_dir,f'*.pem')):
+                files_list.append((getctime(file), file))
+            files_list = [file for _, file in sorted(files_list, reverse=True)]
+        # Need to delete uploaded certificate, compare certificates by creation time
+        # Use removeCertificate api to delete the certificate
+        if len(files_list) > 1:
+            uploaded_file_path = files_list[0]
+            global_functions.uvmContext.certificateManager().removeCertificate("SERVER",os.path.basename(uploaded_file_path))
+        final_certificates_list = global_functions.uvmContext.certificateManager().getServerCertificateList()
+        #certificates list should be unchanged after test execution
+        assert(len(initial_certificates_list['list']) == len(final_certificates_list['list']))
+        os.remove(output_file_path)
+
+    #Test to validate import certificate or key with space and DOS style CRLF endings, new line and Upload Cerificate 
+    def test_022_validate_import_server_certificate(self):
+
+        certificates_dir = '/usr/share/untangle/settings/untangle-certificates'
+        initial_certificates_list = global_functions.uvmContext.certificateManager().getServerCertificateList()
+        isDir = os.path.exists(certificates_dir)
+        isFile = os.path.exists(f"{certificates_dir}/apache.pem")
+        if not isDir and not isFile:
+            pytest.skip('%s certificate directory or certificate not present' % self.appName())
+        url = global_functions.get_http_url()
+        headers = {'accept': 'application/json',}
+        output_file_path = '/tmp/uploadcertificate.pem'
+
+        with open(f"{certificates_dir}/apache.pem", 'r') as input_file:
+            content = input_file.read()
+
+        # Convert LF to add trailing spaces and CRLF line endings
+        modified_content = content.replace('\n', ' \r\n')
+        #modified_content = content.replace('\n', '\r\n')
+        with open(f"{output_file_path}", 'w') as output_file:
+            output_file.write(modified_content)
+
+        files = {
+            'type': (None, 'certificate_upload'),
+            'argument': (None, 'upload_server'),
+            'filename': ('uploadcert.pem', open(f"{output_file_path}", 'rb') , 'application/x-x509-ca-cert')
+        }
+        rpc_url = f"{url}/admin/upload"
+        s = requests.Session()
+        # Log in
+        response = s.post(
+            f"{url}/auth/login?url=/admin&realm=Administrator",
+            data=f"fragment=&username={username}&password={password}",
+            verify=False
+        )
+        # Upload pem file containing cert and key files
+        response = s.post(
+            f"{rpc_url}",
+            headers=headers,
+            files=files
+
+        )
+
+        certificate_upload_response = json.loads(response.text)
+        files_list = []
+        cert_upload_json = json.loads(certificate_upload_response.get('msg', None))
+        if (cert_upload_json.get("certData", None)):
+            uploaded_response = global_functions.uvmContext.certificateManager().uploadCertificate("SERVER", cert_upload_json.get("certData"), cert_upload_json.get("keyData"), "" )
+            assert "Certificate successfully uploaded" in uploaded_response.get("output", None)
+
+            for file in glob(join(certificates_dir,f'*.pem')):
+                files_list.append((getctime(file), file))
+            files_list = [file for _, file in sorted(files_list, reverse=True)]
+        # Need to delete uploaded certificate, compare certificates by creation time
+        # Use removeCertificate api to delete the certificate
+        if len(files_list) > 1:
+            uploaded_file_path = files_list[0]
+            global_functions.uvmContext.certificateManager().removeCertificate("SERVER",os.path.basename(uploaded_file_path))
+        final_certificates_list = global_functions.uvmContext.certificateManager().getServerCertificateList()
+        #  certificates list should be unchanged after test execution
+        assert(len(initial_certificates_list['list']) == len(final_certificates_list['list']))
+        os.remove(output_file_path)
+
+    #Test to validate import certificate or key and DOS style CRLF endings, new line and Upload Cerificate 
+    def test_023_validate_import_server_certificate(self):
+
+        certificates_dir = '/usr/share/untangle/settings/untangle-certificates'
+        initial_certificates_list = global_functions.uvmContext.certificateManager().getServerCertificateList()
+        isDir = os.path.exists(certificates_dir)
+        isFile = os.path.exists(f"{certificates_dir}/apache.pem")
+        if not isDir and not isFile:
+            pytest.skip('%s certificate directory or certificate not present' % self.appNameWF())
+        url = global_functions.get_http_url()
+        headers = {'accept': 'application/json',}
+        output_file_path = '/tmp/uploadcertificate.pem'
+
+        with open(f"{certificates_dir}/apache.pem", 'r') as input_file:
+            content = input_file.read()
+
+        # Convert LF to add CRLF line endings
+        modified_content = content.replace('\n', '\r\n')
+        with open(f"{output_file_path}", 'w') as output_file:
+            output_file.write(modified_content)
+
+        files = {
+            'type': (None, 'certificate_upload'),
+            'argument': (None, 'upload_server'),
+            'filename': ('uploadcert.pem', open(f"{output_file_path}", 'rb') , 'application/x-x509-ca-cert')
+        }
+        rpc_url = f"{url}/admin/upload"
+        s = requests.Session()
+        # Log in
+        response = s.post(
+            f"{url}/auth/login?url=/admin&realm=Administrator",
+            data=f"fragment=&username={username}&password={password}",
+            verify=False
+        )
+        # Upload pem file containing cert and key files
+        response = s.post(
+            f"{rpc_url}",
+            headers=headers,
+            files=files
+
+        )
+
+        certificate_upload_response = json.loads(response.text)
+        files_list = []
+        cert_upload_json = json.loads(certificate_upload_response.get('msg', None))
+        if (cert_upload_json.get("certData", None)):
+            uploaded_response = global_functions.uvmContext.certificateManager().uploadCertificate("SERVER", cert_upload_json.get("certData"), cert_upload_json.get("keyData"), "" )
+            assert "Certificate successfully uploaded" in uploaded_response.get("output", None)
+
+            for file in glob(join(certificates_dir,f'*.pem')):
+                files_list.append((getctime(file), file))
+            files_list = [file for _, file in sorted(files_list, reverse=True)]
+        # Need to delete uploaded certificate, compare certificates by creation time
+        # Use removeCertificate api to delete the certificate
+        if len(files_list) > 1:
+            uploaded_file_path = files_list[0]
+            global_functions.uvmContext.certificateManager().removeCertificate("SERVER",os.path.basename(uploaded_file_path))
+        final_certificates_list = global_functions.uvmContext.certificateManager().getServerCertificateList()
+        #  certificates list should be unchanged after test execution
+        assert(len(initial_certificates_list['list']) == len(final_certificates_list['list']))
+        os.remove(output_file_path)
+
+    #Test to validate invalid json upload uploadCerificate API
+    def test_024_validate_upload_certificate_api(self):
+        # This test validates certificate upload to uploadCerificate API
+        uploaded_response = global_functions.uvmContext.certificateManager().uploadCertificate("SERVER", invalid_certificate_payload.get("certData"), invalid_certificate_payload.get("keyData"), "" )
+        assert "The certificate is not valid" in uploaded_response.get("output", None)
+
+    #Test to validate import invalid certificate or key file
+    def test_025_validate_import_invalid_server_certificate(self):
+        # This test validates certificate from Text Area in the UI
+
+        certificates_dir = '/usr/share/untangle/settings/untangle-certificates'
+        isDir = os.path.exists(certificates_dir)
+        isFile = os.path.exists(f"{certificates_dir}/apache.pfx")
+        if not isDir and not isFile:
+            pytest.skip('%s certificate directory or certificate not present' % self.appNameWF())
+        url = global_functions.get_http_url()
+        headers = {'accept': 'application/json',}
+        files = {
+            'type': (None, 'certificate_upload'),
+            'argument': (None, 'upload_server'),
+            'filename': ('uploadcert.pem', open(f"{certificates_dir}/apache.pfx", 'rb') , 'application/x-x509-ca-cert')
+        }
+        rpc_url = f"{url}/admin/upload"
+        s = requests.Session()
+        # Log in
+        response = s.post(
+            f"{url}/auth/login?url=/admin&realm=Administrator",
+            data=f"fragment=&username={username}&password={password}",
+            verify=False
+        )
+        # Upload pem file containing cert and key files
+        response = s.post(
+            f"{rpc_url}",
+            headers=headers,
+            files=files
+
+        )
+        certificate_upload_response = json.loads(response.text)
+        #for invalid certificated files should get following error
+        assert "The file does not contain any valid certificates or keys" in certificate_upload_response.get('msg', None)
+
 test_registry.register_module("administration-tests", AdministrationTests)

--- a/uvm/hier/usr/share/untangle/bin/ut-cert-parser
+++ b/uvm/hier/usr/share/untangle/bin/ut-cert-parser
@@ -3,7 +3,7 @@
 import json
 import sys
 import os
-
+import re
 if "@PREFIX@" != '':
     sys.path.insert(0, '@PREFIX@/usr/lib/python3/dist-packages')
 
@@ -32,6 +32,29 @@ if len(sys.argv) < 2:
     
 if not os.access(sys.argv[1],os.R_OK):
     errorExit("Unable to read file")
+
+
+try:
+    with open(sys.argv[1], 'r') as input_file:
+        content = input_file.read()
+    is_found = False
+    # check if file contains trailing spaces with line endings
+    # check if file contains trailing spaces with CRLF endings or CRLF endings
+    if re.search(r' \n', content) or re.search(r' \r\n', content) or re.search(r' \r\n', content):
+        content = content.replace(' \n', '\n')
+        content = re.sub(r' [ \t]*\r?\n', '\n', content)
+        is_found = True
+    else:
+        pass
+
+    if is_found:
+        with open(sys.argv[1], 'w') as output_file:
+            output_file.write(content)
+except:
+    #uploaded pfx file, this code may throw an exception
+    #added unit test case, pass the exception, failure handled by
+    #code below
+    pass
 
 list = pem.parse_file(sys.argv[1])
 

--- a/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.io.File;
+import org.json.JSONObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -210,12 +211,18 @@ public class CertificateManagerImpl implements CertificateManager
             FileOutputStream fileStream = new FileOutputStream(CERTIFICATE_PARSER_FILE);
             fileStream.write(fileItem.get());
             fileStream.close();
-
+            ExecManagerResult result;
             // call the external utility to parse the uploaded file
             String certData = UvmContextFactory.context().execManager().execOutput(CERTIFICATE_PARSER_SCRIPT + " " + CERTIFICATE_PARSER_FILE + " " + argument);
-
+            if (certData != null && certData.contains("errorData")) {
+                JSONObject jsonCertData = new JSONObject(certData);
+                //errorData is present, fetch the value
+                String errorData = jsonCertData.optString("errorData");
+                result = new ExecManagerResult(1, errorData);
+            } else {
+                result = new ExecManagerResult(0, certData);
+            }
             // returned the results 
-            ExecManagerResult result = new ExecManagerResult(0, certData);
             return (result);
         }
     }


### PR DESCRIPTION
As  per acceptance criteria handled following scenarios and test cases for following have been added.
Test case to implement upload functionality has been added.
Pem files to simulate below scenarios will be added to Jiira Ticket, and customer uploaded pem files from jiira ticket are also working with this change.

1. spaces + newline at the end of the each line
2. DOS style CRLF at end of each line
3. spaces +  DOS style CRLF at end of each line

Earlier in case of failure, nothing was shown on UI, there was a change required in way errorMessage returned to UI
Now the Error message will be shown as PFA
![Screenshot from 2024-03-13 19-53-26](https://github.com/untangle/ngfw_src/assets/154513962/16e77dc4-c68e-441b-bf9a-d6cb7157aa7c)

in ut-cert-parser, try except block is added , if file is not parseable by pem module, above default behavior is shown.

Following is test case output, all tests are passing
![Screenshot from 2024-03-13 20-18-28](https://github.com/untangle/ngfw_src/assets/154513962/d726de7d-715b-4940-afc7-ff4ccd3f832c)

