### PR TITLE
NGFW-14148 Filter Rule: Restricting Client MAC address to be a valid MAC address; Glob Matcher is no longer accepted

### DIFF
--- a/uvm/servlets/admin/app/cmp/ConditionsEditor.js
+++ b/uvm/servlets/admin/app/cmp/ConditionsEditor.js
@@ -473,7 +473,8 @@ Ext.define('Ung.cmp.ConditionsEditor', {
         },{
             name:"SRC_MAC",
             displayName: "Client MAC Address".t(), 
-            type: 'textfield'
+            type: 'textfield',
+            vtype: 'macAddress'
         },{
             name:'DST_MAC',
             displayName: 'Server MAC Address'.t(),


### PR DESCRIPTION
- Since `iptables` couldn't accept the Glob Matcher pattern for MAC address, we will accept a valid MAC address for `Client MAC Address` type of Filter Rule

![image](https://github.com/untangle/ngfw_src/assets/154527616/54a2d7de-08e0-4ecf-967f-f913d919ecf8)

