### PR TITLE
ngfw-13538 not allowing reserved addresses in ADDRESSED and STATIC interface Address and aliases

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -907,6 +907,29 @@ Ext.define('Ung.util.Util', {
     },
 
     /**
+     * From the specified IP address and netmask, return the broadcast.
+     * For example, 192.168.1.1/255.255.255.0 returns 192.168.1.255
+     * @param {*} ip
+     * @param {*} netmask
+     */
+    getBroadcast: function(ip, netmask){
+        var network = this.getNetwork(ip, netmask);
+        var networkOctets = network.split('.');
+        var netMaskOctets = netmask.split('.');
+
+        // Convert octets to integers
+        var networkInt = networkOctets.map(function(octet) { return parseInt(octet, 10); });
+        var netmaskInt = netMaskOctets.map(function(octet) { return parseInt(octet, 10); });
+
+        // Calculate the the broadcast address
+        var broadcastOctets = networkInt.map(function(octet, index) { return (octet & netmaskInt[index]) | (~netmaskInt[index] & 255); });
+    
+        // Format the broadcast address
+        var broadcastAddr = broadcastOctets.join('.');
+        return broadcastAddr;
+    },
+
+    /**
      * Increment the passed IP
      * @param  string ip      IP address to increment.
      * @param  int inc        Number to increment by.

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -406,6 +406,17 @@ Ext.define('Ung.config.network.Interface', {
                     blankText: 'Address must be specified.'.t(),
                     vtype: 'ip4AddExcldDflt',
                     validator: function(value) {
+                        // Validation for not allowing network and broadcast address of selected netmask
+                        try {
+                            var staticPrefix = this.up('window').down('#intfcNetmask').getValue(),
+                                intfcNetMask = Util.getV4NetmaskMap()[staticPrefix];
+                            if(value == Util.getNetwork(value, intfcNetMask) || value == Util.getBroadcast(value, intfcNetMask)) {
+                                return Ext.String.format('Entered address is network or broadcast address of selected Netmask {0}.'.t(), intfcNetMask);
+                            }
+                        } catch(er) {
+                            console.log(er);
+                        }
+                        // Validation for not allowing conflicing addresses
                         var intfName = this.up('window').down('#iterfacename').getValue(),
                             intfStore = this.up('config-network').getViewModel().getStore('interfaces'),
                             intfRecName;   
@@ -435,6 +446,7 @@ Ext.define('Ung.config.network.Interface', {
                         value: '{intf.v4StaticPrefix}',
                     },
                     fieldLabel: 'Netmask'.t(),
+                    itemId: 'intfcNetmask',
                     allowBlank: false,
                     editable: false,
                     store: Util.getV4NetmaskList(false, true),
@@ -585,6 +597,18 @@ Ext.define('Ung.config.network.Interface', {
                         emptyText: '[enter IPv4 address]'.t(),
                         allowBlank: false,
                         validator: function(value) {
+                            // Validation for not allowing network and broadcast address of selected netmask                           
+                            try {
+                                var staticPrefix = this.up("ungrid").getSelectionModel().getSelection()[0].get('staticPrefix'),
+                                    aliasNetMask = Util.getV4NetmaskMap()[staticPrefix];
+
+                                if(value == Util.getNetwork(value, aliasNetMask) || value == Util.getBroadcast(value, aliasNetMask)) {
+                                    return Ext.String.format('Entered address is network or broadcast address of selected Netmask {0}.'.t(), aliasNetMask);
+                                }
+                            } catch(err) {
+                                console.log(err);
+                            }
+                            // Validation for not allowing duplicate IP Addresses
                             if(this.dirty) {
                                 // Check if current value is eqaul to original value
                                 if(this.value === this.originalValue) return true;


### PR DESCRIPTION
Changes:
1. Added a `getBroadcast` method in `Util.js` file to obtain broadcast address from given IP and Netmask.
2. Added validation for `Address` field in `IPv4 Static Configuration` to not allow any reserved ip address (network or broadcast)
3. Added validation for `Address` field in `IPv4 Aliases` grid to not allow any reserved ip address (network or broadcast)

Error message: Entered address is network or broadcast address of selected Netmask {ipSubnetMask}.

Local Testing Screenshots

![Screenshot from 2024-03-14 18-56-28](https://github.com/untangle/ngfw_src/assets/154422821/3ac21145-2d8c-4fc4-997a-94a464377029)

![Screenshot from 2024-03-14 20-02-03](https://github.com/untangle/ngfw_src/assets/154422821/9a9a2538-79b1-4075-a7a5-86108d45c4b7)

