### PR TITLE
Ngfw 14555 add syslog server grid and update syslog rules grid

### DIFF
--- a/uvm/js/common/ungrid/GridColumns.js
+++ b/uvm/js/common/ungrid/GridColumns.js
@@ -69,6 +69,17 @@ Ext.define('Ung.cmp.GridColumns', {
         renderer: function() {
             return '<i class="fa fa-arrows" style="cursor: move;"></i>';
         }
+    },
+
+    serverId: {
+        header: 'Server Id'.t(),
+        width: Renderer.idWidth,
+        align: 'right',
+        resizable: false,
+        dataIndex: 'serverId',
+        renderer: function(value) {
+            return value < 0 ? 'new'.t() : value;
+        }
     }
 });
 

--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -1244,5 +1244,5 @@ Ext.define('Ung.util.Util', {
             ]];
         }
     },
-
+    
 });

--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -1245,34 +1245,4 @@ Ext.define('Ung.util.Util', {
         }
     },
 
-    /**
-     * Method to get list of syslog servers and for checkboxgroup items value
-     * @return List of checkbox items with fields boxLabel, name and inputValue
-     */
-    getSysLogsServers: function(){
-        var eventSettings = Rpc.directData('rpc.UvmContext.eventManager').getSettings(),
-            data = [];
-        eventSettings.syslogServers.list.forEach(function(server){
-            data.push({ boxLabel: server.host, name: 'list', inputValue: Number(server.serverId) });
-        });
-        return data;
-    },
-
-    /**
-     * Method to get list of syslog server hostnames from syslog server Id list
-     * @param list List of sysolg server id's
-     * @return List of syslog server host names whose id's are present in serverId list
-     */
-    getSysLogsServerNameFromId: function(serverIds) {
-        if(serverIds.length == 0) return '<i>' + 'No Sys Log Server'.t() + '<i>';
-
-        var eventSettings = Rpc.directData('rpc.UvmContext.eventManager').getSettings();
-
-        var data = eventSettings.syslogServers.list.filter(function(server) {
-            return serverIds.includes(server.serverId);
-        }).map(function(server) {
-            return server.host;
-        });
-        return data;
-    }
 });

--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -1244,5 +1244,35 @@ Ext.define('Ung.util.Util', {
             ]];
         }
     },
-    
+
+    /**
+     * Method to get list of syslog servers and for checkboxgroup items value
+     * @return List of checkbox items with fields boxLabel, name and inputValue
+     */
+    getSysLogsServers: function(){
+        var eventSettings = Rpc.directData('rpc.UvmContext.eventManager').getSettings(),
+            data = [];
+        eventSettings.syslogServers.list.forEach(function(server){
+            data.push({ boxLabel: server.host, name: 'list', inputValue: Number(server.serverId) });
+        });
+        return data;
+    },
+
+    /**
+     * Method to get list of syslog server hostnames from syslog server Id list
+     * @param list List of sysolg server id's
+     * @return List of syslog server host names whose id's are present in serverId list
+     */
+    getSysLogsServerNameFromId: function(serverIds) {
+        if(serverIds.length == 0) return '<i>' + 'No Sys Log Server'.t() + '<i>';
+
+        var eventSettings = Rpc.directData('rpc.UvmContext.eventManager').getSettings();
+
+        var data = eventSettings.syslogServers.list.filter(function(server) {
+            return serverIds.includes(server.serverId);
+        }).map(function(server) {
+            return server.host;
+        });
+        return data;
+    }
 });

--- a/uvm/servlets/admin/app/overrides/form/CheckboxGroup.js
+++ b/uvm/servlets/admin/app/overrides/form/CheckboxGroup.js
@@ -1,13 +1,6 @@
 Ext.define('Ung.overrides.form.CheckboxGroup', {
     override: 'Ext.form.CheckboxGroup',
 
-    initComponent:function(){
-        if(this.itemId == 'syslogserverscheckbox') {
-            this.items = Util.getSysLogsServers();
-        }
-        this.callParent(arguments);
-     },
-
     setValue: function(value) {
         if(this.useParentDefinition) {
             return this.callParent(arguments);

--- a/uvm/servlets/admin/app/overrides/form/CheckboxGroup.js
+++ b/uvm/servlets/admin/app/overrides/form/CheckboxGroup.js
@@ -1,7 +1,17 @@
 Ext.define('Ung.overrides.form.CheckboxGroup', {
     override: 'Ext.form.CheckboxGroup',
 
+    initComponent:function(){
+        if(this.itemId == 'syslogserverscheckbox') {
+            this.items = Util.getSysLogsServers();
+        }
+        this.callParent(arguments);
+     },
+
     setValue: function(value) {
+        if(this.useParentDefinition) {
+            return this.callParent(arguments);
+        }
         var me    = this,
             boxes = me.getBoxes(),
             b,
@@ -35,6 +45,9 @@ Ext.define('Ung.overrides.form.CheckboxGroup', {
     },
 
     getValue: function() {
+        if(this.useParentDefinition) {
+            return this.callParent(arguments);
+        }
         var values = [],
             boxes  = this.getBoxes(),
             b,

--- a/uvm/servlets/admin/config/events/MainController.js
+++ b/uvm/servlets/admin/config/events/MainController.js
@@ -165,6 +165,13 @@ Ext.define('Ung.config.events.MainController', {
                         record.drop();
                     }
                 });
+                if(grid.itemId == 'syslogservers') {
+                    store.each(function (record) {
+                        if(!record.get('tag')) {
+                            record.set('tag', Ext.String.format('uvm-to-{0}', record.get('host')));
+                        }
+                    });
+                }
                 store.isReordered = undefined;
                 vm.set(grid.listProperty, Ext.Array.pluck(store.getRange(), 'data'));
                 store.commitChanges();

--- a/uvm/servlets/admin/config/events/MainController.js
+++ b/uvm/servlets/admin/config/events/MainController.js
@@ -330,3 +330,21 @@ Ext.define('Ung.config.events.MainController', {
     }
 
 });
+
+Ext.define('Ung.config.events.SyslogRulesController', {
+    extend: 'Ung.cmp.GridController',
+    alias: 'controller.uneventssyslogrulesgrid',
+
+    sysLogServersRenderer: function(value, column) {
+        value.javaClass = "java.util.LinkedList";
+        if(value.list) {
+            if(!Ext.isArray(value.list)) {
+                value.list = [ value.list ];
+            }
+            return Util.getSysLogsServerNameFromId(value.list);
+        } else {
+            value.list = [];
+        }
+        return '<i>' + 'No Sys Log Server'.t() + '<i>';
+    }
+});

--- a/uvm/servlets/admin/config/events/MainModel.js
+++ b/uvm/servlets/admin/config/events/MainModel.js
@@ -15,6 +15,7 @@ Ext.define('Ung.config.events.MainModel', {
     stores: {
         alertRules: { data: '{settings.alertRules.list}' },
         triggerRules: { data: '{settings.triggerRules.list}' },
-        syslogRules: { data: '{settings.syslogRules.list}' }
+        syslogRules: { data: '{settings.syslogRules.list}' },
+        syslogServers: { data: '{settings.syslogServers.list}'}
     }
 });

--- a/uvm/servlets/admin/config/events/view/Syslog.js
+++ b/uvm/servlets/admin/config/events/view/Syslog.js
@@ -23,33 +23,64 @@ Ext.define('Ung.config.events.view.Syslog', {
                     ck.setValue(false);
                 }
             }
+        }]
+    },{
+        xtype: 'ungrid',
+        title: 'Syslog Servers'.t(),
+        itemId: 'syslogservers',
+        region: 'center',
+
+        hidden: true,
+        disabled: true,
+        padding: '20 0',
+        bind: {
+            store: '{syslogServers}',
+            hidden: '{settings.syslogEnabled == false}',
+            disabled: '{settings.syslogEnabled == false}'
+        },
+
+        listProperty: 'settings.syslogServers.list',
+        tbar: ['@add'],
+        recordActions: ['edit', 'delete'],
+
+        emptyRow: {
+            javaClass: 'com.untangle.uvm.event.SyslogServer',
+            serverId: -1,
+            enabled: true,
+            port: 514,
+            protocol: "UDP"
+        },
+
+        columns: [
+            Column.serverId,
+            Column.enabled,
+        {
+            header: 'Host'.t(),
+            dataIndex: 'host',
+            flex: 1,
+            width: Renderer.hostnameWidth
         }, {
-            xtype:'fieldset',
-            collapsible: false,
-            hidden: true,
-            disabled: true,
-            bind: {
-                hidden: '{settings.syslogEnabled == false}',
-                disabled: '{settings.syslogEnabled == false}'
-            },
-            items:[{
+            header: 'Port'.t(),
+            width: Renderer.portWidth,
+            dataIndex: 'port'
+        },{
+            header: 'Protocol'.t(),
+            width: Renderer.protocolWidth,
+            dataIndex: 'protocol'
+        }],
+
+        editorFields: [
+            Field.enableRule(),
+            {
                 xtype: 'textfield',
                 fieldLabel: 'Host'.t(),
-                bind: '{settings.syslogHost}',
-                toValidate: true,
-                allowBlank: false,
-                blankText: 'Host must be specified.'.t(),
-                validator: Ext.bind( function( value ){
-                    if( value == '127.0.0.1' ||
-                        value == 'localhost' ){
-                        return 'Host cannot be localhost address.'.t();
-                    }
-                    return true;
-                }, this)
+                bind: '{record.host}',
+                emptyText: '[no host]'.t(),
+                allowBlank: false
             },{
                 xtype: 'numberfield',
                 fieldLabel: 'Port'.t(),
-                bind: '{settings.syslogPort}',
+                bind: '{record.port}',
                 toValidate: true,
                 allowDecimals: false,
                 minValue: 0,
@@ -60,17 +91,13 @@ Ext.define('Ung.config.events.view.Syslog', {
                 xtype: 'combo',
                 editable: false,
                 fieldLabel: 'Protocol'.t(),
+                bind: '{record.protocol}',
                 queryMode: 'local',
                 store: [["UDP", 'UDP'.t()],
-                        ["TCP", "TCP".t()]],
-                bind: '{settings.syslogProtocol}',
-            },{
-                name: 'syslogEventsSummary',
-                xtype: 'component',
-                html: '',
-            }]
-        }]
-    }, {
+                        ["TCP", "TCP".t()]]
+            }
+        ]
+    },{
         xtype: 'ungrid',
         title: 'Syslog Rules'.t(),
         region: 'center',

--- a/uvm/servlets/admin/config/events/view/Syslog.js
+++ b/uvm/servlets/admin/config/events/view/Syslog.js
@@ -76,7 +76,8 @@ Ext.define('Ung.config.events.view.Syslog', {
                 fieldLabel: 'Host'.t(),
                 bind: '{record.host}',
                 emptyText: '[no host]'.t(),
-                allowBlank: false
+                allowBlank: false,
+                blankText: 'This field is required'.t()
             },{
                 xtype: 'numberfield',
                 fieldLabel: 'Port'.t(),
@@ -99,7 +100,9 @@ Ext.define('Ung.config.events.view.Syslog', {
         ]
     },{
         xtype: 'ungrid',
+        controller: 'uneventssyslogrulesgrid',
         title: 'Syslog Rules'.t(),
+        itemId: 'syslogrules',
         region: 'center',
 
         hidden: true,
@@ -132,7 +135,11 @@ Ext.define('Ung.config.events.view.Syslog', {
             thresholdEnabled: false,
             thresholdTimeframeSec: 60,
             thresholdGroupingField: null,
-            syslog: true
+            syslog: true,
+            syslogServers: {
+                "javaClass": "java.util.LinkedList",
+                "list": []
+            }
         },
 
         columns: [
@@ -142,10 +149,11 @@ Ext.define('Ung.config.events.view.Syslog', {
             Ung.config.events.MainController.conditionsClass,
             Ung.config.events.MainController.conditions,
         {
-            xtype:'checkcolumn',
-            header: 'Remote Syslog'.t(),
-            dataIndex: 'syslog',
-            width: Renderer.booleanWidth + 30
+            header: 'Syslog Servers'.t(),
+            width: Renderer.conditionsWidth,
+            flex: 2,
+            dataIndex: 'syslogServers',
+            renderer: 'sysLogServersRenderer'
         }],
 
         editorFields: [
@@ -220,15 +228,16 @@ Ext.define('Ung.config.events.view.Syslog', {
             xtype: 'fieldset',
             title: 'Perform the following action(s):'.t(),
             items:[{
-                xtype:'checkbox',
-                fieldLabel: 'Remote Syslog'.t(),
-                labelWidth: 160,
-                bind: '{record.syslog}',
-                listeners: {
-                    disable: function (ck) {
-                        ck.setValue(false);
-                    }
-                }
+                xtype: 'checkboxgroup',
+                fieldLabel: 'Syslog Servers'.t(),
+                useParentDefinition: true,
+                itemId: 'syslogserverscheckbox',
+                labelWidth: 155,
+                bind: {
+                    value: '{record.syslogServers}'
+                },
+                columns: 3,
+                vertical: true
             }]
         }]
     }]

--- a/uvm/servlets/admin/config/events/view/Syslog.js
+++ b/uvm/servlets/admin/config/events/view/Syslog.js
@@ -156,6 +156,7 @@ Ext.define('Ung.config.events.view.Syslog', {
             renderer: 'sysLogServersRenderer'
         }],
 
+        editorXtype: 'ung.cmp.unsyslogruleseditor',
         editorFields: [
             Field.enableRule(),
             Field.description,
@@ -227,18 +228,7 @@ Ext.define('Ung.config.events.view.Syslog', {
         }, {
             xtype: 'fieldset',
             title: 'Perform the following action(s):'.t(),
-            items:[{
-                xtype: 'checkboxgroup',
-                fieldLabel: 'Syslog Servers'.t(),
-                useParentDefinition: true,
-                itemId: 'syslogserverscheckbox',
-                labelWidth: 155,
-                bind: {
-                    value: '{record.syslogServers}'
-                },
-                columns: 3,
-                vertical: true
-            }]
+            itemId: 'actioncontainer'
         }]
     }]
 });


### PR DESCRIPTION
Enable adding multiple syslog servers by adding grid. Allowing user to use these servers in syslog rules.
[Design Document](https://awakesecurity.atlassian.net/wiki/spaces/ngfw/pages/2372993027/Design+Multiple+Remote+Syslog+Events)

Changes on Config --> Events --> Syslog Page
1. Removed `Remote Syslog Configuration` container.
2. Added Syslog Servers Grid where user can add syslog using `add` button.
3. Added editor to enable user to edit syslog server configuration.
4. Each server will be assigned a unique `Server Id` and it can not be reordered.
5. `tag` value for each syslog server (except Remote Syslog server `tag=uvm[0]`) will be auto populated in format `uvm-to-%host%`

![Screenshot from 2024-04-03 17-26-19](https://github.com/untangle/ngfw_src/assets/154422821/5209f7eb-ee72-4a62-bb2f-e8faad420a5b)

![Screenshot from 2024-04-03 17-28-15](https://github.com/untangle/ngfw_src/assets/154422821/dfc8d28a-174d-4064-a494-aa9c1e426351)

![Screenshot from 2024-04-03 17-28-30](https://github.com/untangle/ngfw_src/assets/154422821/95c4a315-fa21-4aae-ab01-166d868a4f70)

Syslog Servers object in `event.js` file

![Screenshot from 2024-04-03 17-29-15](https://github.com/untangle/ngfw_src/assets/154422821/dd417df3-3323-4f06-b6b9-d97614957d58)




6. Removed `Remote Syslog` column and editor field from Syslog Rules Grid and Grid Editor
7. Added `Syslog Servers` column in Syslog Rules grid
8. Added `Syslog Servers` checkbox group editor field in Syslog Server Grid editor window.

![Screenshot from 2024-04-03 17-30-04](https://github.com/untangle/ngfw_src/assets/154422821/ed897069-1790-49c0-9fa7-ca77ac1a4039)

![Screenshot from 2024-04-03 18-40-29](https://github.com/untangle/ngfw_src/assets/154422821/6256401f-fbd8-444c-afde-96f8141a2fac)


Syslog Rules object in `event.js` file
![Screenshot from 2024-04-03 17-33-12](https://github.com/untangle/ngfw_src/assets/154422821/8044de4b-196e-400d-985d-84de129d453c)

