### PR TITLE
ngfw:14588 - test case changed for MAC Address

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -2608,7 +2608,13 @@ class NetworkTests(NGFWTestCase):
         """
         Verify we can get vendors for the mac addresses
         """
-        mac_address_list = { 'javaClass': 'java.util.LinkedList', 'list': ["08:00:27:45:bf:f6"] }
+        deviceStatus = uvmContext.networkManager().getDeviceStatus()
+        interfaceList = deviceStatus["list"]
+        if(len(interfaceList) <= 0): 
+            raise unittest.SkipTest('Interface Not Known')
+        if(interfaceList[0]["macAddress"] == None):
+            raise unittest.SkipTest('MAC Address Not Known')
+        mac_address_list = { 'javaClass': 'java.util.LinkedList', 'list': [interfaceList[0]["macAddress"]] }
 
         # Get vendor for mac Address
         mac_address_vendor_map = uvmContext.networkManager().lookupMacVendorList(mac_address_list)


### PR DESCRIPTION
Hardcoded value for the mac addresss changed to dynamic MAC Address

![image](https://github.com/untangle/ngfw_src/assets/154496583/1729ea72-8b75-4352-830c-2b2586d578c1)

