### PR TITLE
ngfw-14564 handling syslog server and rules update and dataChange events

### DIFF
--- a/uvm/servlets/admin/config/events/MainModel.js
+++ b/uvm/servlets/admin/config/events/MainModel.js
@@ -15,7 +15,19 @@ Ext.define('Ung.config.events.MainModel', {
     stores: {
         alertRules: { data: '{settings.alertRules.list}' },
         triggerRules: { data: '{settings.triggerRules.list}' },
-        syslogRules: { data: '{settings.syslogRules.list}' },
-        syslogServers: { data: '{settings.syslogServers.list}'}
+        syslogRules: { 
+            data: '{settings.syslogRules.list}',
+            listeners: {
+                update: 'onSyslogRulesGridChange',
+                datachanged: 'onSyslogRulesGridChange'
+            }
+        },
+        syslogServers: { 
+            data: '{settings.syslogServers.list}',
+            listeners: {
+                update: 'onSyslogServersGridChange',
+                datachanged: 'onSyslogServersGridChange'
+            }
+        }
     }
 });

--- a/uvm/servlets/admin/config/events/view/Syslog.js
+++ b/uvm/servlets/admin/config/events/view/Syslog.js
@@ -22,6 +22,11 @@ Ext.define('Ung.config.events.view.Syslog', {
         itemId: 'syslogservers',
         region: 'center',
 
+        restrictedRecords: {
+            keyMatch: 'reserved',
+            valueMatch: true
+        },
+
         padding: '20 0',
         bind: {
             store: '{syslogServers}',
@@ -87,14 +92,25 @@ Ext.define('Ung.config.events.view.Syslog', {
             }
         ]
     },{
+        xtype: 'container',
+        padding: '8 5',
+        style: { fontSize: '12px', background: '#DADADA'},
+        html: '<i class="fa fa-info-circle" style="color: orange;"></i> ' + 'Save the New/Modified/Deleted records in Syslog Server grid to enable Syslog Rules'.t(),
+        hidden: true,
+        bind: {
+            hidden: '{!syslogRuleGridDisabled}'
+        }
+    },{
         xtype: 'ungrid',
         controller: 'uneventssyslogrulesgrid',
         title: 'Rules'.t(),
         itemId: 'syslogrules',
         region: 'center',
 
+        disabled: false,
         bind: {
             store: '{syslogRules}',
+            disabled: '{syslogRuleGridDisabled}'
         },
 
         listProperty: 'settings.syslogRules.list',


### PR DESCRIPTION
**Changes:**

1. For `Syslog Servers` grid `serverId` comes from the back-end during `setSettings`.  Therefore it will not be available for `Syslog Rules` until settings have been saved.  Therefore after a syslog server has been added/edited/deleted, **disabled** the `Syslog Rules` grid with a message `Save the New/Modified/Deleted records in Syslog Server grid to enable Syslog Rules`.

2. **Reserved** the `Syslog Server` if any of `Syslog Rule` is using it.

Local Testing Screenshots.

If new Syslog Server is added or existing edited/marked for delete then disabling the Syslog Rules Grid.
![Screenshot from 2024-04-08 16-55-30](https://github.com/untangle/ngfw_src/assets/154422821/10aace41-7f85-4baf-8f7f-c92dae50558f)

------------------------
On clicking on save button, syslog rules grid is enabled.

![Screenshot from 2024-04-08 16-55-40](https://github.com/untangle/ngfw_src/assets/154422821/52089828-1bca-44b8-b0c3-4cb7c080b383)

------------------------
If any of newly added or existing syslog rule is using syslog server then mark it as reserved and restrict it from editing and deleting

![Screenshot from 2024-04-08 16-56-21](https://github.com/untangle/ngfw_src/assets/154422821/f7c86987-0e37-4f01-bf96-173a6114dbe7)

------------------------

![Screenshot from 2024-04-08 16-57-05](https://github.com/untangle/ngfw_src/assets/154422821/4a9c343f-7d26-456b-ab83-32bb7d8bf877)

------------------------

If any syslog rule is marked for delete then servers used by that rule will not be reserved.

![Screenshot from 2024-04-08 16-57-52](https://github.com/untangle/ngfw_src/assets/154422821/cfaab496-f095-4c5e-948a-373bbc27f74e)
