### PR TITLE
ngfw-14567: Add description field to syslogserver (Backend changes)

### DIFF
--- a/uvm/api/com/untangle/uvm/event/SyslogServer.java
+++ b/uvm/api/com/untangle/uvm/event/SyslogServer.java
@@ -21,6 +21,7 @@ public class SyslogServer implements Serializable, JSONString {
     private int port = 514;
     private String protocol = "UDP";
     private String tag = "";
+    private String description;
 
     /**
      * Initialize empty instance of SyslogServer. 
@@ -36,14 +37,16 @@ public class SyslogServer implements Serializable, JSONString {
      * @param  port                   integer, port of server  boolean if true remote syslog the event, otherwise don't syslog
      * @param  protocol               integer, protocol for communication UDP/TCP
      * @param  tag                    String, server identifier
+     * @param  description            String, server description
      */
-    public SyslogServer(int serverId, boolean enabled, String host, int port, String protocol, String tag) {
+    public SyslogServer(int serverId, boolean enabled, String host, int port, String protocol, String tag, String description) {
         this.serverId = serverId;
         this.enabled = enabled;
         this.host = host;
         this.port = port;
         this.protocol = protocol;
         this.tag = tag;
+        this.description = description;
     }
 
     public int getServerId() {
@@ -81,6 +84,13 @@ public class SyslogServer implements Serializable, JSONString {
     }
     public void setTag(String tag) {
         this.tag = tag;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public String toJSONString()

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
@@ -52,7 +52,9 @@ class SysLogTests(NGFWTestCase):
               syslogSettings['syslogRules']['list'][0]['syslogServers']['list'].append(1)
         uvmContext.eventManager().setSettings(syslogSettings)
         syslogUpdatedSettings = uvmContext.eventManager().getSettings()
-        assert(len(syslogSettings['syslogRules']['list'][0]['syslogServers']['list']) == 1)
+        assert(len(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list']) == 1)
+        #check for description field populated in case of setup where syslog server is enabled
+        assert("Default Syslog Server" == syslogUpdatedSettings['syslogServers']['list'][0]['description'])
         assert (len(syslogUpdatedSettings['syslogServers']['list']) == 1)
         if (len(syslogUpdatedSettings['syslogRules']['list']) == 1):
            if "syslogServers" in syslogUpdatedSettings['syslogRules']['list'][0].keys() and syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']:

--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -216,7 +216,7 @@ public class EventManagerImpl implements EventManager
                     LinkedList<SyslogServer> syslogList = new LinkedList<SyslogServer>();
                     //  syslogHost for newsetups will be null, skip the default syslog addition, but initialize empty list
                     if (newSettings.getSyslogHost() != null) {
-                        SyslogServer logServer = new SyslogServer(getLastUsedServerId(inputServerList) + 1, true, newSettings.getSyslogHost(), newSettings.getSyslogPort(), newSettings.getSyslogProtocol(), SyslogManagerImpl.LOG_TAG_PREFIX);
+                        SyslogServer logServer = new SyslogServer(getLastUsedServerId(inputServerList) + 1, true, newSettings.getSyslogHost(), newSettings.getSyslogPort(), newSettings.getSyslogProtocol(), SyslogManagerImpl.LOG_TAG_PREFIX, "Default Syslog Server");
                         syslogList.add(logServer);
                     }
                     newSettings.setSyslogServers(syslogList);


### PR DESCRIPTION
Added description field for syslog server. Modified test case to check for description field.
Following is screenshot for description field
![Screenshot from 2024-04-09 18-10-17](https://github.com/untangle/ngfw_src/assets/154513962/65b8f52b-70bf-4fc2-9090-ab5e87ca43bb)


Testcases Output
![Screenshot from 2024-04-09 18-29-42](https://github.com/untangle/ngfw_src/assets/154513962/81484b63-11c6-4581-9e74-4c1d3e0cdb2a)
