### PR TITLE
Cannot give online access to existing Reports users

### DIFF
--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -1421,8 +1421,9 @@ class ReportsTests(NGFWTestCase):
 
     @classmethod
     def final_extra_tear_down(cls):
-        global web_app
-
+        global web_app, orig_settings
+        #Restoring original report settings
+        cls._app.setSettings(orig_settings)
         # remove all the apps in case test 103 does not remove them.
         for name in apps_list:
             if (uvmContext.appManager().isInstantiated(name)):

--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -936,7 +936,7 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
         if ( settings.getReportsUsers() != null) {
             for ( ReportsUser user : settings.getReportsUsers() ) {
                 if ( user.getOnlineAccess() ) {
-                    if ( user.trans_getPasswordHash() == null )
+                    if ( user.getPasswordHashShadow() == null )
                         throw new RuntimeException(I18nUtil.marktr("Invalid Settings") + ": \"" + user.getEmailAddress() + "\" " + I18nUtil.marktr("has online access, but no password is set."));
                 }
             }


### PR DESCRIPTION
Made change to sanityCheck method to check for getPasswordHashShadow() method which has value instead of trans_getPasswordHash.

Unit tests are already present which was failing due to above scenario, TestCase is passing.
Made a small change to revert to original report settings
Following are testcase screenshot
![Screenshot from 2024-03-22 15-39-00](https://github.com/untangle/ngfw_src/assets/154513962/8ee5fdcb-7754-4c03-b81a-329a6eb0ddb1)
 screen shots
![Screenshot from 2024-03-22 16-21-25](https://github.com/untangle/ngfw_src/assets/154513962/e7f98da6-4124-4ec7-a9aa-fa300f0f2173)
