### PR TITLE
Ngfw 14440 warn about bypass rules for lan addresses

### DIFF
--- a/intrusion-prevention/js/MainController.js
+++ b/intrusion-prevention/js/MainController.js
@@ -2201,3 +2201,50 @@ Ext.define ('Ung.apps.intrusionprevention.model.Condition', {
         }
     }
 });
+
+Ext.define('Ung.apps.intrusionprevention.cmp.BypassRulesController', {
+    extend: 'Ung.cmp.GridController',
+    alias: 'controller.unintrusionbypassrulesgrid',
+
+    warnSrcAddrIsLan: function() {
+        var vm = this.getViewModel();
+
+        vm.set('warnBypassRuleSrcAddrIsLan', false);
+        var lanIpAddrs = Util.getLanIpAddrs(),
+            bypassRules = Ext.Array.pluck(this.getView().getStore().getRange(), 'data');    
+
+        if(bypassRules) {
+            bypassRules.forEach(function(rule) {
+                if(rule) {
+                    rule.conditions.list.forEach(function(condition) {
+                        if(condition.conditionType == "SRC_ADDR" && lanIpAddrs.includes(condition.value)) {
+                            vm.set('warnBypassRuleSrcAddrIsLan', true);
+                        }
+                    });
+                }
+            });
+        }
+    },
+});
+
+Ext.define('Ung.apps.intrusionprevention.cmp.BypassRulesRecordEditor', {
+    extend: 'Ung.cmp.RecordEditor',
+    xtype: 'ung.cmp.unintrusionbypassrulesrecordeditor',
+
+    controller: 'unintrusionbypassrulesrecordeditorcontroller',
+});
+
+Ext.define('Ung.apps.intrusionprevention.cmp.BypassRulesRecordEditorController', {
+    extend: 'Ung.cmp.RecordEditorController',
+    alias: 'controller.unintrusionbypassrulesrecordeditorcontroller',
+
+    onApply: function () {
+        var view = this.getView();
+        if(view.up('[srcAddrIsLanCheck=true]')) {
+            var controller = view.up('[srcAddrIsLanCheck=true]').getController();
+            this.callParent();
+            controller.warnSrcAddrIsLan();
+        } else
+            this.callParent();
+    }
+});

--- a/intrusion-prevention/js/view/BypassRules.js
+++ b/intrusion-prevention/js/view/BypassRules.js
@@ -6,6 +6,24 @@ Ext.define('Ung.apps.intrusionprevention.view.BypassRules', {
     withValidation: false,
     editorFieldProtocolTcpUdpOnly: true,
     title: 'Bypass Rules'.t(),
+    controller: 'unintrusionbypassrulesgrid',
+    srcAddrIsLanCheck: true,
+
+    listeners: {
+        afterrender: 'warnSrcAddrIsLan',
+        itemclick: 'warnSrcAddrIsLan'
+    },
+
+    dockedItems: [{
+        xtype: 'container',
+        padding: '8 5',
+        style: { fontSize: '12px', background: '#DADADA'},
+        html: '<i class="fa fa-exclamation-triangle" style="color: red;"></i> ' + 'One or more rules have the condition of the source address a LAN address.'.t(),
+        hidden: true,
+        bind: {
+            hidden: '{!warnBypassRuleSrcAddrIsLan}'
+        }
+    }],
 
     tbar: ['@add', '->', '@import', '@export'],
     recordActions: ['edit', 'copy', 'delete', 'reorder'],
@@ -39,6 +57,7 @@ Ext.define('Ung.apps.intrusionprevention.view.BypassRules', {
             dataIndex: 'bypass',
             width: Renderer.booleanWidth
         }],
+        editorXtype: 'ung.cmp.unintrusionbypassrulesrecordeditor',
         editorFields: [
             Field.enableRule(),
             Field.description,

--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -447,6 +447,39 @@ Ext.define('Ung.util.Util', {
         return interfaces;
     },
 
+    /**
+     * Method to get list of LAN Interface IP's
+     * @return List of LAN IP's from network settings based on onlyTcpUdp flag value.
+     */
+    lanIpList: null,
+    lanIpLastUpdated: null,
+    lanIpMaxAge: 30 * 1000,
+    getLanIpAddrs: function() {
+        var currentTime = new Date().getTime();
+        
+        if (this.lanIpList === null ||
+            this.lanIpLastUpdated === null ||
+            ((this.lanIpLastUpdated + this.lanIpMaxAge) < currentTime)){
+                this.lanIpLastUpdated = currentTime;
+                var networkSettings = Rpc.directData('rpc.networkSettings'),
+                    data = [];
+
+                networkSettings.interfaces.list.forEach( function(intf){
+                    if(!intf.isWan && intf.v4StaticAddress) {
+                        data.push(intf.v4StaticAddress);
+                    }
+                });
+                networkSettings.virtualInterfaces.list.forEach( function(intf){
+                    if(!intf.isWan && intf.v4StaticAddress) {
+                        data.push(intf.v4StaticAddress);
+                    }
+                });
+                this.lanIpList = data;
+        }
+        var lanIps = Ext.clone(this.lanIpList);
+        return lanIps;
+    },
+
     bytesToMBs: function(value) {
         return Math.round(value/10000)/100;
     },

--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -1930,16 +1930,20 @@ Ext.define('Ung.config.network.cmp.BypassRulesController', {
 
     control: {
         '#bypass-rules-grid': { 
-            afterrender: 'warnSrcAddrIsLan'
+            afterrender: 'afterByPassRulesRender',
+            itemclick: 'warnSrcAddrIsLan'
         },
     },
 
-    warnSrcAddrIsLan: function() {
+    afterByPassRulesRender: function() {
+        this.warnSrcAddrIsLan(true);
+    },
+    warnSrcAddrIsLan: function(isAfterRendererCall) {
         var vm = this.getViewModel();
 
         vm.set('warnBypassRuleSrcAddrIsLan', false);
         var lanIpAddrs = Util.getLanIpAddrs(),
-            bypassRules = Ext.Array.pluck(this.getView().getStore().getRange(), 'data');
+            bypassRules = isAfterRendererCall ? vm.get('settings.bypassRules.list') : Ext.Array.pluck(this.getView().getStore().getRange(), 'data');
 
         if(bypassRules) {
             bypassRules.forEach(function(rule) {

--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -1923,3 +1923,57 @@ Ext.define('Ung.config.network.cmp.OspfAreaRecordEditorController', {
         v.close();
     }
 });
+
+Ext.define('Ung.config.network.cmp.BypassRulesController', {
+    extend: 'Ung.cmp.GridController',
+    alias: 'controller.unconfigbypassrulesgridcontroller',
+
+    control: {
+        '#bypass-rules-grid': { 
+            afterrender: 'warnSrcAddrIsLan'
+        },
+    },
+
+    warnSrcAddrIsLan: function() {
+        var vm = this.getViewModel();
+
+        vm.set('warnBypassRuleSrcAddrIsLan', false);
+        var lanIpAddrs = Util.getLanIpAddrs(),
+            bypassRules = Ext.Array.pluck(this.getView().getStore().getRange(), 'data');
+
+        if(bypassRules) {
+            bypassRules.forEach(function(rule) {
+                if(rule) {
+                    rule.conditions.list.forEach(function(condition) {
+                        if(condition.conditionType == "SRC_ADDR" && lanIpAddrs.includes(condition.value)) {
+                            vm.set('warnBypassRuleSrcAddrIsLan', true);
+                        }
+                    });
+                }
+            });
+        }
+    },
+});
+
+Ext.define('Ung.config.network.cmp.BypassRulesRecordEditor', {
+    extend: 'Ung.cmp.RecordEditor',
+    xtype: 'ung.cmp.unconfigbypassrulesrecordeditor',
+
+    controller: 'unconfigbypassrulesrecordeditorontroller'
+});
+
+Ext.define('Ung.config.network.cmp.BypassRulesRecordEditorController', {
+    extend: 'Ung.cmp.RecordEditorController',
+    alias: 'controller.unconfigbypassrulesrecordeditorontroller',
+
+    onApply: function () {
+        console.log("In onApply");
+        var view = this.getView();
+        if(view.up('[srcAddrIsLanCheck=true]')) {
+            var controller = view.up('[srcAddrIsLanCheck=true]').getController();
+            this.callParent();
+            controller.warnSrcAddrIsLan();
+        } else
+            this.callParent();
+    }
+});

--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -1967,7 +1967,6 @@ Ext.define('Ung.config.network.cmp.BypassRulesRecordEditorController', {
     alias: 'controller.unconfigbypassrulesrecordeditorontroller',
 
     onApply: function () {
-        console.log("In onApply");
         var view = this.getView();
         if(view.up('[srcAddrIsLanCheck=true]')) {
             var controller = view.up('[srcAddrIsLanCheck=true]').getController();

--- a/uvm/servlets/admin/config/network/view/BypassRules.js
+++ b/uvm/servlets/admin/config/network/view/BypassRules.js
@@ -18,6 +18,20 @@ Ext.define('Ung.config.network.view.BypassRules', {
 
     items: [{
         xtype: 'ungrid',
+        itemId: 'bypass-rules-grid',
+        srcAddrIsLanCheck: true,
+        controller: 'unconfigbypassrulesgridcontroller',
+
+        dockedItems: [{
+            xtype: 'container',
+            padding: '8 5',
+            style: { fontSize: '12px', background: '#DADADA'},
+            html: '<i class="fa fa-exclamation-triangle" style="color: red;"></i> ' + 'One or more rules have the condition of the source address a LAN address.'.t(),
+            hidden: true,
+            bind: {
+                hidden: '{!warnBypassRuleSrcAddrIsLan}'
+            }
+        }],
 
         tbar: ['@add', '->', '@import', '@export'],
         recordActions: ['edit', 'copy', 'delete', 'reorder'],
@@ -53,6 +67,7 @@ Ext.define('Ung.config.network.view.BypassRules', {
             dataIndex: 'bypass',
             width: Renderer.booleanWidth
         }],
+        editorXtype: 'ung.cmp.unconfigbypassrulesrecordeditor',
         editorFields: [
             Field.enableRule(),
             Field.description,


### PR DESCRIPTION
If User creates a bypass rule such that one of the condition is having source address as LAN IP address then user should get a warning message.

Change Applied on Pages: 
Intrusion Prevention --> Bypass Rules
Config --> Network --> Bypass Rules

Local Testing screenshots:

![Screenshot from 2024-03-26 23-52-22](https://github.com/untangle/ngfw_src/assets/154422821/9b701e91-51e9-4e7c-8138-75df0abf96c3)

![Screenshot from 2024-03-26 23-08-40](https://github.com/untangle/ngfw_src/assets/154422821/f2d5cfde-50c0-4e20-8ca2-f4dd8d27104a)


If there is no such condition user should not see warning message.

![Screenshot from 2024-03-26 23-07-58](https://github.com/untangle/ngfw_src/assets/154422821/1e1327fe-b66f-471b-a44e-129ac93c85e3)


