### PR TITLE
NGFW-14382: Fixed vertical scrolling issue

### DIFF
--- a/uvm/servlets/admin/sass/base.scss
+++ b/uvm/servlets/admin/sass/base.scss
@@ -70,6 +70,10 @@ cite {
     overflow: visible;
 }
 
+.x-scroller-spacer {
+    transform: none !important;
+}
+
 .nav-item {
     display: inline-block;
     height: 40px;


### PR DESCRIPTION
**ISSUE:**  When the content is overflow, scroll is braking while coming to top of the window, and instead will loop over the bottom. The cause of this issue is ExtJs is internally creating x-scroller-spacer  with style transform : translate3d(), which is not allowing grid, style transform: translate3d() , to fetch correct value and loop is formed.

![Screenshot from 2024-04-17 14-07-47](https://github.com/untangle/ngfw_src/assets/155290371/5db72fa0-1818-4a94-adf2-9b90128ad558)


**Fixed:** Override ExtJs x-scroller-spacer style.

**Test:**
Go to below apps tab and Scroll down to the bottom of a window with a scroll bar. Then, attempt to scroll to top quickly. You will  reach the top of the window.
- Intrusion Prevention > Signatures
- Web Monitor > Categories
- Web Filter > Categories
- Report > All Reports
Tested It for all below resolutions and browser window.
![Screenshot from 2024-04-17 14-29-41](https://github.com/untangle/ngfw_src/assets/155290371/f55b2c21-f049-4461-a0fa-5a7b6a9aaab7)
