### PR TITLE
ngfw-13562 show warning sysmbol with qtip message if user changes the wireguard settings

### DIFF
--- a/wireguard-vpn/js/MainController.js
+++ b/wireguard-vpn/js/MainController.js
@@ -308,7 +308,25 @@ Ext.define('Ung.apps.wireguard-vpn.MainController', {
         addressPool = vm.get('settings.addressPool'),
         store = vm.getStore('tunnels');
         return Util.getUnusedPoolAddr(addressPool, store, 'peerAddress');
+    },
+
+    settingsChangeListener: function(field, newValue, settingField) {
+        var app = Rpc.directData('rpc.UvmContext.appManager').app('wireguard-vpn'),
+            currentFieldValue = app.getSettings()[settingField];
+
+        var warningLabel = field.nextSibling('label[cls=warningLabel]'),
+            metaData = warningLabel.getEl();
+
+        if (newValue != currentFieldValue) {
+            warningLabel.setHtml('<span class="fa fa-exclamation-triangle" style="color: orange;"></span>');
+            metaData.set({
+                'data-qtip': 'Clients will need to configure their connections'.t(),
+            });
+            warningLabel.show();
+        } else {
+            warningLabel.hide();
         }
+    }
 });
 
 Ext.define('Ung.apps.reports.cmp.Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelGridController', {

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -13,15 +13,45 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
     },
 
     items: [{
-        fieldLabel: 'Listen port'.t(),
-        xtype: 'textfield',
-        vtype: 'isSinglePortValid',
-        maxLength: 5,
-        enforceMaxLength :true,
-        bind: {
-            value: '{settings.listenPort}'
-        },
-        allowBlank: false
+        xtype: 'fieldcontainer',
+        layout: 'hbox',
+        items: [{
+            fieldLabel: 'Listen port'.t(),
+            xtype: 'textfield',
+            vtype: 'isSinglePortValid',
+            maxLength: 5,
+            enforceMaxLength :true,
+            bind: {
+                value: '{settings.listenPort}'
+            },
+            allowBlank: false,
+            labelWidth: 175,
+            padding: '8 5 5 0',
+            listeners: {
+                change: function(field, newValue, oldValue) {
+                    var app = Rpc.directData('rpc.UvmContext.appManager').app('wireguard-vpn'),
+                        currentListenPort = app.getSettings().listenPort;
+
+                    var warningLabel = field.nextSibling('label[cls=warningLabel]'),
+                        metaData = warningLabel.getEl();
+
+                    if (newValue != currentListenPort) {
+                        warningLabel.setHtml('<span class="fa fa-exclamation-triangle" style="color: orange;"></span>');
+                        metaData.set({
+                            'data-qtip': 'Clients will need to configure their connections'.t(),
+                        });
+                        warningLabel.show();
+                    } else {
+                        warningLabel.hide();
+                    }
+                }
+            }
+        },{
+            xtype: 'label',
+            cls: 'warningLabel',
+            hidden: true,
+            margin: '18 0 5 5'
+        }]
     },{
         fieldLabel: 'Keepalive interval'.t(),
         xtype: 'textfield',
@@ -33,13 +63,43 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
         regexText: 'Only accepts valid positive integer.'.t(),
         allowBlank: false
     },{
-        fieldLabel: 'MTU'.t(),
-        xtype: 'textfield',
-        vtype: 'mtu',
-        bind: {
-            value: '{settings.mtu}'
-        },
-        allowBlank: false
+        xtype: 'fieldcontainer',
+        layout: 'hbox',
+        items: [{
+            fieldLabel: 'MTU'.t(),
+            xtype: 'textfield',
+            vtype: 'mtu',
+            bind: {
+                value: '{settings.mtu}'
+            },
+            allowBlank: false,
+            labelWidth: 175,
+            padding: '8 5 5 0',
+            listeners: {
+                change: function(field, newValue, oldValue) {
+                    var app = Rpc.directData('rpc.UvmContext.appManager').app('wireguard-vpn'),
+                        currentMtu = app.getSettings().mtu;
+
+                    var warningLabel = field.nextSibling('label[cls=warningLabel]'),
+                        metaData = warningLabel.getEl();
+
+                    if (newValue != currentMtu) {
+                        warningLabel.setHtml('<span class="fa fa-exclamation-triangle" style="color: orange;"></span>');
+                        metaData.set({
+                            'data-qtip': 'Clients will need to configure their connections'.t(),
+                        });
+                        warningLabel.show();
+                    } else {
+                        warningLabel.hide();
+                    }
+                }
+            }
+        },{
+            xtype: 'label',
+            cls: 'warningLabel',
+            hidden: true,
+            margin: '18 0 5 5'
+        }],
     }, {
         xtype: 'fieldset',
         title: 'Remote Client Configuration'.t(),
@@ -164,6 +224,25 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                         disabled: '{settings.autoAddressAssignment}',
                         editable: '{!settings.autoAddressAssignment}'
                     },
+                    listeners: {
+                        change: function(field, newValue, oldValue) {
+                            var app = Rpc.directData('rpc.UvmContext.appManager').app('wireguard-vpn'),
+                                currentNetSpace = app.getSettings().addressPool;
+
+                            var warningLabel = field.nextSibling('label[cls=warningLabel]'),
+                                metaData = warningLabel.getEl();
+
+                            if (newValue != currentNetSpace) {
+                                warningLabel.setHtml('<span class="fa fa-exclamation-triangle" style="color: orange;"></span>');
+                                metaData.set({
+                                    'data-qtip': 'Clients will need to configure their connections'.t(),
+                                });
+                                warningLabel.show();
+                            } else {
+                                warningLabel.hide();
+                            }
+                        }
+                    },
                     validator: function(value) {
                         try{
                             var isValidVtypeField = Ext.form.field.VTypes[this.vtype](value);
@@ -197,6 +276,11 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                     listeners: {
                         click: 'getNewAddressSpace'
                     }
+                },{
+                    xtype: 'label',
+                    cls: 'warningLabel',
+                    hidden: true,
+                    margin: '10 0 5 10'
                 }
             ]
         }]

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -29,21 +29,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
             padding: '8 5 5 0',
             listeners: {
                 change: function(field, newValue, oldValue) {
-                    var app = Rpc.directData('rpc.UvmContext.appManager').app('wireguard-vpn'),
-                        currentListenPort = app.getSettings().listenPort;
-
-                    var warningLabel = field.nextSibling('label[cls=warningLabel]'),
-                        metaData = warningLabel.getEl();
-
-                    if (newValue != currentListenPort) {
-                        warningLabel.setHtml('<span class="fa fa-exclamation-triangle" style="color: orange;"></span>');
-                        metaData.set({
-                            'data-qtip': 'Clients will need to configure their connections'.t(),
-                        });
-                        warningLabel.show();
-                    } else {
-                        warningLabel.hide();
-                    }
+                    this.up('app-wireguard-vpn').getController().settingsChangeListener(field, newValue, 'listenPort');
                 }
             }
         },{
@@ -77,21 +63,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
             padding: '8 5 5 0',
             listeners: {
                 change: function(field, newValue, oldValue) {
-                    var app = Rpc.directData('rpc.UvmContext.appManager').app('wireguard-vpn'),
-                        currentMtu = app.getSettings().mtu;
-
-                    var warningLabel = field.nextSibling('label[cls=warningLabel]'),
-                        metaData = warningLabel.getEl();
-
-                    if (newValue != currentMtu) {
-                        warningLabel.setHtml('<span class="fa fa-exclamation-triangle" style="color: orange;"></span>');
-                        metaData.set({
-                            'data-qtip': 'Clients will need to configure their connections'.t(),
-                        });
-                        warningLabel.show();
-                    } else {
-                        warningLabel.hide();
-                    }
+                    this.up('app-wireguard-vpn').getController().settingsChangeListener(field, newValue, 'mtu');
                 }
             }
         },{
@@ -226,21 +198,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                     },
                     listeners: {
                         change: function(field, newValue, oldValue) {
-                            var app = Rpc.directData('rpc.UvmContext.appManager').app('wireguard-vpn'),
-                                currentNetSpace = app.getSettings().addressPool;
-
-                            var warningLabel = field.nextSibling('label[cls=warningLabel]'),
-                                metaData = warningLabel.getEl();
-
-                            if (newValue != currentNetSpace) {
-                                warningLabel.setHtml('<span class="fa fa-exclamation-triangle" style="color: orange;"></span>');
-                                metaData.set({
-                                    'data-qtip': 'Clients will need to configure their connections'.t(),
-                                });
-                                warningLabel.show();
-                            } else {
-                                warningLabel.hide();
-                            }
+                            this.up('app-wireguard-vpn').getController().settingsChangeListener(field, newValue, 'addressPool');
                         }
                     },
                     validator: function(value) {


### PR DESCRIPTION
If user changes the Wireguard VPN settings `Listen port, Peer Address Pool and MTU` then showing a warning symbol with qtip message `Clients will need to configure their connections`.

![Screenshot from 2024-03-27 15-11-33](https://github.com/untangle/ngfw_src/assets/154422821/6c366d39-2632-41db-bcb3-4d20e5a78237)

If user re-enters current settings value then warning symbol is not shown.

![Screenshot from 2024-03-27 18-19-29](https://github.com/untangle/ngfw_src/assets/154422821/7f5f63e1-e748-4c66-9fac-3974ce885169)
