### PR TITLE
ngfw-14567: Add description field for each syslog server

### DIFF
--- a/uvm/api/com/untangle/uvm/event/SyslogServer.java
+++ b/uvm/api/com/untangle/uvm/event/SyslogServer.java
@@ -21,6 +21,7 @@ public class SyslogServer implements Serializable, JSONString {
     private int port = 514;
     private String protocol = "UDP";
     private String tag = "";
+    private String description;
 
     /**
      * Initialize empty instance of SyslogServer. 
@@ -36,14 +37,16 @@ public class SyslogServer implements Serializable, JSONString {
      * @param  port                   integer, port of server  boolean if true remote syslog the event, otherwise don't syslog
      * @param  protocol               integer, protocol for communication UDP/TCP
      * @param  tag                    String, server identifier
+     * @param  description            String, server description
      */
-    public SyslogServer(int serverId, boolean enabled, String host, int port, String protocol, String tag) {
+    public SyslogServer(int serverId, boolean enabled, String host, int port, String protocol, String tag, String description) {
         this.serverId = serverId;
         this.enabled = enabled;
         this.host = host;
         this.port = port;
         this.protocol = protocol;
         this.tag = tag;
+        this.description = description;
     }
 
     public int getServerId() {
@@ -81,6 +84,13 @@ public class SyslogServer implements Serializable, JSONString {
     }
     public void setTag(String tag) {
         this.tag = tag;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public String toJSONString()

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
@@ -45,23 +45,25 @@ class SysLogTests(NGFWTestCase):
         syslogSettings["syslogPort"] = 514
         syslogSettings["syslogProtocol"] = "UDP"
         syslogSettings["syslogHost"] = "192.168.56.195"
-        uvmContext.eventManager().setSettings(syslogSettings)
-        #this will add rule with server id as 1, the first server is assigned server id 1 always
-        if (len(syslogSettings['syslogRules']['list']) == 1):
-           if "syslogServers" in syslogSettings['syslogRules']['list'][0].keys() and syslogSettings['syslogRules']['list'][0]['syslogServers']:
-              syslogSettings['syslogRules']['list'][0]['syslogServers']['list'].append(1)
+        if "syslogServers" in syslogSettings:
+           syslogSettings.pop("syslogServers")
+        for rule in syslogSettings['syslogRules']['list']:
+            if "syslogServers" in  rule.keys():
+               rule.pop("syslogServers")
         uvmContext.eventManager().setSettings(syslogSettings)
         syslogUpdatedSettings = uvmContext.eventManager().getSettings()
-        assert(len(syslogSettings['syslogRules']['list'][0]['syslogServers']['list']) == 1)
+        assert(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'][0] == 1)
         assert (len(syslogUpdatedSettings['syslogServers']['list']) == 1)
-        if (len(syslogUpdatedSettings['syslogRules']['list']) == 1):
-           if "syslogServers" in syslogUpdatedSettings['syslogRules']['list'][0].keys() and syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']:
-              syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].clear()
-              syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].append(2)
+        print(syslogUpdatedSettings['syslogServers']['list'])
+        print(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers'])
+        if "syslogServers" in syslogUpdatedSettings['syslogRules']['list'][0].keys() and syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']:
+           syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].clear()
+           syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].append(2)
         uvmContext.eventManager().setSettings(syslogUpdatedSettings)
         syslogUpdatedSettings = uvmContext.eventManager().getSettings()
         assert (len(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list']) == 1)
         #server ID should be updated to 2 for the syslogRule
+        print(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'])
         assert (syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'][0] == 2)
         uvmContext.eventManager().setSettings(orig_settings)
 
@@ -86,7 +88,7 @@ class SysLogTests(NGFWTestCase):
         syslogSettings = uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
         syslogSettings["syslogEnabled"] = True
-        if "syslogServers" in syslogSettings.keys():
+        if "syslogServers" not in syslogSettings.keys():
            syslogSettings['syslogServers'] = {"javaClass": "java.util.LinkedList","list": [] }
         else:
            initial_logservers = len(syslogSettings['syslogServers']['list'])
@@ -106,7 +108,7 @@ class SysLogTests(NGFWTestCase):
         syslogSettings["syslogEnabled"] = True
         #Default setup list will not be present. UI payload will contain server list, need to generate for unittest
         #Testcase covers both enabled and disabled syslogserver scenario
-        if "syslogServers" in syslogSettings.keys():
+        if "syslogServers" not in syslogSettings.keys():
            syslogSettings['syslogServers'] = {"javaClass": "java.util.LinkedList","list": [] }
         else:
            initial_logservers = len(syslogSettings['syslogServers']['list'])

--- a/uvm/impl/com/untangle/uvm/SyslogManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SyslogManagerImpl.java
@@ -62,10 +62,6 @@ public class SyslogManagerImpl
      */
     public static void sendSyslog(LogEvent e, JSONObject jsonEvent)
     {
-        if (!enabled) {
-            return;
-        }
-
         try {
             logger.log(org.apache.log4j.Level.INFO, e.getTag() + " " + jsonEvent);
         } catch (Exception exn) {
@@ -100,13 +96,10 @@ public class SyslogManagerImpl
      */
     public static void reconfigure(EventSettings eventSettings)
     {
-        if (eventSettings != null && eventSettings.getSyslogEnabled() && eventSettings.getSyslogServers() != null) {
-            enabled = true;
+        if (eventSettings != null && eventSettings.getSyslogServers() != null ) {
             //Delete the CONF_FILE as rsyslog process is restarted at the end of reconfigure method
             CONF_FILE.delete();
             for (SyslogServer sysLogServer: eventSettings.getSyslogServers()) {
-                //skip if SyslogServer  is not enabled
-                if (!sysLogServer.isEnabled()) continue;
                 String hostname = sysLogServer.getHost();
                 int port = sysLogServer.getPort();
                 String protocol = sysLogServer.getProtocol();
@@ -141,7 +134,6 @@ public class SyslogManagerImpl
 
         } else {
             // Remove rsyslog conf
-            enabled = false;
             CONF_FILE.delete();
         }
 


### PR DESCRIPTION
1.Added description field for syslog servers
2. If before Upgrade syslog server is enabled then all the rules will be assigned that particular syslog server after upgrade, and a server in syslog server list 
3. If Before  Upgrade syslog server is disabled  then all the rules will be assigned empty integer syslog server list, along with empty syslog
server list.

In both the cases step 2 and 3, Enable syslog field after upgrade , will not affect syslog servers. After UI changes Enable syslog field won't be visible in UI.

Modified testcases to cover scenario 2 above rules should be assigned syslog server in case before syslog is enabled and configured.