### PR TITLE
Ngfw 14567 add description field syslog servers

### DIFF
--- a/uvm/servlets/admin/config/events/MainController.js
+++ b/uvm/servlets/admin/config/events/MainController.js
@@ -416,7 +416,7 @@ Ext.define('Ung.config.events.SyslogRulesController', {
             data = serverList.filter(function(server) {
                 return serverIds.includes(server.serverId);
             }).map(function(server) {
-                return server.host;
+                return server.description;
             });
         column.tdAttr = 'data-qtip="' + Ext.String.htmlEncode(data.join(", ")) + '"';
         return data.join(", ");
@@ -451,6 +451,7 @@ Ext.define('Ung.config.events.SyslogRulesEditorController', {
             useParentDefinition: true,
             itemId: 'syslogserverscheckbox',
             labelWidth: 155,
+            readOnlyCls: 'x-item-disabled',
             bind: {
                 value: '{record.syslogServers}'
             },
@@ -467,14 +468,17 @@ Ext.define('Ung.config.events.SyslogRulesEditorController', {
 
         syslogServerStore.each(function(record) {
             if(record.get('serverId') > 0 && !record.get('markedForDelete')) {
+                var readOnly = !record.get('enabled'),
+                    qtip = readOnly ? Ext.String.format('Enable the server with host {0}'.t(), record.get('host')) : record.get('host');
                 items.push({ 
-                    boxLabel: record.get('host'), 
+                    boxLabel: record.get('description'),
                     name: 'list', 
                     inputValue: Number(record.get('serverId')),
                     autoEl: {
                         tag: 'div',
-                        'data-qtip': record.get('host')
-                    }
+                        'data-qtip': qtip
+                    },
+                    readOnly: readOnly
                 });
             }
         });

--- a/uvm/servlets/admin/config/events/view/Syslog.js
+++ b/uvm/servlets/admin/config/events/view/Syslog.js
@@ -47,6 +47,7 @@ Ext.define('Ung.config.events.view.Syslog', {
         columns: [
             Column.serverId,
             Column.enabled,
+            Column.description,
         {
             header: 'Host'.t(),
             dataIndex: 'host',
@@ -64,6 +65,7 @@ Ext.define('Ung.config.events.view.Syslog', {
 
         editorFields: [
             Field.enableRule(),
+            Field.description,
             {
                 xtype: 'textfield',
                 fieldLabel: 'Host'.t(),

--- a/uvm/servlets/admin/config/events/view/Syslog.js
+++ b/uvm/servlets/admin/config/events/view/Syslog.js
@@ -73,13 +73,17 @@ Ext.define('Ung.config.events.view.Syslog', {
                 allowBlank: false,
                 validator: function(value) {
                     var store = this.up('#syslogservers').getStore(),
-                        currentDesc = this.up('window').getViewModel().get('record.description');
+                        currentServerId = this.up('window').getViewModel().get('record.serverId');
                 
                     // Check if a record with the same description exists in the store
                     var isDescUnique = store.findBy(function(record) {
-                        return record.get('description') === value;
+                        if(currentServerId == -1) {
+                            return record.get('description') === value;
+                        } else {
+                            return record.get('serverId') !== currentServerId && record.get('description') === value;
+                        }
                     }) === -1;
-                    return (value === currentDesc || isDescUnique) ? true : 'Duplicate description.'.t();
+                    return (isDescUnique) ? true : 'Duplicate description.'.t();
                 }
             },
             {

--- a/uvm/servlets/admin/config/events/view/Syslog.js
+++ b/uvm/servlets/admin/config/events/view/Syslog.js
@@ -65,7 +65,23 @@ Ext.define('Ung.config.events.view.Syslog', {
 
         editorFields: [
             Field.enableRule(),
-            Field.description,
+            {
+                xtype: 'textfield',
+                fieldLabel: 'Description'.t(),
+                bind: '{record.description}',
+                emptyText: '[no description]'.t(),
+                allowBlank: false,
+                validator: function(value) {
+                    var store = this.up('#syslogservers').getStore(),
+                        currentDesc = this.up('window').getViewModel().get('record.description');
+                
+                    // Check if a record with the same description exists in the store
+                    var isDescUnique = store.findBy(function(record) {
+                        return record.get('description') === value;
+                    }) === -1;
+                    return (value === currentDesc || isDescUnique) ? true : 'Duplicate description.'.t();
+                }
+            },
             {
                 xtype: 'textfield',
                 fieldLabel: 'Host'.t(),


### PR DESCRIPTION
1. Added **Description column and editor field** in Syslog server grid.
2. Added validator for description editor field to not allow duplicate values.
3. In Syslog Rules record editor - Syslog servers field will be a check-box group with syslog **description as label**. On hover syslog **host** will be shown in qtip message.
4. If Syslog server is **disabled** then respective checkbox in rule editor will be marked as **read only** with qtip message **Enable the server with host {host}**
 
 
 Local Testing Screenshots
 
 Description Column
 
 ![Screenshot from 2024-04-12 15-39-09](https://github.com/untangle/ngfw_src/assets/154422821/941651e4-4e36-4468-98c5-4c53f271023b)
 
 -------------------------
 
 Description Editor
 
 ![Screenshot from 2024-04-12 15-39-40](https://github.com/untangle/ngfw_src/assets/154422821/d280e41b-8a7f-46ca-8ad0-ded63a96bd14)
 
  -------------------------
  
  On Syslog Server Add
  
  ![Screenshot from 2024-04-12 15-40-11](https://github.com/untangle/ngfw_src/assets/154422821/daad7986-a867-4922-b23e-a078b2d9df2c)
  
  ------------------------
  
  After saving server description is correctly populated in events.js file
  
  ![Screenshot from 2024-04-12 15-40-46](https://github.com/untangle/ngfw_src/assets/154422821/6d8d410f-610d-4f63-bd9d-4aca886d04fc)
  
  -------------------------
 
 Syslog rule editor - Syslog servers checkbox-group
 
![Screenshot from 2024-04-12 15-41-44](https://github.com/untangle/ngfw_src/assets/154422821/4c540335-4034-4df5-8ed6-38fc6c42d482)

---------------------------

Disabled servers will be marked as read-Only with given qtip message

![Screenshot from 2024-04-12 15-41-24](https://github.com/untangle/ngfw_src/assets/154422821/eb2dbe7c-2df4-4bbd-9e2b-7eb9534e5330)




