### PR TITLE
 NGFW-14518 : Removing the code to set hash values in IPS settings on signature update

### DIFF
--- a/intrusion-prevention/hier/usr/lib/python3/dist-packages/tests/test_intrusion_prevention.py
+++ b/intrusion-prevention/hier/usr/lib/python3/dist-packages/tests/test_intrusion_prevention.py
@@ -631,10 +631,7 @@ class IntrusionPreventionTests(NGFWTestCase):
         # Update configurations files
         self.modify_conf_value()
         #Sync updated settings in current settings
-        app.synchronizeSettingsWithDefaults()
-        app.synchronizeSettingsWithClassifications()
-        app.synchronizeSettingsWithVariables()
-        app.setSettings(app.getSettings(), True, False)
+        app.synchronizeSettings()
         # Read updated settings file
         with open(original_file_path, "r") as updated_file:
             updated_content = updated_file.readlines()
@@ -645,10 +642,7 @@ class IntrusionPreventionTests(NGFWTestCase):
         #Restore updated configuration file to original files
         self.restore_original_files()
         #Restoring original settings as current settings
-        app.synchronizeSettingsWithDefaults()
-        app.synchronizeSettingsWithClassifications()
-        app.synchronizeSettingsWithVariables()
-        app.setSettings(app.getSettings(), True, False)
+        app.synchronizeSettings()
         #Read Restored settings file
         with open(original_file_path, "r") as restored_file:
             restored_content = restored_file.readlines()

--- a/intrusion-prevention/hier/usr/share/untangle/bin/intrusion-prevention-get-updates
+++ b/intrusion-prevention/hier/usr/share/untangle/bin/intrusion-prevention-get-updates
@@ -208,7 +208,7 @@ class Update:
         time_begin = time.time()
         app = Update.get_app()
         if app is not None:
-            app.setSettings(app.getSettings())
+            app.synchronizeSettings()
 
         if self.Debug is True:
             Logger.message("elapsed={elapsed:.2f}s".format(elapsed=time.time() - time_begin))

--- a/intrusion-prevention/src/com/untangle/app/intrusion_prevention/IntrusionPreventionApp.java
+++ b/intrusion-prevention/src/com/untangle/app/intrusion_prevention/IntrusionPreventionApp.java
@@ -335,11 +335,6 @@ public class IntrusionPreventionApp extends AppBase
                 }
             }
             try{
-                String defaultsMd5sum = md5sum(defaultsContents);
-                if(!defaultsMd5sum.equals(this.settings.getDefaultsMd5sum())){
-                    /**
-                     * Only sync if file has changed.
-                     */
                     JSONSerializer serializer = UvmContextFactory.context().getSerializer();
                     Iterator<?> keys = defaults.keys();
                     while( keys.hasNext()){
@@ -385,9 +380,8 @@ public class IntrusionPreventionApp extends AppBase
                         }
 
                     }
-                    this.settings.setDefaultsMd5sum(defaultsMd5sum);
                     changed = true;
-                }
+                
             }catch(Exception e){
                 logger.error("synchronizeSettingsWithDefaults: json parsing - ", e);
             }
@@ -422,11 +416,6 @@ public class IntrusionPreventionApp extends AppBase
                 }
             }
             try{
-                String classificationMd5sum = md5sum(classificationContents);
-                if(!classificationMd5sum.equals(this.settings.getClassificationMd5sum())){
-                    /**
-                     * Only sync if file has changed.
-                     */
                     List<IntrusionPreventionRule> classificationRules = new LinkedList<>();
                     List<IntrusionPreventionRuleCondition> classificationConditions = null;
 
@@ -482,11 +471,8 @@ public class IntrusionPreventionApp extends AppBase
                             rules.add(0, classificationRule);
                         }
                     }
-
-                    this.settings.setClassificationMd5sum(classificationMd5sum);
                     changed = true;
-                }
-
+                
             }catch(Exception e){
                 logger.error("synchronizeSettingsWithClassifications: parsing - ", e);
             }
@@ -507,8 +493,6 @@ public class IntrusionPreventionApp extends AppBase
             return false;
         }
 
-        String variablesMd5sum = md5sum(result.getOutput());
-        if(!variablesMd5sum.equals(this.settings.getVariablesMd5sum())){
             List<IntrusionPreventionVariable> variables = this.settings.getVariables();
             for ( String line : result.getOutput().split("\\r?\\n") ){
                 String variableLine[] = line.split("=");
@@ -524,9 +508,7 @@ public class IntrusionPreventionApp extends AppBase
                 }
             }
             this.settings.setVariables(variables);
-            this.settings.setVariablesMd5sum(variablesMd5sum);
             changed = true;
-        }
         return changed;
     }
 

--- a/intrusion-prevention/src/com/untangle/app/intrusion_prevention/IntrusionPreventionApp.java
+++ b/intrusion-prevention/src/com/untangle/app/intrusion_prevention/IntrusionPreventionApp.java
@@ -335,52 +335,52 @@ public class IntrusionPreventionApp extends AppBase
                 }
             }
             try{
-                    JSONSerializer serializer = UvmContextFactory.context().getSerializer();
-                    Iterator<?> keys = defaults.keys();
-                    while( keys.hasNext()){
-                        String key = (String) keys.next();
-                        if(key.equals("rules")){
-                            /**
-                             * Special handling for rules:  Replace but keep existing enabled values.
-                             */
-                            List<IntrusionPreventionRule> rules = settings.getRules();
+                JSONSerializer serializer = UvmContextFactory.context().getSerializer();
+                Iterator<?> keys = defaults.keys();
+                while( keys.hasNext()){
+                    String key = (String) keys.next();
+                    if(key.equals("rules")){
+                        /**
+                         * Special handling for rules:  Replace but keep existing enabled values.
+                         */
+                        List<IntrusionPreventionRule> rules = settings.getRules();
 
-                            JSONArray defaultRules = defaults.getJSONObject(key).getJSONArray("list");
-                            for(int i = 0; i < defaultRules.length(); i++){
-                                IntrusionPreventionRule defaultRule = (IntrusionPreventionRule) serializer.fromJSON(defaultRules.getString(i));
+                        JSONArray defaultRules = defaults.getJSONObject(key).getJSONArray("list");
+                        for(int i = 0; i < defaultRules.length(); i++){
+                            IntrusionPreventionRule defaultRule = (IntrusionPreventionRule) serializer.fromJSON(defaultRules.getString(i));
 
-                                boolean found = false;
-                                for(int j = 0; j < rules.size(); j++){
-                                    IntrusionPreventionRule rule = rules.get(j);
-                                    if(rule.getId().equals(defaultRule.getId())){
-                                        defaultRule.setEnabled(rule.getEnabled());
-                                        rules.set(j, defaultRule);
-                                        found = true;
-                                    }
-                                }
-                                if(found == false){
-                                    rules.add(defaultRule);
+                            boolean found = false;
+                            for(int j = 0; j < rules.size(); j++){
+                                IntrusionPreventionRule rule = rules.get(j);
+                                if(rule.getId().equals(defaultRule.getId())){
+                                    defaultRule.setEnabled(rule.getEnabled());
+                                    rules.set(j, defaultRule);
+                                    found = true;
                                 }
                             }
-                        }else{
-                            try{
-                                /**
-                                 * For everything else, perform a straight merge assuming methods exist.
-                                 */
-                                Method getMethod = this.settings.getClass().getMethod("get" + key.substring(0, 1).toUpperCase() + key.substring(1));
-                                Method setMethod = this.settings.getClass().getMethod("set" + key.substring(0, 1).toUpperCase() + key.substring(1), defaults.get(key).getClass());
-                                if(defaults.get(key).getClass().toString().equals("JSONObject")){
-                                    setMethod.invoke(this.settings, merge((JSONObject) defaults.get(key), (JSONObject) getMethod.invoke(this.settings)));
-                                }else{
-                                    setMethod.invoke(this.settings, defaults.get(key));                                    
-                                }
-                            }catch(Exception e){
-                                logger.error("synchronizeSettingsWithDefaults: method exception", e);
+                            if(found == false){
+                                rules.add(defaultRule);
                             }
                         }
-
+                    }else{
+                        try{
+                            /**
+                             * For everything else, perform a straight merge assuming methods exist.
+                             */
+                            Method getMethod = this.settings.getClass().getMethod("get" + key.substring(0, 1).toUpperCase() + key.substring(1));
+                            Method setMethod = this.settings.getClass().getMethod("set" + key.substring(0, 1).toUpperCase() + key.substring(1), defaults.get(key).getClass());
+                            if(defaults.get(key).getClass().toString().equals("JSONObject")){
+                                setMethod.invoke(this.settings, merge((JSONObject) defaults.get(key), (JSONObject) getMethod.invoke(this.settings)));
+                            }else{
+                                setMethod.invoke(this.settings, defaults.get(key));                                    
+                            }
+                        }catch(Exception e){
+                            logger.error("synchronizeSettingsWithDefaults: method exception", e);
+                        }
                     }
-                    changed = true;
+
+                }
+                changed = true;
                 
             }catch(Exception e){
                 logger.error("synchronizeSettingsWithDefaults: json parsing - ", e);
@@ -416,63 +416,63 @@ public class IntrusionPreventionApp extends AppBase
                 }
             }
             try{
-                    List<IntrusionPreventionRule> classificationRules = new LinkedList<>();
-                    List<IntrusionPreventionRuleCondition> classificationConditions = null;
+                List<IntrusionPreventionRule> classificationRules = new LinkedList<>();
+                List<IntrusionPreventionRuleCondition> classificationConditions = null;
 
-                    classificationConditions = new LinkedList<>();
-                    classificationConditions.add(new IntrusionPreventionRuleCondition( "CLASSTYPE", "=", ""));
-                    classificationRules.add(
-                        new IntrusionPreventionRule("default", classificationConditions, "Low Priority", false, CLASSIFICATION_ID_PREFIX + "_4")
-                    );
-                    classificationConditions = new LinkedList<>();
-                    classificationConditions.add(new IntrusionPreventionRuleCondition( "CLASSTYPE", "=", ""));
-                    classificationRules.add(
-                        new IntrusionPreventionRule("log", classificationConditions, "Medium Priority", false, CLASSIFICATION_ID_PREFIX + "_3")
-                    );
-                    classificationConditions = new LinkedList<>();
-                    classificationConditions.add(new IntrusionPreventionRuleCondition( "CLASSTYPE", "=", ""));
-                    classificationRules.add(
-                        new IntrusionPreventionRule("blocklog", classificationConditions, "High Priority", false, CLASSIFICATION_ID_PREFIX + "_2")
-                    );
-                    classificationConditions = new LinkedList<>();
-                    classificationConditions.add(new IntrusionPreventionRuleCondition( "CLASSTYPE", "=", ""));
-                    classificationRules.add(
-                        new IntrusionPreventionRule("blocklog", classificationConditions, "Critical Priority", false, CLASSIFICATION_ID_PREFIX + "_1")
-                    );
+                classificationConditions = new LinkedList<>();
+                classificationConditions.add(new IntrusionPreventionRuleCondition( "CLASSTYPE", "=", ""));
+                classificationRules.add(
+                    new IntrusionPreventionRule("default", classificationConditions, "Low Priority", false, CLASSIFICATION_ID_PREFIX + "_4")
+                );
+                classificationConditions = new LinkedList<>();
+                classificationConditions.add(new IntrusionPreventionRuleCondition( "CLASSTYPE", "=", ""));
+                classificationRules.add(
+                    new IntrusionPreventionRule("log", classificationConditions, "Medium Priority", false, CLASSIFICATION_ID_PREFIX + "_3")
+                );
+                classificationConditions = new LinkedList<>();
+                classificationConditions.add(new IntrusionPreventionRuleCondition( "CLASSTYPE", "=", ""));
+                classificationRules.add(
+                    new IntrusionPreventionRule("blocklog", classificationConditions, "High Priority", false, CLASSIFICATION_ID_PREFIX + "_2")
+                );
+                classificationConditions = new LinkedList<>();
+                classificationConditions.add(new IntrusionPreventionRuleCondition( "CLASSTYPE", "=", ""));
+                classificationRules.add(
+                    new IntrusionPreventionRule("blocklog", classificationConditions, "Critical Priority", false, CLASSIFICATION_ID_PREFIX + "_1")
+                );
 
-                    Matcher match = null;
-                    for(String line : classificationContents.split("\\r?\\n")){
-                        Matcher matcher = CLASSIFICATION_PATTERN.matcher(line);
-                        if(matcher.find()){
-                            for(IntrusionPreventionRule rule : classificationRules){
-                                String id = rule.getId();
-                                if(id.substring(id.length() -1).equals(matcher.group(3))){
-                                    classificationConditions = rule.getConditions();
-                                    String value = classificationConditions.get(0).getValue();
-                                    classificationConditions.get(0).setValue( value + ( value.isEmpty() ? ""  : ",") + matcher.group(1));
-                                    rule.setConditions(classificationConditions);
-                                }
+                Matcher match = null;
+                for(String line : classificationContents.split("\\r?\\n")){
+                    Matcher matcher = CLASSIFICATION_PATTERN.matcher(line);
+                    if(matcher.find()){
+                        for(IntrusionPreventionRule rule : classificationRules){
+                            String id = rule.getId();
+                            if(id.substring(id.length() -1).equals(matcher.group(3))){
+                                classificationConditions = rule.getConditions();
+                                String value = classificationConditions.get(0).getValue();
+                                classificationConditions.get(0).setValue( value + ( value.isEmpty() ? ""  : ",") + matcher.group(1));
+                                rule.setConditions(classificationConditions);
                             }
                         }
                     }
+                }
 
-                    List<IntrusionPreventionRule> rules = settings.getRules();
-                    for(IntrusionPreventionRule classificationRule : classificationRules){
-                        boolean found = false;
-                        for(int j = 0; j < rules.size(); j++){
-                            IntrusionPreventionRule rule = rules.get(j);
-                            if(rule.getId().equals(classificationRule.getId())){
-                                classificationRule.setEnabled(rule.getEnabled());
-                                rules.set(j, classificationRule);
-                                found = true;
-                            }
-                        }
-                        if(found == false){
-                            rules.add(0, classificationRule);
+                List<IntrusionPreventionRule> rules = settings.getRules();
+                for(IntrusionPreventionRule classificationRule : classificationRules){
+                    boolean found = false;
+                    for(int j = 0; j < rules.size(); j++){
+                        IntrusionPreventionRule rule = rules.get(j);
+                        if(rule.getId().equals(classificationRule.getId())){
+                            classificationRule.setEnabled(rule.getEnabled());
+                            rules.set(j, classificationRule);
+                            found = true;
                         }
                     }
-                    changed = true;
-                
+                    if(found == false){
+                        rules.add(0, classificationRule);
+                    }
+                }
+                changed = true;
+            
             }catch(Exception e){
                 logger.error("synchronizeSettingsWithClassifications: parsing - ", e);
             }
@@ -493,22 +493,22 @@ public class IntrusionPreventionApp extends AppBase
             return false;
         }
 
-            List<IntrusionPreventionVariable> variables = this.settings.getVariables();
-            for ( String line : result.getOutput().split("\\r?\\n") ){
-                String variableLine[] = line.split("=");
+        List<IntrusionPreventionVariable> variables = this.settings.getVariables();
+        for ( String line : result.getOutput().split("\\r?\\n") ){
+            String variableLine[] = line.split("=");
 
-                Boolean found = false;
-                for( IntrusionPreventionVariable variable : variables){
-                    if(variable.getName().equals(variableLine[0])){
-                        found = true;
-                    }
-                }
-                if(found == false){
-                    variables.add( new IntrusionPreventionVariable(variableLine[0], variableLine[1]) );
+            Boolean found = false;
+            for( IntrusionPreventionVariable variable : variables){
+                if(variable.getName().equals(variableLine[0])){
+                    found = true;
                 }
             }
-            this.settings.setVariables(variables);
-            changed = true;
+            if(found == false){
+                variables.add( new IntrusionPreventionVariable(variableLine[0], variableLine[1]) );
+            }
+        }
+        this.settings.setVariables(variables);
+        changed = true;
         return changed;
     }
 

--- a/intrusion-prevention/src/com/untangle/app/intrusion_prevention/IntrusionPreventionApp.java
+++ b/intrusion-prevention/src/com/untangle/app/intrusion_prevention/IntrusionPreventionApp.java
@@ -186,6 +186,16 @@ public class IntrusionPreventionApp extends AppBase
             this.settings = readSettings;
             logger.debug("Settings: " + this.settings.toJSONString());
         }
+        synchronizeSettings();
+
+        this.ipsEventMonitor = new IntrusionPreventionEventMonitor( this );
+    }
+
+    /**
+     * Sync Settings with updated
+     *
+     */
+    public void synchronizeSettings(){
         boolean updated = false;
         updated = synchronizeSettingsWithDefaults();
         updated = synchronizeSettingsWithClassifications() || updated;
@@ -194,10 +204,7 @@ public class IntrusionPreventionApp extends AppBase
         if(updated){
             this.setSettings(this.settings, true, false);
         }
-
-        this.ipsEventMonitor = new IntrusionPreventionEventMonitor( this );
     }
-
     /**
      * Get intrusion prevention settings.
      *

--- a/intrusion-prevention/src/com/untangle/app/intrusion_prevention/IntrusionPreventionSettings.java
+++ b/intrusion-prevention/src/com/untangle/app/intrusion_prevention/IntrusionPreventionSettings.java
@@ -19,8 +19,12 @@ import java.util.LinkedList;
 public class IntrusionPreventionSettings implements Serializable, JSONString
 {
     private Integer version = 3;
+    /* deprecated - defaultsMd5sum, classificationMd5sum and variablesMd5sum - this remains so json serialization works */
+    @Deprecated
     private String defaultsMd5sum = "";
+    @Deprecated
     private String classificationMd5sum = "";
+    @Deprecated
     private String variablesMd5sum = "";
     private List<IntrusionPreventionRule> rules = new LinkedList<>();
     private List<IntrusionPreventionSignature> signatures = new LinkedList<>();
@@ -62,14 +66,17 @@ public class IntrusionPreventionSettings implements Serializable, JSONString
 
     public Integer getVersion() { return version; }
     public void setVersion(Integer version) { this.version = version; }
-
+    @Deprecated
     public String getDefaultsMd5sum() { return defaultsMd5sum; }
+    @Deprecated
     public void setDefaultsMd5sum(String defaultsMd5sum) { this.defaultsMd5sum = defaultsMd5sum; }
-
+    @Deprecated
     public String getClassificationMd5sum() { return classificationMd5sum; }
+    @Deprecated
     public void setClassificationMd5sum(String classificationMd5sum) { this.classificationMd5sum = classificationMd5sum; }
-
+    @Deprecated
     public String getVariablesMd5sum() { return variablesMd5sum; }
+    @Deprecated
     public void setVariablesMd5sum(String variablesMd5sum) { this.variablesMd5sum = variablesMd5sum; }
 
     public List<IntrusionPreventionRule> getRules() { return rules; }


### PR DESCRIPTION
**Request:**  We should stop setting hash value in settings file while updating the signature, as there is not significant use of those values.

**FIX:** Removed all the relevant references to MD5 value generation.

**TEST:**

- Run the ngfw build 
- Added new rule, signature in IPS and checked the setting file generation. It should not contain below fileds: 
     classificationMd5sum, defaultsMd5sum and variablesMd5sumq

Added unit test:

1. Make copies of current files (copy to /tmp):
Current settings file
/usr/share/untangle-suricata-config/current/templates/defaults.js
/usr/share/untangle-suricata-config/current/rules/classification.config
/etc/suricata/suricata.yaml
2. Make modifications:
/usr/share/untangle-suricata-config/current/templates/defaults.js
	Safe value to change: SYSTEM_MEMORY value to any other number
/usr/share/untangle-suricata-config/current/rules/classification.config
Add a new entry like:
config classification: test-test,Test classification,1
/etc/suricata/suricata.yaml
under vars: add new variable like TEST_PORTS under ports-group.
3. call setSettings with current settings
Verify changes in settings file.
4. Restore original files
call setSettings with current settings
Verify settings file matches original settings file.
