### PR TITLE
ngfw-13920: Investigate Web Filter Search Terms with $ do not get blocked

### DIFF
--- a/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
+++ b/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
@@ -10,7 +10,6 @@ import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 import tests.global_functions as global_functions
 
-
 default_policy_id = 1
 app = None
 appWeb = None
@@ -233,6 +232,52 @@ class SslInspectorTests(NGFWTestCase):
                                                    'flagged', True )
             assert( found )
         search_term_rules_clear()
+
+    def test_650_web_search_rules(self):
+        """check the web filter search terms with $ are evaluated and blocked if set
+            %24 will be converted to $
+        """
+        term = "a$$"
+        termTests = [{
+            "host": "www.google.com",
+            "uri":  ("/search?hl=en&q=%s" % "a%24%24"),
+        }]
+        search_term_rule_add(term)
+        for t in termTests:
+            eventTime = datetime.datetime.now()
+            result = remote_control.run_command(global_functions.build_curl_command(output_file="/dev/null", user_agent="Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.1) Gecko/20061204 Firefox/2.0.0.1", uri=f"https://{t['host']}{t['uri']}"))
+            events = global_functions.get_events("Web Filter",'All Search Events',None,1)
+            found = global_functions.check_events( events.get('list'), 5,
+                                                   "host", t["host"],
+                                                   "term", term,
+                                                   'blocked', True,
+                                                   'flagged', True )
+            assert( found )
+        search_term_rules_clear()
+
+
+    def test_655_web_search_rules(self):
+        """check the web filter search terms with $ are evaluated and blocked if set"""
+        term = "a$$"
+        termTests = [{
+            "host": "www.google.com",
+            "uri":  ("/search?hl=en&q=%s" % "a\$\$"),
+        }]
+        search_term_rule_add(term)
+        for t in termTests:
+            eventTime = datetime.datetime.now()
+            result = remote_control.run_command(global_functions.build_curl_command(output_file="/dev/null", user_agent="Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.1) Gecko/20061204 Firefox/2.0.0.1", uri=f"https://{t['host']}{t['uri']}"))
+            events = global_functions.get_events("Web Filter",'All Search Events',None,1)
+            found = global_functions.check_events( events.get('list'), 5,
+                                                   "host", t["host"],
+                                                   "term", term,
+                                                   'blocked', True,
+                                                   'flagged', True )
+            assert( found )
+        search_term_rules_clear()
+
+
+
 
     def test_700_youtube_safe_search(self):
         """Verify activation of YouTube Safe Search"""

--- a/uvm/api/com/untangle/uvm/util/GlobUtil.java
+++ b/uvm/api/com/untangle/uvm/util/GlobUtil.java
@@ -30,14 +30,39 @@ public class GlobUtil
         /**
          * transform globbing operators into regex ones
          */
-        String re = glob;
-        re = re.replaceAll(Pattern.quote("."), "\\.");
-        re = re.replaceAll(Pattern.quote("*"), ".*");
-        re = re.replaceAll(Pattern.quote("?"), ".");
-
-        re = "^" + re + "$";
-        
-        return re;
+        StringBuilder re = new StringBuilder();
+        re.append("^");
+        for (char c : glob.toCharArray()) {
+            switch (c) {
+                case '*':
+                    re.append(".*");
+                    break;
+                case '?':
+                    re.append(".");
+                    break;
+                case '.':
+                case '(':
+                case ')':
+                case '{':
+                case '}':
+                case '+':
+                case '|':
+                case '^':
+                case '[':
+                case ']':
+                case '@':
+                    re.append("\\").append(c);
+                    break;
+                case '$':  // Handle $ as a literal character
+                    re.append("\\$");
+                    break;
+                default:
+                    re.append(c);
+                    break;
+            }
+        }
+        re.append("$");
+        return re.toString();
     }
 
     /**

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterDecisionEngine.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterDecisionEngine.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.json.JSONArray;
@@ -139,7 +140,16 @@ public class WebFilterDecisionEngine extends DecisionEngine
                      */
                     if (matcherO == null || !(matcherO instanceof GlobMatcher)) {
                         try{
-                            matcher = GlobMatcher.getMatcher("*\\b" + rule.getString() + "\\b*");
+                            //Code to handle special characters in search terms
+                            String match = null;
+                            Pattern specialCharacter = Pattern.compile (".*[!@#$%&*()_+=|<>?{}\\[\\]~-].*");
+                            Matcher m1 = specialCharacter.matcher(rule.getString());
+                            if (m1.find()) {
+                                match = "*" + rule.getString() + "*";
+                            } else {
+                                match = "*\\b" + rule.getString() + "\\b*";
+                            }
+                            matcher = GlobMatcher.getMatcher(match);
                         }catch(Exception e){
                             logger.warn("Invalid matching string:" + rule.getString());
                             continue;


### PR DESCRIPTION
The GlobMatcher didn't have logic to handle special characters. Added logic to handle the same

Testing steps:
Configure Web Filter to block and flag the search terms a$$, b/$/$, c%24%24

Enable SSL Inspector and deploy cert to a test Windows 10 device

Search on Google a$$, b$$, and c$$

Check reports to see that whole character is blocked for a$$, but not b$$ or c$$

Added testcases to support the changes
![testcase](https://github.com/untangle/ngfw_src/assets/154513962/8a840b77-ad89-4958-92bc-2b817f067a28)
