### PR TITLE
NGFW-13867: Add record of purges of the database to admin all settings changes report.

### DIFF
--- a/docs/EventsDescriptionExtensionImpl.java
+++ b/docs/EventsDescriptionExtensionImpl.java
@@ -51,6 +51,7 @@ public class ExtensionImpl implements Runnable
         classDescriptions.put("QuotaEvent","These events are created by the [[Bandwidth Control]] and inserted or update the [[Database_Schema#quotas|quotas]] table when quotas are given or exceeded.");
         classDescriptions.put("PrioritizeEvent","These events are created by the [[Bandwidth Control]] and update the [[Database_Schema#sessions|session]] table when a session is prioritized.");
         classDescriptions.put("SettingsChangesEvent","These events are created by the base system and inserted to the [[Database_Schema#settings_changes|settings_changes]] table when settings are changed.");
+        classDescriptions.put("OperationsEvent","These events are created when certain operations are performed and inserted to the [[Database_Schema#system_operations|system_operations]] table when operations are completed.");
         classDescriptions.put("CriticalAlertEvent","These events are created by the base system and inserted to the [[Database_Schema#critical_alerts|critical_alerts]] table to record critical system alerts.");
         classDescriptions.put("LogEvent","These base class for all events.");
         classDescriptions.put("InterfaceStatEvent","These events are created by the base system and inserted to the [[Database_Schema#interface_stat_events|interface_stat_events]] table periodically with interface stats.");

--- a/docs/EventsDocumentationExtensionImpl.java
+++ b/docs/EventsDocumentationExtensionImpl.java
@@ -49,6 +49,7 @@ public class ExtensionImpl implements Runnable
         classDescriptions.put("QuotaEvent","These events are created by the [[Bandwidth Control]] and inserted or update the [[Database_Schema#quotas|quotas]] table when quotas are given or exceeded.");
         classDescriptions.put("PrioritizeEvent","These events are created by the [[Bandwidth Control]] and update the [[Database_Schema#sessions|session]] table when a session is prioritized.");
         classDescriptions.put("SettingsChangesEvent","These events are created by the base system and inserted to the [[Database_Schema#settings_changes|settings_changes]] table when settings are changed.");
+        classDescriptions.put("OperationsEvent","These events are created when certain operations are performed and inserted to the [[Database_Schema#system_operations|system_operations]] table when operations are completed.");
         classDescriptions.put("CriticalAlertEvent","These events are created by the base system and inserted to the [[Database_Schema#critical_alerts|critical_alerts]] table to record critical system alerts.");
         classDescriptions.put("LogEvent","These base class for all events.");
         classDescriptions.put("InterfaceStatEvent","These events are created by the base system and inserted to the [[Database_Schema#interface_stat_events|interface_stat_events]] table periodically with interface stats.");

--- a/docs/reports-generate-docs-column-names.py
+++ b/docs/reports-generate-docs-column-names.py
@@ -193,6 +193,7 @@ dict = {
     'active_hosts' : i18n._('Active Hosts'),
     'rx_rate' : i18n._('Rx Rate'),
     'tx_rate' : i18n._('Tx Rate'),
+    'operation' : i18n._('Operation'),
 }
 
 

--- a/docs/reports-generate-docs-db-schema.py
+++ b/docs/reports-generate-docs-db-schema.py
@@ -110,6 +110,7 @@ human_names = {
 'old_value': 'Old Value',
 'os_name': 'Interface O/S Name',
 'out_bytes': 'Out Bytes',
+'operation': 'Operation',
 'p2c_bytes': 'To-Client Bytes',
 'p2s_bytes': 'To-Server Bytes',
 'phish_blocker_action': 'Phish Blocker ' + 'Action',
@@ -650,6 +651,14 @@ dict['settings_changes'] = copy.deepcopy(generic)
 dict['settings_changes'].update({
     'table_description' : 'This table stores settings changes.',
     'settings_file' : 'The name of the file changed',
+    'username' : 'The username logged in at the time of the change',
+    'hostname' : 'The remote hostname',
+})
+
+dict['system_operations'] = copy.deepcopy(generic)
+dict['system_operations'].update({
+    'table_description' : 'This table stores all operations.',
+    'operation' : 'The name of the operation',
     'username' : 'The username logged in at the time of the change',
     'hostname' : 'The remote hostname',
 })

--- a/reports/hier/usr/lib/python3/dist-packages/reports/untangle_vm.py
+++ b/reports/hier/usr/lib/python3/dist-packages/reports/untangle_vm.py
@@ -12,6 +12,7 @@ def generate_tables():
     __create_alerts_events_table()
     __create_settings_changes_table()
     __create_critical_alerts_table()
+    __create_system_operations_table()
     # 13.0 conversion
     if sql_helper.table_exists( "penaltybox" ):
         sql_helper.drop_table("penaltybox") 
@@ -274,3 +275,13 @@ CREATE TABLE reports.user_table_updates (
         value text,
         old_value text,
         time_stamp timestamp)""",[],["time_stamp"])
+
+
+@sql_helper.print_timing
+def __create_system_operations_table(  ):
+    sql_helper.create_table("""\
+CREATE TABLE reports.system_operations (
+        time_stamp timestamp NOT NULL,
+        operation text NOT NULL,
+        username text NOT NULL,
+        hostname text NOT NULL)""")

--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -843,6 +843,11 @@ class ReportsTests(NGFWTestCase):
         
         assert(len(pre_reinit_tables) == len(post_reinit_tables))
         assert(pre_reinit_tables == post_reinit_tables)
+        # Verify delete all reports data operation event is generated.
+        events = global_functions.get_events("Administration",'All Operations',None,5)
+        found = global_functions.check_events( events.get('list'), 5,
+                                              "operation", "delete all reports data" )
+        assert(found)
 
     def test_040_remote_syslog(self):
         if (not can_syslog):

--- a/reports/hier/usr/share/untangle/bin/reports-reinitialize-database.sh
+++ b/reports/hier/usr/share/untangle/bin/reports-reinitialize-database.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-/etc/init.d/postgresql stop >/dev/null 2>&1
+#/etc/init.d/postgresql stop >/dev/null 2>&1
 
 for d in /var/lib/postgresql/* ; do
     if [ -d "${d}" ] ; then
@@ -16,7 +16,7 @@ PG_VAR_DIR="/var/lib/postgresql/${PG_VERSION}"
 PG_BIN_DIR="/usr/lib/postgresql/${PG_VERSION}/bin"
 su -c "${PG_BIN_DIR}/initdb --encoding=utf8 --locale=${1:-"en_US.UTF-8"} -D ${PG_VAR_DIR}/main" postgres >/dev/null 2>&1
 
-/etc/init.d/postgresql start >/dev/null 2>&1
-/usr/share/untangle/bin/reports-generate-tables.py >/dev/null 2>&1
+#/etc/init.d/postgresql start >/dev/null 2>&1
+#/usr/share/untangle/bin/reports-generate-tables.py >/dev/null 2>&1
 
 echo "done."

--- a/reports/hier/usr/share/untangle/bin/reports-reinitialize-database.sh
+++ b/reports/hier/usr/share/untangle/bin/reports-reinitialize-database.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-/etc/init.d/postgresql stop
+/etc/init.d/postgresql stop >/dev/null 2>&1
 
 for d in /var/lib/postgresql/* ; do
     if [ -d "${d}" ] ; then
@@ -14,10 +14,9 @@ done
 PG_VERSION=$(psql --version | sed 's/^[^0-9]*\([0-9]\+\).*/\1/')
 PG_VAR_DIR="/var/lib/postgresql/${PG_VERSION}"
 PG_BIN_DIR="/usr/lib/postgresql/${PG_VERSION}/bin"
-su -c "${PG_BIN_DIR}/initdb --encoding=utf8 --locale=${1:-"en_US.UTF-8"} -D ${PG_VAR_DIR}/main" postgres
+su -c "${PG_BIN_DIR}/initdb --encoding=utf8 --locale=${1:-"en_US.UTF-8"} -D ${PG_VAR_DIR}/main" postgres >/dev/null 2>&1
 
-/etc/init.d/postgresql start
-/usr/share/untangle/bin/reports-generate-tables.py
+/etc/init.d/postgresql start >/dev/null 2>&1
+/usr/share/untangle/bin/reports-generate-tables.py >/dev/null 2>&1
 
-echo
 echo "done."

--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -353,6 +353,21 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
 
         return 0;
     }
+
+
+    /**
+     * Return EventWriterImpl object.
+     *
+     * @return
+     *  EventWriterImpl object.
+     */
+    protected EventWriterImpl getEventWriter()
+    {
+        if (ReportsApp.eventWriter != null)
+            return ReportsApp.eventWriter;
+
+        return null;
+    }
     
     /** 
      * Save settings using default values.

--- a/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
+++ b/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
@@ -3,6 +3,8 @@
  */
 package com.untangle.app.reports;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -25,6 +27,7 @@ import org.json.JSONObject;
 
 import com.untangle.uvm.AdminUserSettings;
 import com.untangle.uvm.ExecManagerResult;
+import com.untangle.uvm.OperationsEvent;
 import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.WebBrowser;
 import com.untangle.uvm.network.InterfaceSettings;
@@ -33,7 +36,7 @@ import com.untangle.uvm.app.AppSettings;
 import com.untangle.uvm.app.App;
 import com.untangle.uvm.app.AppBase;
 import com.untangle.uvm.app.PolicyManager;
-
+import com.untangle.uvm.app.HostnameLookup;
 /**
  * Reports manager implementation for reports manager API
  */
@@ -44,6 +47,8 @@ public class ReportsManagerImpl implements ReportsManager
     private static ReportsManagerImpl instance = null;
 
     private static ReportsApp app = null;
+
+    private static String DELETE_ALL_REPORTS = "delete all reports data";
 
     /**
      * This stores the table column metadata lookup results so we don't have to frequently lookup metadata
@@ -1200,6 +1205,17 @@ public class ReportsManagerImpl implements ReportsManager
     public void reinitializeDatabase()
     {
         String cmd = "/usr/share/untangle/bin/reports-reinitialize-database.sh";
-        ExecManagerResult result = UvmContextFactory.context().execManager().exec( cmd );
+        ExecManagerResult result = UvmContextFactory.context().execManager().exec(cmd);
+        String username = null;
+        String hostname = null;
+        String userHostNameInfo = UvmContextFactory.context().settingsManager().getUserAndHostNameInfo("reports");
+        if (userHostNameInfo != null) {
+            String infoArray[] = userHostNameInfo.split(",");
+            if (infoArray != null & infoArray.length == 2) {
+                username = infoArray[0];
+                hostname = infoArray[1];
+            }
+        }
+        UvmContextFactory.context().logEvent(new OperationsEvent(DELETE_ALL_REPORTS, username, hostname));
     }
 }

--- a/uvm/api/com/untangle/uvm/OperationsEvent.java
+++ b/uvm/api/com/untangle/uvm/OperationsEvent.java
@@ -1,0 +1,66 @@
+/**
+ * $Id: OperationsEvent.java 33539 2024-04-23 12:45:01Z rohitsingh $
+ */
+package com.untangle.uvm;
+
+import com.untangle.uvm.logging.LogEvent;
+
+/**
+ * Settings change event
+ */
+@SuppressWarnings("serial")
+public class OperationsEvent extends LogEvent
+{
+    private String operation;
+    private String username = "localadmin";
+    private String hostname = "127.0.0.1";
+
+    public OperationsEvent( String operation, String username, String hostname )
+    {
+        this.operation = operation;
+        if( username != null ){
+            this.username = username;
+        }
+        if( hostname != null ){
+            this.hostname = hostname;
+        }
+    }
+
+    public String getOperation() { return this.operation; }
+    public void setOperation( String newValue ) { this.operation = newValue; }
+
+    public String getUsername() { return this.username; }
+    public void setUsername( String newValue ) { this.username = newValue; }
+
+    public String getHostname() { return this.hostname; }
+    public void setHostname( String newValue ) { this.hostname = newValue; }
+    
+    @Override
+    public void compileStatements( java.sql.Connection conn, java.util.Map<String,java.sql.PreparedStatement> statementCache ) throws Exception
+    {
+        String sql = "INSERT INTO " + schemaPrefix() + "system_operations" + getPartitionTablePostfix() + " " +
+            "( time_stamp, operation, username, hostname)" +
+            " values " +
+            "( ?, ?, ?, ?); ";
+
+        java.sql.PreparedStatement pstmt = getStatementFromCache( sql, statementCache, conn );        
+
+        int i=0;
+        pstmt.setTimestamp(++i, getSqlTimeStamp());
+        pstmt.setString(++i, this.operation);
+        pstmt.setString(++i, this.username);
+        pstmt.setString(++i, this.hostname);
+
+        pstmt.addBatch();
+        return;
+    }
+
+    @Override
+    public String toSummaryString()
+    {
+        String summary = "OperationsEvent" + " " + this.operation;
+        return summary;
+    }
+    
+    
+}

--- a/uvm/api/com/untangle/uvm/SettingsManager.java
+++ b/uvm/api/com/untangle/uvm/SettingsManager.java
@@ -45,6 +45,11 @@ public interface SettingsManager
     public String getDiff(String fileName) throws SettingsException;
 
     /**
+     * See SettingsManagerImpl
+     */
+    public String getUserAndHostNameInfo(String appName);
+
+    /**
      * Settings exception
      */
     @SuppressWarnings("serial")

--- a/uvm/hier/usr/share/untangle/lib/untangle-vm/events/classFields.json
+++ b/uvm/hier/usr/share/untangle/lib/untangle-vm/events/classFields.json
@@ -1631,6 +1631,36 @@
         },
     ]
     },
+    OperationsEvent: {
+        description: "These events are created when certain operations are performed and inserted to the [[Database_Schema#system_operations|system_operations]] table when operations are stored.",
+        fields: [
+            {
+            name: "class",
+            type: "Class",
+            description: "The class name",
+            },
+            {
+            name: "hostname",
+            type: "String",
+            description: "The hostname",
+            },
+            {
+            name: "operation",
+            type: "String",
+            description: "The operation name",
+            },
+            {
+            name: "timeStamp",
+            type: "Timestamp",
+            description: "The timestamp",
+            },
+            {
+            name: "username",
+            type: "String",
+            description: "The username",
+            },
+        ]
+    },
     CriticalAlertEvent: {
     description: "These events are created by the base system and inserted to the [[Database_Schema#critical_alerts|critical_alerts]] table to record critical system alerts.",
     fields: [

--- a/uvm/hier/usr/share/untangle/lib/untangle-vm/reports/administration-operations.json
+++ b/uvm/hier/usr/share/untangle/lib/untangle-vm/reports/administration-operations.json
@@ -1,0 +1,13 @@
+{
+    "category": "Administration",
+    "readOnly": true,
+    "type": "EVENT_LIST",
+    "conditions": [],
+    "defaultColumns": ["time_stamp","hostname","username","operation"],
+    "description": "All operations performed by an administrator.",
+    "displayOrder": 1010,
+    "javaClass": "com.untangle.app.reports.ReportEntry",
+    "table": "system_operations",
+    "title": "All Operations",
+    "uniqueId": "administration-sHKXX7Tj"
+}

--- a/uvm/js/common/util/_Map.js
+++ b/uvm/js/common/util/_Map.js
@@ -399,6 +399,10 @@ Ext.define('Ung.util.Map', {
             col: { text: 'Out Bytes'.t(), filter: Rndr.filters.numeric, width: 100 },
             fld: { type: 'number' }
         },
+        operation: {
+            col: { text: 'Operation'.t(), width: 200, renderer: Rndr.operation },
+            fld: { type: 'string' }
+        },
         p2c_bytes: {
             col: { text: 'To-Client Bytes'.t(), filter: Rndr.filters.numeric, width: 80, align: 'right', renderer: Renderer.datasize },
             fld: { type: 'number' }
@@ -1227,6 +1231,12 @@ Ext.define('Ung.util.Map', {
             'username',
             'hostname',
             'differences' // custom non sql table field
+        ],
+        system_operations: [
+            'time_stamp',
+            'operation',
+            'username',
+            'hostname'
         ],
         critical_alerts: [
             'time_stamp',


### PR DESCRIPTION
Following changes done for the PR

- Create a new system_operations table.  Model this after the existing settings_changes table except instead of a “settings_file” column, add a new text-type column for “operation”.
![image](https://github.com/untangle/ngfw_src/assets/154513962/0f549dfc-ccde-45a9-8995-f20d286bca0c)

![image](https://github.com/untangle/ngfw_src/assets/154513962/314f06d8-49d9-4968-b452-86c789a0cdc8)


- Create a new “All Operations” report modeled after the existing “All Settings Changes” report.  It should just display the operation.
- Create a new Operations log event modelled after SettingsChangesEvent will be created when operations like the Delete All Reports Data action is called.  
- For this case, use an operation value of “delete all reports data”.
![image](https://github.com/untangle/ngfw_src/assets/154513962/ea8f3f8c-ccf0-4a64-a7ac-4d3a53c23bd8)


- ATS should verify that after the action is executed, a query of this table has the expected event.
![image](https://github.com/untangle/ngfw_src/assets/154513962/c32be398-13b0-42e9-b26b-b8065ff9db9a)

Testing steps:
1. go to apps/reports/data
2. click on delete all reports data
3. click on yes to continue
4. after completion , verify in Reports tab under administration->All Operations -> operation ->  delete all reports data should be present, refer to following screenshot 

![image](https://github.com/untangle/ngfw_src/assets/154513962/2f3885d1-9651-4aeb-81d4-f77a94f99845)



