### PR TITLE
NGFW-13892 Fixed AD get groups issue

### DIFF
--- a/directory-connector/src/com/untangle/app/directory_connector/GroupManager.java
+++ b/directory-connector/src/com/untangle/app/directory_connector/GroupManager.java
@@ -12,9 +12,6 @@ import java.util.Set;
 
 import org.apache.log4j.Logger;
 
-import com.untangle.uvm.UvmContextFactory;
-// import com.untangle.app.directory_connector.GroupEntry;
-// import com.untangle.app.directory_connector.UserEntry;
 import com.untangle.uvm.app.GroupMatcher;
 import com.untangle.uvm.app.DomainMatcher;
 import com.untangle.uvm.util.Pulse;
@@ -524,7 +521,7 @@ public class GroupManager
                         groupList = adAdapter.listAllGroups(true, searchBase);
                     } catch ( Exception ex ) {
                         logger.warn("Unable to retrieve the group entries", ex);
-                        return;
+                        continue;
                     }
 
                     // Map<String,Boolean> domainUsersMap = new ConcurrentHashMap<String,Boolean>();
@@ -659,7 +656,7 @@ public class GroupManager
                 domainsGroupsChildrenCache.put(domain, groupsChildrenMap);
                 domainsUsersCache.put(domain, domainUsersMap);
                 logger.info("Renewing AD Group Cache: domain=" + domain + ", users=" + domainUsersMap.size() + ", groups=" + groupsUsersMap.size());
-            }
+}
             GroupManager.this.domainsGroupsUsersCache = domainsGroupsUsersCache;
             GroupManager.this.domainsGroupsChildrenCache = domainsGroupsChildrenCache;
             GroupManager.this.domainsUsersCache = domainsUsersCache;

--- a/directory-connector/src/com/untangle/app/directory_connector/GroupManager.java
+++ b/directory-connector/src/com/untangle/app/directory_connector/GroupManager.java
@@ -656,7 +656,7 @@ public class GroupManager
                 domainsGroupsChildrenCache.put(domain, groupsChildrenMap);
                 domainsUsersCache.put(domain, domainUsersMap);
                 logger.info("Renewing AD Group Cache: domain=" + domain + ", users=" + domainUsersMap.size() + ", groups=" + groupsUsersMap.size());
-}
+            }
             GroupManager.this.domainsGroupsUsersCache = domainsGroupsUsersCache;
             GroupManager.this.domainsGroupsChildrenCache = domainsGroupsChildrenCache;
             GroupManager.this.domainsUsersCache = domainsUsersCache;


### PR DESCRIPTION
- Fixed AD get groups when the first AD is non functional and second one is functional.
![Screenshot from 2024-04-22 15-21-49](https://github.com/untangle/ngfw_src/assets/154527616/8d708e0c-6ac5-46a1-bcef-1dd0e38565a3)
- Issue was we were doing `return` if we encounter a connection failure. Instead we must skip that AD server.