### PR TITLE
NGFW-14149: ‘Is Not’ operator does not work for Protocol condition with multiple value

### DIFF
--- a/uvm/servlets/admin/app/cmp/ConditionsEditorController.js
+++ b/uvm/servlets/admin/app/cmp/ConditionsEditorController.js
@@ -630,6 +630,15 @@ Ext.define('Ung.cmp.ConditionsEditorController', {
                     store: comparator.store,
                     listeners: {
                         change: function(combo, newValue, oldValue){
+                            if( combo.uiCls == 'form-focus' && combo.rawValue === 'is NOT' ){
+                                var record = combo.up().$widgetRecord;
+                                if ( record.data['javaClass'] === 'com.untangle.uvm.network.FilterRuleCondition' &&
+                                record.data['conditionType'] !== 'SRC_PORT' && 
+                                record.data['conditionType'] !== 'DST_PORT' )
+                                {
+                                    Ext.Msg.alert('Warning'.t(), Ext.String.format('"is NOT" is not supported for multiple values. Ensure to have only one rule for "{0}" condition type with "is NOT" operator.', record.data['conditionType']).t());
+                                }
+                            }
                             combo.up('conditionseditor').getController().forceValidate();
                         }
                     }


### PR DESCRIPTION
**ISSUE:**
‘Is Not’ operator does not work for Protocol condition with multiple value

**FIX:**
IPtable itself does not allow the invert operator with multiple values other than Ports, so added the alert while choosing "is NOT" operator in filter-rule conditions.

**TEST:**
Alert should be pop-up in case of all the condition except DESTINATION PORT.

![Screenshot from 2024-04-04 18-32-27](https://github.com/untangle/ngfw_src/assets/155290371/0493280c-b841-4e8b-b166-8d6414d37cbd)
