### PR TITLE
NGFW-14533: Updated logic validate only network space in WG against network Registry

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -1191,7 +1191,7 @@ Ext.define('Ung.util.Util', {
 
             if(index !== null) return "Address pool conflict".t();
 
-            if(context.dirty) {
+            if(context.dirty && context.ui === "default") {
                 var ntwkSpace=null;
                 if(currentIpDirtyCheck){
                     ntwkSpace = rpc.UvmContext.netspaceManager().isNetworkAvailable('wireguard-vpn', currentFieldIp.trim());   


### PR DESCRIPTION
**ISSUE:** 
Local network should not be validated against network registry.

**FIXED:**
Updated logic to validate only Network Space in WG settings against network Registry

**TEST:**

- Have two LANs configured in Config → Network → Interfaces.
- Under WireGuard → Settings, remove one of them from the Local Networks table (may need to remove the Wireguard app and reinstall for both networks to appear in table). Save.
- Now test below scenarios.

1.  Try to assign same Ip address under Network space , it should show address pool conflict.
![Screenshot from 2024-04-09 18-42-07](https://github.com/untangle/ngfw_src/assets/155290371/effb6df4-9c1d-498d-a872-c41f79119119)

2. Try to assign deleted IP address again in local network, it should not show any conflict.
![Screenshot from 2024-04-09 18-41-25](https://github.com/untangle/ngfw_src/assets/155290371/f4249d5e-a353-4f09-845e-5115b39e9f50)

3. Try to assign the IP address already present in local network pool, it should show address pool conflict.
![Screenshot from 2024-04-09 18-43-00](https://github.com/untangle/ngfw_src/assets/155290371/740e6f83-ea65-4fed-bf88-2ec4b090dff6)


- Go to WG -> Tunnels
- Add new tunnel try to add same network IP in Remote Network, it will show address pool conflict.
![Screenshot from 2024-04-09 18-40-00](https://github.com/untangle/ngfw_src/assets/155290371/becb1341-5bcf-43b8-900d-74522577bf39)


