### PR TITLE
ngfw-13845: Virus Blocker/Virus Blocker Lite FTP reports pulling from from wrong table

### DIFF
--- a/virus-blocker-lite/hier/usr/share/untangle/lib/virus-blocker-lite/reports/top-ftp-clients.json
+++ b/virus-blocker-lite/hier/usr/share/untangle/lib/virus-blocker-lite/reports/top-ftp-clients.json
@@ -19,7 +19,7 @@
         }
     ],
     "readOnly": true,
-    "table": "http_events",
+    "table": "ftp_events",
     "title": "FTP Top Blocked Clients",
     "pieStyle": "PIE",
     "type": "PIE_GRAPH"

--- a/virus-blocker-lite/hier/usr/share/untangle/lib/virus-blocker-lite/reports/top-ftp-servers.json
+++ b/virus-blocker-lite/hier/usr/share/untangle/lib/virus-blocker-lite/reports/top-ftp-servers.json
@@ -1,14 +1,14 @@
 {
     "uniqueId": "virus-blocker-lite-Gtrs5GtR",
     "category": "Virus Blocker Lite",
-    "description": "The number of clients with blocked viruses by FTP activity.",
+    "description": "The number of sites with blocked viruses by FTP activity.",
     "displayOrder": 206,
     "enabled": true,
     "javaClass": "com.untangle.app.reports.ReportEntry",
     "orderByColumn": "value",
     "orderDesc": true,
     "units": "hits",
-    "pieGroupColumn": "host",
+    "pieGroupColumn": "s_server_addr",
     "pieSumColumn": "count(*)",
     "conditions": [
         {
@@ -19,7 +19,7 @@
         }
     ],
     "readOnly": true,
-    "table": "http_events",
+    "table": "ftp_events",
     "title": "FTP Top Blocked Sites",
     "pieStyle": "PIE",
     "type": "PIE_GRAPH"

--- a/virus-blocker/hier/usr/share/untangle/lib/virus-blocker/reports/top-ftp-clients.json
+++ b/virus-blocker/hier/usr/share/untangle/lib/virus-blocker/reports/top-ftp-clients.json
@@ -19,7 +19,7 @@
         }
     ],
     "readOnly": true,
-    "table": "http_events",
+    "table": "ftp_events",
     "title": "FTP Top Blocked Clients",
     "pieStyle": "PIE",
     "type": "PIE_GRAPH"

--- a/virus-blocker/hier/usr/share/untangle/lib/virus-blocker/reports/top-ftp-servers.json
+++ b/virus-blocker/hier/usr/share/untangle/lib/virus-blocker/reports/top-ftp-servers.json
@@ -1,14 +1,14 @@
 {
     "uniqueId": "virus-blocker-gNI4MdxW",
     "category": "Virus Blocker",
-    "description": "The number of clients with blocked viruses by FTP activity.",
+    "description": "The number of sites with blocked viruses by FTP activity.",
     "displayOrder": 206,
     "enabled": true,
     "javaClass": "com.untangle.app.reports.ReportEntry",
     "orderByColumn": "value",
     "orderDesc": true,
     "units": "hits",
-    "pieGroupColumn": "host",
+    "pieGroupColumn": "s_server_addr",
     "pieSumColumn": "count(*)",
     "conditions": [
         {
@@ -19,7 +19,7 @@
         }
     ],
     "readOnly": true,
-    "table": "http_events",
+    "table": "ftp_events",
     "title": "FTP Top Blocked Sites",
     "pieStyle": "PIE",
     "type": "PIE_GRAPH"


### PR DESCRIPTION
Since FTP server test.untangle.com has some issues while running the FTP tests and local FTP server is passing the blocking scenarios 

Tested this by failing the success event in  virus-blocker-base/src/com/untangle/app/virus_blocker/VirusFtpHandler.java
modifying VirusScannerResult to error always.
`result = new VirusScannerResult(false, "TestError");`

Changes Done for virus_blocker and virus_blocker_lite apps
1. Changed the table names to ftp_events and field in  FTP Top Blocked Sites to s_server_address as hostname field contains address of client from where ftp test is running. 
2. Modified description of FTP Top Blocked Sites which was referring to clients instead of sites.

Following are screenshots for virusblocker and virusblockerlite apps : Affected reports
- FTP Top Blocked Clients
- FTP Top Blocked Sites

Virus Blocker Lite / FTP Top Blocked Sites
![Screenshot from 2024-03-20 17-32-40](https://github.com/untangle/ngfw_src/assets/154513962/3fbe9a8b-b725-4692-a092-bd6cf9916756)

Virus Blocker Lite / FTP Top Blocked Clients
![Screenshot from 2024-03-20 17-32-30](https://github.com/untangle/ngfw_src/assets/154513962/5b835d2a-2683-43de-ae4e-b9f5444abf0c)

Virus Blocker / FTP Top Blocked Clients
![Screenshot from 2024-03-20 17-30-49](https://github.com/untangle/ngfw_src/assets/154513962/b33f8f2a-40f4-494b-bb82-032277805cf1)

Virus Blocker / FTP Top Blocked Sites
![Screenshot from 2024-03-20 17-30-35](https://github.com/untangle/ngfw_src/assets/154513962/68544576-3c08-4e4d-ad3e-f102afb22ba8)
