### PR TITLE
ngfw-14565: Remove the "Enable Syslog" (Backend changes)

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
@@ -45,25 +45,25 @@ class SysLogTests(NGFWTestCase):
         syslogSettings["syslogPort"] = 514
         syslogSettings["syslogProtocol"] = "UDP"
         syslogSettings["syslogHost"] = "192.168.56.195"
-        uvmContext.eventManager().setSettings(syslogSettings)
-        #this will add rule with server id as 1, the first server is assigned server id 1 always
-        if (len(syslogSettings['syslogRules']['list']) == 1):
-           if "syslogServers" in syslogSettings['syslogRules']['list'][0].keys() and syslogSettings['syslogRules']['list'][0]['syslogServers']:
-              syslogSettings['syslogRules']['list'][0]['syslogServers']['list'].append(1)
+        if "syslogServers" in syslogSettings:
+           syslogSettings.pop("syslogServers")
+        for rule in syslogSettings['syslogRules']['list']:
+            if "syslogServers" in  rule.keys():
+               rule.pop("syslogServers")
         uvmContext.eventManager().setSettings(syslogSettings)
         syslogUpdatedSettings = uvmContext.eventManager().getSettings()
-        assert(len(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list']) == 1)
+        assert (len(syslogUpdatedSettings['syslogServers']['list']) == 1)
         #check for description field populated in case of setup where syslog server is enabled
         assert("Default Syslog Server" == syslogUpdatedSettings['syslogServers']['list'][0]['description'])
-        assert (len(syslogUpdatedSettings['syslogServers']['list']) == 1)
-        if (len(syslogUpdatedSettings['syslogRules']['list']) == 1):
-           if "syslogServers" in syslogUpdatedSettings['syslogRules']['list'][0].keys() and syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']:
-              syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].clear()
-              syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].append(2)
+        assert(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'][0] == 1)
+        if "syslogServers" in syslogUpdatedSettings['syslogRules']['list'][0].keys() and syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']:
+           syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].clear()
+           syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].append(2)
         uvmContext.eventManager().setSettings(syslogUpdatedSettings)
         syslogUpdatedSettings = uvmContext.eventManager().getSettings()
         assert (len(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list']) == 1)
         #server ID should be updated to 2 for the syslogRule
+        print(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'])
         assert (syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'][0] == 2)
         uvmContext.eventManager().setSettings(orig_settings)
 
@@ -88,7 +88,7 @@ class SysLogTests(NGFWTestCase):
         syslogSettings = uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
         syslogSettings["syslogEnabled"] = True
-        if "syslogServers" in syslogSettings.keys():
+        if "syslogServers" not in syslogSettings.keys():
            syslogSettings['syslogServers'] = {"javaClass": "java.util.LinkedList","list": [] }
         else:
            initial_logservers = len(syslogSettings['syslogServers']['list'])
@@ -108,7 +108,7 @@ class SysLogTests(NGFWTestCase):
         syslogSettings["syslogEnabled"] = True
         #Default setup list will not be present. UI payload will contain server list, need to generate for unittest
         #Testcase covers both enabled and disabled syslogserver scenario
-        if "syslogServers" in syslogSettings.keys():
+        if "syslogServers" not in syslogSettings.keys():
            syslogSettings['syslogServers'] = {"javaClass": "java.util.LinkedList","list": [] }
         else:
            initial_logservers = len(syslogSettings['syslogServers']['list'])

--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -185,16 +185,6 @@ public class EventManagerImpl implements EventManager
         idx = 0;
         for (SyslogRule rule : newSettings.getSyslogRules()) {
             rule.setRuleId(++idx);
-            if(newSettings.getSyslogEnabled()) {
-                //Initialize empty LinkedList for each rule 
-                if (rule.getSyslogServers() == null ) {
-                    LinkedList<Integer> syslogServerIDsList = new LinkedList<Integer>();
-                    rule.setSyslogServers(syslogServerIDsList);
-                }
-            }
-            if(!newSettings.getSyslogEnabled() && rule.getSyslogServers() != null && rule.getSyslogServers().size() > 0) {
-                rule.getSyslogServers().clear();
-            }
         }
         idx = 0;
         for (TriggerRule rule : newSettings.getTriggerRules()) {
@@ -210,31 +200,39 @@ public class EventManagerImpl implements EventManager
 
         if (newSettings != null) {
             LinkedList<SyslogServer> inputServerList =  newSettings.getSyslogServers();
-            if(newSettings.getSyslogEnabled()) {
-                //cover the Base scenario of default LogServer enabled and default logserver post upgrade restart
-                if (inputServerList == null || inputServerList.size() == 0  ) {
-                    LinkedList<SyslogServer> syslogList = new LinkedList<SyslogServer>();
-                    //  syslogHost for newsetups will be null, skip the default syslog addition, but initialize empty list
-                    if (newSettings.getSyslogHost() != null) {
-                        SyslogServer logServer = new SyslogServer(getLastUsedServerId(inputServerList) + 1, true, newSettings.getSyslogHost(), newSettings.getSyslogPort(), newSettings.getSyslogProtocol(), SyslogManagerImpl.LOG_TAG_PREFIX, "Default Syslog Server");
-                        syslogList.add(logServer);
-                    }
+            //cover the Base scenario of default LogServer enabled and default logserver post upgrade restart
+            if (inputServerList == null ) {
+                LinkedList<SyslogServer> syslogList = new LinkedList<SyslogServer>();
+                LinkedList<Integer> sysLogIntegerList = new LinkedList<Integer>();
+                if (newSettings.getSyslogEnabled()) {
+                    SyslogServer logServer = new SyslogServer(getLastUsedServerId(inputServerList) + 1, true, newSettings.getSyslogHost(), newSettings.getSyslogPort(), newSettings.getSyslogProtocol(), SyslogManagerImpl.LOG_TAG_PREFIX, "Default Syslog Server");
+                    syslogList.add(logServer);
+                    //Disable sysLogHost, and sysLogEnabled field
+                    //Syslog servers will be managed by List
+                    newSettings.setSyslogHost(null);
+                    newSettings.setSyslogEnabled(false);
                     newSettings.setSyslogServers(syslogList);
+                    //During Upgrade with Syslog enabled and default syslog set
+                    // first syslog server will have server ID as 1.
+                    sysLogIntegerList.add(1);
                 } else {
-                    // set ServerIDs based on last used logic 
-                    for (SyslogServer syslogServer : inputServerList ) {
-                        //Skip Default Scenario, and set serverID and Tag for New SyslogServers
-                        if (syslogServer.getServerId() == -1) {
-                            syslogServer.setServerId(getLastUsedServerId(inputServerList) + 1);
-                        }
+                    newSettings.setSyslogServers(syslogList);
+                }
+                //Set Empty List in case of Syslog Disabled during upgrade.
+                for (SyslogRule rule : newSettings.getSyslogRules()) {
+                    rule.setSyslogServers(sysLogIntegerList);
+                }
+            } else {
+                // set ServerIDs based on last used logic
+                for (SyslogServer syslogServer : inputServerList ) {
+                    //Skip Default Scenario, and set serverID and Tag for New SyslogServers
+                    if (syslogServer.getServerId() == -1) {
+                        syslogServer.setServerId(getLastUsedServerId(inputServerList) + 1);
                     }
                 }
             }
-            if (!newSettings.getSyslogEnabled() && inputServerList != null && inputServerList.size() > 0) {
-                inputServerList.clear();
-            }
-
         }
+
         /**
          * Save the settings
          */
@@ -1328,8 +1326,6 @@ public class EventManagerImpl implements EventManager
     {
         if ( event == null )
             return;
-        if ( ! settings.getSyslogEnabled() )
-            return;
 
         List<SyslogRule> rules = UvmContextFactory.context().eventManager().getSettings().getSyslogRules();
         if ( rules == null )
@@ -1357,7 +1353,7 @@ public class EventManagerImpl implements EventManager
                 //get syslogserver list using IDs
                 for (SyslogServer syslogServer: getFilteredSyslogByIDs(rulesSyslogServerIDList) ) {
                     event.setTag(syslogServer.getTag());
-                    if ( rule.getSyslog() ) {
+                    if ( rule.getSyslog() && syslogServer.isEnabled()) {
                         try {
                             SyslogManagerImpl.sendSyslog( event, jsonSendObject );
                         } catch (Exception exn) {

--- a/uvm/impl/com/untangle/uvm/SyslogManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SyslogManagerImpl.java
@@ -62,10 +62,6 @@ public class SyslogManagerImpl
      */
     public static void sendSyslog(LogEvent e, JSONObject jsonEvent)
     {
-        if (!enabled) {
-            return;
-        }
-
         try {
             logger.log(org.apache.log4j.Level.INFO, e.getTag() + " " + jsonEvent);
         } catch (Exception exn) {
@@ -100,13 +96,10 @@ public class SyslogManagerImpl
      */
     public static void reconfigure(EventSettings eventSettings)
     {
-        if (eventSettings != null && eventSettings.getSyslogEnabled() && eventSettings.getSyslogServers() != null) {
-            enabled = true;
+        if (eventSettings != null && eventSettings.getSyslogServers() != null ) {
             //Delete the CONF_FILE as rsyslog process is restarted at the end of reconfigure method
             CONF_FILE.delete();
             for (SyslogServer sysLogServer: eventSettings.getSyslogServers()) {
-                //skip if SyslogServer  is not enabled
-                if (!sysLogServer.isEnabled()) continue;
                 String hostname = sysLogServer.getHost();
                 int port = sysLogServer.getPort();
                 String protocol = sysLogServer.getProtocol();
@@ -141,7 +134,6 @@ public class SyslogManagerImpl
 
         } else {
             // Remove rsyslog conf
-            enabled = false;
             CONF_FILE.delete();
         }
 


### PR DESCRIPTION
This Pr covers following scenarios, along with changes for Enable Syslog from backend
1. If before Upgrade syslog server is enabled then all the rules will be assigned to that particular syslog server after upgrade, and a server in syslog server list
2. If Before Upgrade syslog server is disabled then all the rules will be assigned empty integer syslog server list, along with empty syslog
server list.

In both the cases step 2 and 3, Enable syslog field after upgrade , will not affect syslog servers. After UI changes Enable syslog field won't be visible in UI.

Modified testcases to cover scenario 1 above rules should be assigned syslog server in case before syslog is enabled and configured.


Modified Test cases Passing
![Screenshot from 2024-04-09 18-56-08](https://github.com/untangle/ngfw_src/assets/154513962/a8fd37ed-09d1-4caf-9678-9dec5fdd525b)

