### PR TITLE
NGFW-13925: Fixed Copy Button alignment for WG App under 'local service information' and 'status' form

### DIFF
--- a/wireguard-vpn/js/Main.js
+++ b/wireguard-vpn/js/Main.js
@@ -110,7 +110,8 @@ Ext.define('Ung.apps.wireguard-vpn.Main', {
                         labelAlign: recordEditor ? 'right' : 'left',
                     },
                     items:[{
-                        xtype: 'copytoclipboard',   
+                        xtype: 'copytoclipboard',
+                        width: '100%',
                         key: {
                             key: 'itemId'
                         },
@@ -131,7 +132,7 @@ Ext.define('Ung.apps.wireguard-vpn.Main', {
                             items: [{
                                 xtype: 'fieldset',
                                 border: false,
-                                width: '100%',
+                                width: '90%',
                                 items: [{
                                     xtype: 'displayfield',
                                     itemId: 'hostname',


### PR DESCRIPTION
**ISSUE:**
Copy Button for WG doesn't show with large amount of networks

**FIX:**
Adjusted alignment to ensure the copy button remains visible regardless of the fieldset contents by modifying the width of the child fieldset.

**TEST:**
1. Go to App>Wiregauard>Settings
2.  Add multiple local networks 
3. Go to  App>Wiregauard>Status , all remote networks as well as copy button should be visible regardless of the number of remote networks.
4. Go to App>Wireguard>Tunnels, click on edit button, check for local service information copy button should be visible regardless of the number of remote networks.

![Screenshot from 2024-03-27 17-42-23](https://github.com/untangle/ngfw_src/assets/155290371/82c5b63c-f7d4-4b70-ac02-4c5de54c7396)
![Screenshot from 2024-03-27 17-41-56](https://github.com/untangle/ngfw_src/assets/155290371/fdd1c2ed-4b08-4ae7-9726-89dcee6f0755)
![Screenshot from 2024-03-27 17-41-24](https://github.com/untangle/ngfw_src/assets/155290371/c34a6c8b-84b8-41e6-ae24-49fcce2f4b62)
