### PR TITLE
NGFW-14307 IPsec VPN- Restricting network bits to <= 30 for L2TP, XAuth, IKEv2

### DIFF
--- a/ipsec-vpn/js/view/VpnConfig.js
+++ b/ipsec-vpn/js/view/VpnConfig.js
@@ -52,13 +52,19 @@ Ext.define('Ung.apps.ipsecvpn.view.VpnConfig', {
             bind: '{settings.virtualAddressPool}',
             vtype: 'cidrBlock',
             allowBlank: false,
-            fieldLabel: 'L2TP Address Pool'.t()
+            fieldLabel: 'L2TP Address Pool'.t(),
+            validator: function(value) {
+                return value.split('/')[1] <= 30 ? true : 'Network identifier bits must be less than or equal to 30.'.t();
+            }
         },{
             xtype: 'textfield',
             bind: '{settings.virtualXauthPool}',
             vtype: 'cidrBlock',
             allowBlank: false,
-            fieldLabel: 'Xauth/IKEv2 Address Pool'.t()
+            fieldLabel: 'Xauth/IKEv2 Address Pool'.t(),
+            validator: function(value) {
+                return value.split('/')[1] <= 30 ? true : 'Network identifier bits must be less than or equal to 30.'.t();
+            }
         },{
             xtype: 'textfield',
             bind: '{settings.virtualDnsOne}',


### PR DESCRIPTION
For IPSec VPN virtual config, we are now restricting address pool network bits to <= 30 for L2TP, XAuth, IKEv2.
![Screenshot from 2024-03-19 23-03-11](https://github.com/untangle/ngfw_src/assets/154527616/19e76c40-68fc-4148-a487-0a5887d0b1e4)


For CIDR: `10.1.0.15/30`, `/etc/xl2tpd/xl2tpd.conf` gets,
```
[lns default]
	ip range = 10.1.0.14 - 10.1.0.14
	local ip = 10.1.0.13
```
For CIDR: `10.1.0.15/29`, `/etc/xl2tpd/xl2tpd.conf` gets,
```
[lns default]
	ip range = 10.1.0.10 - 10.1.0.14
	local ip = 10.1.0.9
```