### PR TITLE
ngfw-13254: Web Filter Unflagged Pass Rule No Trigger

### DIFF
--- a/web-filter-base/src/com/untangle/app/web_filter/DecisionEngine.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/DecisionEngine.java
@@ -276,10 +276,12 @@ public abstract class DecisionEngine
                             new WebFilterRedirectDetails( app.getSettings(), host, uri.toString(), filterRule.getDescription(), clientIp, app.getAppTitle(), Reason.FILTER_RULE, host), 
                             sess, uri.toString(), header),
                         HttpRedirect.RedirectType.BLOCK));
-            } else if ((filterRule != null) && (filterRule.getFlagged())) {
-                WebFilterEvent hbe = new WebFilterEvent(requestLine.getRequestLine(), sess.sessionEvent(), Boolean.FALSE, Boolean.TRUE, Reason.FILTER_RULE, bestCategory.getId(), filterRule.getRuleId(), filterRule.getDescription(), app.getName());
+            } else if (filterRule != null) {
+                //Rule should be triggered irrespective of Flag
+                if(filterRule.getFlagged()) isFlagged = true;
+                WebFilterEvent hbe = new WebFilterEvent(requestLine.getRequestLine(), sess.sessionEvent(), Boolean.FALSE, isFlagged, Reason.FILTER_RULE, bestCategory.getId(), filterRule.getRuleId(), filterRule.getDescription(), app.getName());
                 app.logEvent(hbe);
-                app.incrementFlagCount();
+                if (isFlagged) app.incrementFlagCount();
                 return null;
             }
         }


### PR DESCRIPTION
Root Cause:
Earlier code was just checking for Flagged and passing the rule, made changes to check both flagged and unflagged,
In case of Flagged added event to flagged events.

Added test case to simulate the scenario and it is passing.
![Screenshot from 2024-03-18 15-59-46](https://github.com/untangle/ngfw_src/assets/154513962/76f080fa-93d8-48f1-863e-1b37f28c2702)

Testing Steps:
For existing setup, got to Apps-> WebFilter
1. Enable Social Networking  category in Group Productivity in categories,
2. Enable block and flag check box, at this point , verify (www.facebook.com is blocked by web filter)
3.  Add a Rule from rules tab, with condition as Web Filter category and Value as Social Networking, enable flag check box, action as pass , verify (www.facebook.com is not blocked by web filter and accessible)
![Screenshot from 2024-03-18 16-06-33](https://github.com/untangle/ngfw_src/assets/154513962/9a5d03ee-b45f-405b-bc66-69a343096091)
4. In step 3 go back and removed flagged checked option from above rule, verify (www.facebook.com is blocked by web filter)
![Screenshot from 2024-03-18 16-06-57](https://github.com/untangle/ngfw_src/assets/154513962/9fe5eba0-c748-46a0-96d6-ea88419fa1e7)

Upgrade the setup with this PR,
and repeat step4 , 
- Verify (www.facebook.com is accessible and not blocked by WebFilter
- Verify (www.facebook.com ) Events are visible in Reports section of Web Filter / All Web Events, with Flagged and Blocked as False
![Screenshot from 2024-03-18 16-18-18](https://github.com/untangle/ngfw_src/assets/154513962/5292850b-b51b-4edc-aec7-46b1cbfdeb99)

