### PR TITLE
NGFW-14146 UI validation for descending order for filter condition IP range

### DIFF
--- a/uvm/api/com/untangle/uvm/app/IPMatcher.java
+++ b/uvm/api/com/untangle/uvm/app/IPMatcher.java
@@ -108,9 +108,9 @@ public class IPMatcher
      */
     public IPMatcher(String matcher)
     {
-                    initialize(matcher);
-        }
-        
+        initialize(matcher);
+    }
+
     /**
      * Make a subnet matcher
      * 

--- a/uvm/api/com/untangle/uvm/app/IPMatcher.java
+++ b/uvm/api/com/untangle/uvm/app/IPMatcher.java
@@ -108,9 +108,9 @@ public class IPMatcher
      */
     public IPMatcher(String matcher)
     {
-        initialize(matcher);
-    }
-
+                    initialize(matcher);
+        }
+        
     /**
      * Make a subnet matcher
      * 
@@ -312,6 +312,13 @@ public class IPMatcher
 
                 this.rangeMin = addrToLong(addrMin);
                 this.rangeMax = addrToLong(addrMax);
+
+                // Swap min and max if they are in reverse order
+                if (this.rangeMin > this.rangeMax) {
+                    long temp = this.rangeMin;
+                    this.rangeMin = this.rangeMax;
+                    this.rangeMax = temp;
+                }
             } catch (java.net.UnknownHostException e) {
                 logger.warn("Unknown IPMatcher range format: \"" + matcher + "\"", e);
                 throw new java.lang.IllegalArgumentException("Unknown IPMatcher format: \"" + matcher + "\" (unknown host)", e);

--- a/uvm/api/com/untangle/uvm/app/IPMatcher.java
+++ b/uvm/api/com/untangle/uvm/app/IPMatcher.java
@@ -312,13 +312,6 @@ public class IPMatcher
 
                 this.rangeMin = addrToLong(addrMin);
                 this.rangeMax = addrToLong(addrMax);
-
-                // Swap min and max if they are in reverse order
-                if (this.rangeMin > this.rangeMax) {
-                    long temp = this.rangeMin;
-                    this.rangeMin = this.rangeMax;
-                    this.rangeMax = temp;
-                }
             } catch (java.net.UnknownHostException e) {
                 logger.warn("Unknown IPMatcher range format: \"" + matcher + "\"", e);
                 throw new java.lang.IllegalArgumentException("Unknown IPMatcher format: \"" + matcher + "\" (unknown host)", e);

--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -162,7 +162,7 @@ Ext.define('Ung.overrides.form.field.VTypes', {
             return true;
         }
     },
-    ipMatcherText: 'Invalid IP Address. Ensure that the IP Matcher syntax is followed. The IP range needs to be in ascending order.'.t(),
+    ipMatcherText: 'Invalid IP address range, must be in ascending order.'.t(),
 
     ip4Address: function (val) {
         return this.mask.ip4AddrMaskRe.test(val);

--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -67,6 +67,15 @@ Ext.define('Ung.overrides.form.field.VTypes', {
 
 
     isIpRangeValid: function(val) {
+        var ipRangeArr = val.split('-');
+        if (ipRangeArr.length != 2) {
+            // invalid range
+            return false;
+        }
+        if (Util.convertIPIntoDecimal(ipRangeArr[0]) > Util.convertIPIntoDecimal(ipRangeArr[1])) {
+            // min IP in the range is grater than max IP
+            return false;
+        }
         return this.mask.ipAddrRange.test(val);
     },
     isCIDRValid: function(val) {
@@ -153,7 +162,7 @@ Ext.define('Ung.overrides.form.field.VTypes', {
             return true;
         }
     },
-    ipMatcherText: 'Invalid IP Address.'.t(),
+    ipMatcherText: 'Invalid IP Address. Ensure that the IP Matcher syntax is followed. The IP range needs to be in ascending order.'.t(),
 
     ip4Address: function (val) {
         return this.mask.ip4AddrMaskRe.test(val);


### PR DESCRIPTION
- Added UI validation for filter rule condition: IP range must be in ascending order.
![Screenshot from 2024-03-28 00-08-16](https://github.com/untangle/ngfw_src/assets/154527616/cd1ffd88-8568-4fec-9abf-c6874c3017f9)

- IPMatcher.java to set min and max IP addresses in case of range in ascending order.