### PR TITLE
ngfw-14554: multiple syslog update settings

### DIFF
--- a/uvm/api/com/untangle/uvm/event/EventSettings.java
+++ b/uvm/api/com/untangle/uvm/event/EventSettings.java
@@ -11,7 +11,6 @@ import org.json.JSONString;
 
 import com.untangle.uvm.event.AlertRule;
 import com.untangle.uvm.event.SyslogRule;
-
 /**
  * Settings for the Reports App.
  */
@@ -23,6 +22,7 @@ public class EventSettings implements Serializable, JSONString
     private LinkedList<AlertRule> alertRules = null;
     private LinkedList<SyslogRule> syslogRules = null;
     private LinkedList<TriggerRule> triggerRules = null;
+    private LinkedList<SyslogServer> syslogServers = null;
 
     private boolean syslogEnabled = false;
     private String syslogHost;
@@ -61,6 +61,10 @@ public class EventSettings implements Serializable, JSONString
 
     public LinkedList<TriggerRule> getTriggerRules() { return this.triggerRules; }
     public void setTriggerRules( LinkedList<TriggerRule> newValue ) { this.triggerRules = newValue; }
+
+    public LinkedList<SyslogServer> getSyslogServers() { return this.syslogServers; }
+    public void setSyslogServers( LinkedList<SyslogServer> newValue ) { this.syslogServers = newValue; }
+
 
     /**
      * Email template

--- a/uvm/api/com/untangle/uvm/event/SyslogRule.java
+++ b/uvm/api/com/untangle/uvm/event/SyslogRule.java
@@ -4,7 +4,7 @@
 package com.untangle.uvm.event;
 
 import java.util.List;
-
+import java.util.LinkedList;
 /**
  * This in the implementation of a Event Rule
  * 
@@ -15,6 +15,7 @@ import java.util.List;
 public class SyslogRule extends EventRule
 {
 	private Boolean syslog = false;
+    private LinkedList<Integer> syslogServers = null;
 
     /**
      * Initialize empty instance of EventRuleCondition.
@@ -70,5 +71,23 @@ public class SyslogRule extends EventRule
      * @param newValue boolean if true send remote syslog, otherwise false.
      */
     public void setSyslog( Boolean newValue ) { this.syslog = newValue; }
+
+
+     /**
+     * Return Syslog servers
+     * @return list of Syslogservers.
+     */
+    public LinkedList<Integer> getSyslogServers() {
+        return syslogServers;
+    }
+
+    /**
+     * add Syslog servers.
+     * @param syslogServers add list of Syslog servers.
+     */
+    public void setSyslogServers(LinkedList<Integer> syslogServers) {
+        this.syslogServers = syslogServers;
+    }
+
 
 }

--- a/uvm/api/com/untangle/uvm/event/SyslogServer.java
+++ b/uvm/api/com/untangle/uvm/event/SyslogServer.java
@@ -1,0 +1,92 @@
+/**
+ * $Id: SyslogServer.java,v 1.00 2024/03/27 12:13:17 rohitsingh Exp $
+ */
+package com.untangle.uvm.event;
+import java.util.LinkedList;
+import java.io.Serializable;
+import org.json.JSONString;
+import org.json.JSONObject;
+
+/**
+ * This is the class which defines SyslogServer
+ * 
+ * A SyslogServer is a host which received logs
+ * based on configured SyslogRules
+ */
+@SuppressWarnings("serial")
+public class SyslogServer implements Serializable, JSONString {
+    private int serverId = -1;
+    private boolean enabled = false;
+    private String host;
+    private int port = 514;
+    private String protocol = "UDP";
+    private String tag = "";
+
+    /**
+     * Initialize empty instance of SyslogServer. 
+    */
+    public SyslogServer() { }
+
+
+    /**
+     * Initialize instance of SyslogServer.
+     * @param  serverId               integer serverID
+     * @param  enabled                Boolean if true , logs should be send to this server.
+     * @param  host                   String, ip address/host of server
+     * @param  port                   integer, port of server  boolean if true remote syslog the event, otherwise don't syslog
+     * @param  protocol               integer, protocol for communication UDP/TCP
+     * @param  tag                    String, server identifier
+     */
+    public SyslogServer(int serverId, boolean enabled, String host, int port, String protocol, String tag) {
+        this.serverId = serverId;
+        this.enabled = enabled;
+        this.host = host;
+        this.port = port;
+        this.protocol = protocol;
+        this.tag = tag;
+    }
+
+    public int getServerId() {
+        return serverId;
+    }
+    public void setServerId(int serverId) {
+        this.serverId = serverId;
+    }
+    public boolean isEnabled() {
+        return enabled;
+    }
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+    public String getHost() {
+        return host;
+    }
+    public void setHost(String host) {
+        this.host = host;
+    }
+    public int getPort() {
+        return port;
+    }
+    public void setPort(int port) {
+        this.port = port;
+    }
+    public String getProtocol() {
+        return protocol;
+    }
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+    public String getTag() {
+        return tag;
+    }
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    public String toJSONString()
+    {
+        JSONObject jO = new JSONObject(this);
+        return jO.toString();
+    }
+
+}

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
@@ -1,0 +1,136 @@
+import copy
+import pytest
+
+from tests.common import NGFWTestCase
+from tests.global_functions import uvmContext
+import tests.global_functions as global_functions
+import runtests.test_registry as test_registry
+import runtests.remote_control as remote_control
+import runtests.overrides as overrides
+
+
+SYSLOG_SERVER1 = {"enabled": False, "host": "192.168.56.195", "javaClass": "com.untangle.uvm.event.SyslogServer", "port": 514, "protocol": "UDP", "serverId": -1, "tag": "uvm-to-192.168.56.195" }
+SYSLOG_SERVER2 = {"enabled": False, "host": "192.168.56.196", "javaClass": "com.untangle.uvm.event.SyslogServer", "port": 514, "protocol": "UDP", "serverId": -1, "tag": "uvm-to-192.168.56.196" }
+SYSLOG_SERVER3 = {"enabled": False, "host": "192.168.56.199", "javaClass": "com.untangle.uvm.event.SyslogServer", "port": 514, "protocol": "UDP", "serverId": -1, "tag": "uvm-to-192.168.56.199" }
+SYSLOG_SERVER4 = {"enabled": False, "host": "192.168.56.200", "javaClass": "com.untangle.uvm.event.SyslogServer", "port": 514, "protocol": "UDP", "serverId": -1, "tag": "uvm-to-192.168.56.200" }
+
+
+@pytest.mark.syslog
+class SysLogTests(NGFWTestCase):
+
+    not_an_app= True
+
+    @staticmethod
+    def module_name():
+        return "syslog"
+    
+    def test_050_disable_syslog(self):
+        syslogSettings = uvmContext.eventManager().getSettings()
+        orig_settings = copy.deepcopy(syslogSettings)
+        syslogSettings["syslogEnabled"] = False
+        uvmContext.eventManager().setSettings( syslogSettings )
+        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        if "syslogServers" in syslogSettings.keys() and syslogSettings['syslogServers']:
+            assert (len(syslogUpdatedSettings['syslogServers']['list']) == 0)
+        else:
+          #No Logservers configured
+          pass
+        uvmContext.eventManager().setSettings(orig_settings)
+
+    def test_050_enable_syslog(self):
+        #covering scenario of setup where default syslog is enabled and configured
+        syslogSettings = uvmContext.eventManager().getSettings()
+        orig_settings = copy.deepcopy(syslogSettings)
+        syslogSettings["syslogEnabled"] = True
+        syslogSettings["syslogPort"] = 514
+        syslogSettings["syslogProtocol"] = "UDP"
+        syslogSettings["syslogHost"] = "192.168.56.195"
+        uvmContext.eventManager().setSettings(syslogSettings)
+        #this will add rule with server id as 1, the first server is assigned server id 1 always
+        if (len(syslogSettings['syslogRules']['list']) == 1):
+           if "syslogServers" in syslogSettings['syslogRules']['list'][0].keys() and syslogSettings['syslogRules']['list'][0]['syslogServers']:
+              syslogSettings['syslogRules']['list'][0]['syslogServers']['list'].append(1)
+        uvmContext.eventManager().setSettings(syslogSettings)
+        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        assert(len(syslogSettings['syslogRules']['list'][0]['syslogServers']['list']) == 1)
+        assert (len(syslogUpdatedSettings['syslogServers']['list']) == 1)
+        if (len(syslogUpdatedSettings['syslogRules']['list']) == 1):
+           if "syslogServers" in syslogUpdatedSettings['syslogRules']['list'][0].keys() and syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']:
+              syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].clear()
+              syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].append(2)
+        uvmContext.eventManager().setSettings(syslogUpdatedSettings)
+        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        assert (len(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list']) == 1)
+        #server ID should be updated to 2 for the syslogRule
+        assert (syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'][0] == 2)
+        uvmContext.eventManager().setSettings(orig_settings)
+
+    def test_050_enable_syslog_withouthostnameset(self):
+        #covering scenario of setup where default syslog is enabled and sysloghost not set configured
+        syslogSettings = uvmContext.eventManager().getSettings()
+        orig_settings = copy.deepcopy(syslogSettings)
+        syslogSettings["syslogEnabled"] = True
+        syslogSettings["syslogPort"] = 514
+        syslogSettings["syslogProtocol"] = "UDP"
+        #Removed sysLogHost, initially sysloghostname is not set in backend, in UI its mandatory
+        syslogSettings.pop("syslogHost", None)
+        uvmContext.eventManager().setSettings(syslogSettings)
+        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        assert(len(syslogSettings['syslogRules']['list'][0]['syslogServers']['list']) == 0)
+        assert (len(syslogUpdatedSettings['syslogServers']['list']) == 0)
+        uvmContext.eventManager().setSettings(orig_settings)
+
+
+    def test_050_multiple_syslogservers(self):
+        initial_logservers = 0
+        syslogSettings = uvmContext.eventManager().getSettings()
+        orig_settings = copy.deepcopy(syslogSettings)
+        syslogSettings["syslogEnabled"] = True
+        if "syslogServers" in syslogSettings.keys():
+           syslogSettings['syslogServers'] = {"javaClass": "java.util.LinkedList","list": [] }
+        else:
+           initial_logservers = len(syslogSettings['syslogServers']['list'])
+        syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER1)
+        syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER2)
+        syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER3)
+        uvmContext.eventManager().setSettings(syslogSettings)
+        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        assert (len(syslogUpdatedSettings['syslogServers']['list']) == initial_logservers + 3)
+        uvmContext.eventManager().setSettings(orig_settings)
+
+
+    def test_050_delete_syslogservers(self):
+        initial_logservers = 0
+        syslogSettings = uvmContext.eventManager().getSettings()
+        orig_settings = copy.deepcopy(syslogSettings)
+        syslogSettings["syslogEnabled"] = True
+        #Default setup list will not be present. UI payload will contain server list, need to generate for unittest
+        #Testcase covers both enabled and disabled syslogserver scenario
+        if "syslogServers" in syslogSettings.keys():
+           syslogSettings['syslogServers'] = {"javaClass": "java.util.LinkedList","list": [] }
+        else:
+           initial_logservers = len(syslogSettings['syslogServers']['list'])
+        syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER1)
+        syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER2)
+        syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER3)
+        uvmContext.eventManager().setSettings(syslogSettings)
+        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        assert (len(syslogUpdatedSettings['syslogServers']['list']) == initial_logservers +3)
+        key = 'host'
+        # Fetch Added SyslogServers
+        syslog_list = syslogUpdatedSettings['syslogServers']['list']
+        # Deleting  server 1 and 3
+        syslog_list = [item for item in syslog_list if item.get(key) != '192.168.56.195']
+        syslog_list = [item for item in syslog_list if item.get(key) != '192.168.56.199']
+        syslogUpdatedSettings['syslogServers'] = {"javaClass": "java.util.LinkedList","list": [] }
+        # Adding new server4 and server2 to payload
+        for server in syslog_list:
+           syslogUpdatedSettings['syslogServers']['list'].append(server)
+        syslogUpdatedSettings['syslogServers']['list'].append(SYSLOG_SERVER4)
+        uvmContext.eventManager().setSettings(syslogUpdatedSettings)
+        assert (len(syslogUpdatedSettings['syslogServers']['list']) == initial_logservers + 2)
+        uvmContext.eventManager().setSettings(orig_settings)
+
+
+
+test_registry.register_module("syslog", SysLogTests)


### PR DESCRIPTION
AS per requirement Criteria
Added SyslogServer list in EventSettings default server will have tag (uvm[0] , others will have uvm-to-server-ip)
Added Syslogserver ID list in SyslogRule
Modified rules to evaluate and send logs to multiple logservers
Added iterative syslog remote configuration in syslog conf file
```
if $msg startswith ' <tag>' then @192.168.25.51:514
& stop
```
Added testcase covering scenarios
1. Enabling syslog
2. Disabling syslog
3. Adding multiple syslog
4. Adding/Deleting multiple syslog

Following are screenshots of syslog conifugration
![Screenshot from 2024-04-01 15-25-04](https://github.com/untangle/ngfw_src/assets/154513962/3e30f25d-cfa8-4cb2-9f6c-a770d4aba230)


TestCases
![Screenshot from 2024-04-01 15-59-30](https://github.com/untangle/ngfw_src/assets/154513962/c6b2e7ea-f86c-4c8a-b987-dd81a9ea2ca4)





