### PR TITLE
ngfw-13538 handling initial condition for add alias

### DIFF
--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -599,9 +599,9 @@ Ext.define('Ung.config.network.Interface', {
                         validator: function(value) {
                             // Validation for not allowing network and broadcast address of selected netmask                           
                             try {
-                                var staticPrefix = this.up("ungrid").getSelectionModel().getSelection()[0].get('staticPrefix'),
+                                var selection = this.up("ungrid").getSelectionModel().getSelection()[0],
+                                    staticPrefix = selection ? selection.get('staticPrefix') : 24,
                                     aliasNetMask = Util.getV4NetmaskMap()[staticPrefix];
-
                                 if(value == Util.getNetwork(value, aliasNetMask) || value == Util.getBroadcast(value, aliasNetMask)) {
                                     return Ext.String.format('Address cannot be a network or broadcast address with netmask {0}'.t(), aliasNetMask);
                                 }


### PR DESCRIPTION
According to testing review, user was able to save alias with reserved IP.

I am using `SelectionModel` to get the selected row in the alias grid. 
When we add alias, somehow `SelectionModel` is not able to pick the row and hence value of `this.up("ungrid").getSelectionModel().getSelection()[0]` is `undefined`

Added a condition such that if value of above expression is `undefined` then use default value of `staticPrefix` i.e. 24.
As we are facing this issue only when we add new alias it should not be a problem to use default value as 24.
We are using same default value (24) for empty row.