### PR TITLE
Ngfw 13743 modify protocols condition list

### DIFF
--- a/application-control/js/view/Rules.js
+++ b/application-control/js/view/Rules.js
@@ -4,7 +4,7 @@ Ext.define('Ung.apps.applicationcontrol.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/application-control/js/view/Rules.js
+++ b/application-control/js/view/Rules.js
@@ -4,6 +4,7 @@ Ext.define('Ung.apps.applicationcontrol.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/bandwidth-control/js/view/Rules.js
+++ b/bandwidth-control/js/view/Rules.js
@@ -4,6 +4,7 @@ Ext.define('Ung.apps.bandwidthcontrol.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/bandwidth-control/js/view/Rules.js
+++ b/bandwidth-control/js/view/Rules.js
@@ -4,7 +4,7 @@ Ext.define('Ung.apps.bandwidthcontrol.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/captive-portal/js/view/CaptureRules.js
+++ b/captive-portal/js/view/CaptureRules.js
@@ -4,6 +4,7 @@ Ext.define('Ung.apps.captive-portal.view.CaptureRules', {
     itemId: 'capture-rules',
     title: 'Capture Rules'.t(),
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/captive-portal/js/view/CaptureRules.js
+++ b/captive-portal/js/view/CaptureRules.js
@@ -4,7 +4,7 @@ Ext.define('Ung.apps.captive-portal.view.CaptureRules', {
     itemId: 'capture-rules',
     title: 'Capture Rules'.t(),
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/firewall/js/view/Rules.js
+++ b/firewall/js/view/Rules.js
@@ -5,6 +5,7 @@ Ext.define('Ung.apps.firewall.view.Rules', {
     title: 'Rules'.t(),
     scrollable: true,
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/firewall/js/view/Rules.js
+++ b/firewall/js/view/Rules.js
@@ -5,7 +5,7 @@ Ext.define('Ung.apps.firewall.view.Rules', {
     title: 'Rules'.t(),
     scrollable: true,
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/intrusion-prevention/js/view/BypassRules.js
+++ b/intrusion-prevention/js/view/BypassRules.js
@@ -4,7 +4,7 @@ Ext.define('Ung.apps.intrusionprevention.view.BypassRules', {
     itemId: 'bypass-rules',
     scrollable: true,
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     title: 'Bypass Rules'.t(),
 
     tbar: ['@add', '->', '@import', '@export'],

--- a/intrusion-prevention/js/view/BypassRules.js
+++ b/intrusion-prevention/js/view/BypassRules.js
@@ -4,6 +4,7 @@ Ext.define('Ung.apps.intrusionprevention.view.BypassRules', {
     itemId: 'bypass-rules',
     scrollable: true,
     withValidation: false,
+    onlyTcpUdpSupported: true,
     title: 'Bypass Rules'.t(),
 
     tbar: ['@add', '->', '@import', '@export'],

--- a/intrusion-prevention/js/view/IpsRules.js
+++ b/intrusion-prevention/js/view/IpsRules.js
@@ -5,6 +5,7 @@ Ext.define('Ung.apps.intrusionprevention.view.Rules', {
     title: 'Rules'.t(),
     scrollable: true,
     withValidation: false,
+    onlyTcpUdpSupported: true,
     controller: 'unintrusionrulegrid',
 
     viewConfig: {

--- a/intrusion-prevention/js/view/IpsRules.js
+++ b/intrusion-prevention/js/view/IpsRules.js
@@ -5,7 +5,7 @@ Ext.define('Ung.apps.intrusionprevention.view.Rules', {
     title: 'Rules'.t(),
     scrollable: true,
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     controller: 'unintrusionrulegrid',
 
     viewConfig: {

--- a/policy-manager/js/view/Rules.js
+++ b/policy-manager/js/view/Rules.js
@@ -4,7 +4,7 @@ Ext.define('Ung.apps.policymanager.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/policy-manager/js/view/Rules.js
+++ b/policy-manager/js/view/Rules.js
@@ -4,6 +4,7 @@ Ext.define('Ung.apps.policymanager.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/ssl-inspector/js/view/Rules.js
+++ b/ssl-inspector/js/view/Rules.js
@@ -4,6 +4,7 @@ Ext.define('Ung.apps.sslinspector.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/ssl-inspector/js/view/Rules.js
+++ b/ssl-inspector/js/view/Rules.js
@@ -4,7 +4,7 @@ Ext.define('Ung.apps.sslinspector.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/threat-prevention/js/view/Rules.js
+++ b/threat-prevention/js/view/Rules.js
@@ -5,7 +5,7 @@ Ext.define('Ung.apps.threatprevention.view.Rules', {
     title: 'Rules'.t(),
     scrollable: true,
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/threat-prevention/js/view/Rules.js
+++ b/threat-prevention/js/view/Rules.js
@@ -5,6 +5,7 @@ Ext.define('Ung.apps.threatprevention.view.Rules', {
     title: 'Rules'.t(),
     scrollable: true,
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/tunnel-vpn/js/view/Rules.js
+++ b/tunnel-vpn/js/view/Rules.js
@@ -5,7 +5,7 @@ Ext.define('Ung.apps.tunnel-vpn.view.Rules', {
     title: 'Rules'.t(),
     viewModel: true,
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/tunnel-vpn/js/view/Rules.js
+++ b/tunnel-vpn/js/view/Rules.js
@@ -5,6 +5,7 @@ Ext.define('Ung.apps.tunnel-vpn.view.Rules', {
     title: 'Rules'.t(),
     viewModel: true,
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -1177,6 +1177,39 @@ Ext.define('Ung.util.Util', {
         }catch(err){
             throw err;
         }
-    }
+    },
+
+    /**
+     * Method to get list of supported protocols
+     * @param boolean onlyTcpUdp True if only TCP and UDP traffic is supported.
+     * @return List of protocols based on onlyTcpUdp flag value.
+     */
+    getProtocolList: function(onlyTcpUdp) {
+        if(onlyTcpUdp) {
+            return [[
+                "TCP","TCP"
+            ],[
+                "UDP","UDP"
+            ]];
+        } else {
+            return [[
+                "TCP","TCP"
+            ],[
+                "UDP","UDP"
+            ],[
+                "ICMP","ICMP"
+            ],[
+                "GRE","GRE"
+            ],[
+                "ESP","ESP"
+            ],[
+                "AH","AH"
+            ],[
+                "SCTP","SCTP"
+            ],[
+                "OSPF","OSPF"
+            ]];
+        }
+    },
     
 });

--- a/uvm/servlets/admin/app/cmp/ConditionsEditor.js
+++ b/uvm/servlets/admin/app/cmp/ConditionsEditor.js
@@ -482,23 +482,7 @@ Ext.define('Ung.cmp.ConditionsEditor', {
             name:"PROTOCOL",
             displayName: "Protocol".t(),
             type: 'checkboxgroup',
-            values: [[
-                "TCP","TCP"
-            ],[
-                "UDP","UDP"
-            ],[
-                "ICMP","ICMP"
-            ],[
-                "GRE","GRE"
-            ],[
-                "ESP","ESP"
-            ],[
-                "AH","AH"
-            ],[
-                "SCTP","SCTP"
-            ],[
-                "OSPF","OSPF"
-            ]]
+            values: Util.getProtocolList(false)
         },{
             name:"SRC_INTF",
             displayName: "Source Interface".t(),

--- a/uvm/servlets/admin/app/cmp/ConditionsEditorController.js
+++ b/uvm/servlets/admin/app/cmp/ConditionsEditorController.js
@@ -659,6 +659,20 @@ Ext.define('Ung.cmp.ConditionsEditorController', {
     },
 
     /**
+     * Returns the list of supported protocols for parent grid
+     */
+    getProtocolList: function() {
+        var view = this.getView(),
+            ruleGrid = view.up('grid'),
+            onlyTcpUdpSupportedGrids = ['app-firewall-rules'];
+
+        if(ruleGrid && onlyTcpUdpSupportedGrids.includes(ruleGrid.xtype))
+            return Util.getProtocolList(true);
+        else
+            return Util.getProtocolList(false);
+    },
+
+    /**
      * Adds a new condition for the edited rule
      */
     addCondition: function (menu, item) {
@@ -668,6 +682,11 @@ Ext.define('Ung.cmp.ConditionsEditorController', {
         if( item === undefined){
             return;
         }
+
+        if( item.conditionType == "PROTOCOL" ) {
+            view.conditions.PROTOCOL.values = this.getProtocolList();
+        }
+
         var record = Ext.create(me.getView().model);
 
         record.set(view.fields.type, item.conditionType);

--- a/uvm/servlets/admin/app/cmp/ConditionsEditorController.js
+++ b/uvm/servlets/admin/app/cmp/ConditionsEditorController.js
@@ -666,7 +666,9 @@ Ext.define('Ung.cmp.ConditionsEditorController', {
             ruleGrid = view.up('grid'),
             onlyTcpUdpSupportedGrids = ['app-firewall-rules'];
 
-        if(ruleGrid && onlyTcpUdpSupportedGrids.includes(ruleGrid.xtype))
+        console.log("In getProtocolList");
+
+        if(ruleGrid && ruleGrid.onlyTcpUdpSupported)
             return Util.getProtocolList(true);
         else
             return Util.getProtocolList(false);

--- a/uvm/servlets/admin/app/cmp/ConditionsEditorController.js
+++ b/uvm/servlets/admin/app/cmp/ConditionsEditorController.js
@@ -663,12 +663,9 @@ Ext.define('Ung.cmp.ConditionsEditorController', {
      */
     getProtocolList: function() {
         var view = this.getView(),
-            ruleGrid = view.up('grid'),
-            onlyTcpUdpSupportedGrids = ['app-firewall-rules'];
+            ruleGrid = view.up('grid');
 
-        console.log("In getProtocolList");
-
-        if(ruleGrid && ruleGrid.onlyTcpUdpSupported)
+        if(ruleGrid && ruleGrid.editorFieldProtocolTcpUdpOnly)
             return Util.getProtocolList(true);
         else
             return Util.getProtocolList(false);

--- a/wan-balancer/js/view/RouteRules.js
+++ b/wan-balancer/js/view/RouteRules.js
@@ -6,7 +6,7 @@ Ext.define('Ung.apps.wan-balancer.view.RouteRules', {
     viewModel: true,
     scrollable: true,
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/wan-balancer/js/view/RouteRules.js
+++ b/wan-balancer/js/view/RouteRules.js
@@ -6,6 +6,7 @@ Ext.define('Ung.apps.wan-balancer.view.RouteRules', {
     viewModel: true,
     scrollable: true,
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/web-filter/js/view/Rules.js
+++ b/web-filter/js/view/Rules.js
@@ -4,7 +4,7 @@ Ext.define('Ung.apps.webfilter.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/web-filter/js/view/Rules.js
+++ b/web-filter/js/view/Rules.js
@@ -4,6 +4,7 @@ Ext.define('Ung.apps.webfilter.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/web-monitor/js/view/Rules.js
+++ b/web-monitor/js/view/Rules.js
@@ -4,7 +4,7 @@ Ext.define('Ung.apps.webmonitor.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
-    onlyTcpUdpSupported: true,
+    editorFieldProtocolTcpUdpOnly: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',

--- a/web-monitor/js/view/Rules.js
+++ b/web-monitor/js/view/Rules.js
@@ -4,6 +4,7 @@ Ext.define('Ung.apps.webmonitor.view.Rules', {
     itemId: 'rules',
     title: 'Rules'.t(),
     withValidation: false,
+    onlyTcpUdpSupported: true,
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',


### PR DESCRIPTION
Added conditional list for protocol check boxes . i.e. if app is supporting only TCP/UDP protocol then in Rules Editor, only those two check boxes should be visible.

![Screenshot from 2024-03-20 20-21-16](https://github.com/untangle/ngfw_src/assets/154422821/29948749-9881-4412-b38d-bb55177bd2f8)

List of the rules where change is applied
[ProtcolListChange.txt](https://github.com/untangle/ngfw_src/files/14668446/ProtcolListChange.txt)
