### PR TITLE
NGFW-14309: Added functionality to disallow upgrades if the disk space is low

### DIFF
--- a/uvm/api/com/untangle/uvm/SystemManager.java
+++ b/uvm/api/com/untangle/uvm/SystemManager.java
@@ -5,6 +5,7 @@ package com.untangle.uvm;
 
 import java.util.Calendar;
 import java.util.TimeZone;
+import java.util.List;
 
 /**
  * the System Manager API
@@ -56,6 +57,8 @@ public interface SystemManager
     boolean getIsUpgrading();
 
     boolean downloadUpgrades();
+
+    List<String> canUpgrade();
 
     org.json.JSONObject getDownloadStatus();
 

--- a/uvm/api/com/untangle/uvm/SystemManager.java
+++ b/uvm/api/com/untangle/uvm/SystemManager.java
@@ -5,7 +5,7 @@ package com.untangle.uvm;
 
 import java.util.Calendar;
 import java.util.TimeZone;
-import java.util.List;
+import java.util.HashSet;
 
 /**
  * the System Manager API
@@ -66,7 +66,7 @@ public interface SystemManager
 
     boolean downloadUpgrades();
 
-    List<UpgradeFailures> canUpgrade();
+    HashSet<UpgradeFailures> canUpgrade();
 
     int getUsedDiskSpacePercentage();
 

--- a/uvm/api/com/untangle/uvm/SystemManager.java
+++ b/uvm/api/com/untangle/uvm/SystemManager.java
@@ -5,7 +5,7 @@ package com.untangle.uvm;
 
 import java.util.Calendar;
 import java.util.TimeZone;
-import java.util.HashSet;
+import java.util.Set;
 
 /**
  * the System Manager API
@@ -66,7 +66,7 @@ public interface SystemManager
 
     boolean downloadUpgrades();
 
-    HashSet<UpgradeFailures> canUpgrade();
+    Set<UpgradeFailures> canUpgrade();
 
     int getUsedDiskSpacePercentage();
 

--- a/uvm/api/com/untangle/uvm/SystemManager.java
+++ b/uvm/api/com/untangle/uvm/SystemManager.java
@@ -12,6 +12,14 @@ import java.util.List;
  */
 public interface SystemManager
 {
+    /**
+     * Upgrade issues enum
+     */    
+    public enum UpgradeFailures {
+        LOW_DISK,
+        FAILED_TO_TEST
+    }
+    
     SystemSettings getSettings();
 
     void setSettings(SystemSettings settings);
@@ -58,7 +66,9 @@ public interface SystemManager
 
     boolean downloadUpgrades();
 
-    List<String> canUpgrade();
+    List<UpgradeFailures> canUpgrade();
+
+    int getUsedDiskSpacePercentage();
 
     org.json.JSONObject getDownloadStatus();
 

--- a/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
@@ -340,12 +340,8 @@ public class NotificationManagerImpl implements NotificationManager
     {
         int percentUsed;
         try {
-            File rootFile = new File("/");
-            long totalSpace = rootFile.getTotalSpace();
-            long usedSpace = rootFile.getUsableSpace();
-            percentUsed =(int) ((1-((double) usedSpace / totalSpace) )* 100);
+            percentUsed = UvmContextFactory.context().systemManager().getUsedDiskSpacePercentage();
         } catch (Exception e) {
-            logger.warn("Unable to determine free disk space", e);
             return;
         }
 

--- a/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
@@ -343,7 +343,7 @@ public class NotificationManagerImpl implements NotificationManager
             File rootFile = new File("/");
             long totalSpace = rootFile.getTotalSpace();
             long usedSpace = rootFile.getUsableSpace();
-            percentUsed = (int ) ((usedSpace/totalSpace) * 100);
+            percentUsed =(int) ((1-((double) usedSpace / totalSpace) )* 100);
         } catch (Exception e) {
             logger.warn("Unable to determine free disk space", e);
             return;

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -731,9 +732,9 @@ can look deeper. - mahotz
      * 
      * @return Set of risks which might cause upgrade failure before actual upgrade starts 
      */
-    public HashSet<UpgradeFailures> canUpgrade() 
+    public Set<UpgradeFailures> canUpgrade() 
     {
-        HashSet<UpgradeFailures> upgradeIssues = new HashSet<>();
+        Set<UpgradeFailures> upgradeIssues = new HashSet<>();
       
         try {
             UpgradeFailures failure = testDiskSpace();

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -726,6 +726,46 @@ can look deeper. - mahotz
     }
 
     /**
+     * This test all the risks which might cause upgrade failure before actual upgrade starts
+     * 
+     * @return List of failure raised while upgrade   
+     */
+    public List<String>  canUpgrade()
+    {
+        List<String> upgradeIssues = new ArrayList<>();
+      
+        try {
+            testDiskSpace(upgradeIssues);
+        } catch (Exception e) {
+            logger.warn("Disk space check failed", e);
+        }
+        return upgradeIssues;
+    }
+
+    /**
+     * This test that disk free % is less than 75%
+     * 
+     * @param upgradeIssues take list of existing failure
+     */
+    private void testDiskSpace(List<String> upgradeIssues){
+        int percentUsed;
+        try {
+            File rootFile = new File("/");
+            long totalSpace = rootFile.getTotalSpace();
+            long usedSpace = rootFile.getUsableSpace();
+            percentUsed =(int) ((1-((double) usedSpace / totalSpace) )* 100);
+        } catch (Exception e) {
+            logger.warn("Unable to determine free disk space", e);
+            return;
+        }
+
+        if (percentUsed > 75) {
+            upgradeIssues.add("LOW_DISK");
+        }
+    }
+
+
+    /**
      * If support access in enabled, start pyconnector and enable on startup. If
      * not, stop it and disable on startup
      */

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.TimeZone;
@@ -728,11 +729,11 @@ can look deeper. - mahotz
     /**
      * This test all the risks which might cause upgrade failure before actual upgrade starts
      * 
-     * @return List of risks which might cause upgrade failure before actual upgrade starts 
+     * @return Set of risks which might cause upgrade failure before actual upgrade starts 
      */
-    public List<UpgradeFailures> canUpgrade() 
+    public HashSet<UpgradeFailures> canUpgrade() 
     {
-        List<UpgradeFailures> upgradeIssues = new ArrayList<>();
+        HashSet<UpgradeFailures> upgradeIssues = new HashSet<>();
       
         try {
             UpgradeFailures failure = testDiskSpace();

--- a/uvm/servlets/admin/config/upgrade/MainController.js
+++ b/uvm/servlets/admin/config/upgrade/MainController.js
@@ -81,8 +81,7 @@ Ext.define('Ung.config.upgrade.MainController', {
                         }
                    
                 }, function(ex) {
-                    console.error('Failed to check upgrade issues:', ex);
-
+                    Util.handleException(ex);
                 });
     },
     

--- a/uvm/servlets/admin/config/upgrade/MainController.js
+++ b/uvm/servlets/admin/config/upgrade/MainController.js
@@ -39,7 +39,7 @@ Ext.define('Ung.config.upgrade.MainController', {
 
         me.loadSettings();
         me.checkUpgrades();
-        
+
     },
 
     canUpgrade: function() {

--- a/uvm/servlets/admin/config/upgrade/MainController.js
+++ b/uvm/servlets/admin/config/upgrade/MainController.js
@@ -39,6 +39,7 @@ Ext.define('Ung.config.upgrade.MainController', {
 
         me.loadSettings();
         me.checkUpgrades();
+        
     },
 
     canUpgrade: function() {

--- a/uvm/servlets/admin/config/upgrade/view/Upgrade.js
+++ b/uvm/servlets/admin/config/upgrade/view/Upgrade.js
@@ -28,7 +28,14 @@ Ext.define('Ung.config.upgrade.view.Upgrade', {
             padding: 5,
             margin: 20,
             html: 'No upgrades available.'.t(),
-            hidden: true
+            hidden: true,
+        },{
+            xtype: "component",
+            name: 'upgradeIssueText',
+            padding: 5,
+            margin: 20,
+            html: 'Unable to upgrade.'.t(),
+            hidden: true,
         }, {
             xtype: "button",
             name: 'upgradeButton',

--- a/uvm/servlets/admin/config/upgrade/view/Upgrade.js
+++ b/uvm/servlets/admin/config/upgrade/view/Upgrade.js
@@ -28,14 +28,14 @@ Ext.define('Ung.config.upgrade.view.Upgrade', {
             padding: 5,
             margin: 20,
             html: 'No upgrades available.'.t(),
-            hidden: true,
+            hidden: true
         },{
             xtype: "component",
             name: 'upgradeIssueText',
             padding: 5,
             margin: 20,
             html: 'Unable to upgrade.'.t(),
-            hidden: true,
+            hidden: true
         }, {
             xtype: "button",
             name: 'upgradeButton',


### PR DESCRIPTION
**Issues:** There have been a few customers that had issues with their boxes on upgrade attempt due to low amount of disk space. 

**Fix:** Added provision to disallow upgrade by disabling the upgrade now button and showing the error on UI.

**While analysing the issue found the issue in logic written to calculate the diskusage in NotificationManagerImpl, fixed the same.**

**Test:** 

**-  If no upgrade available then UI will be shown as below:**

 ![Screenshot from 2024-04-23 14-10-14](https://github.com/untangle/ngfw_src/assets/155290371/a76847fe-73ee-47c4-8807-71ac19b63981)

**-  If upgrade available without any configuration issues then only Upgrade button will be visible:**

![Screenshot from 2024-04-23 14-01-12](https://github.com/untangle/ngfw_src/assets/155290371/fb05863f-e297-4d05-864c-177ba218963c)

**-  If upgrade available with any configuration issues then Upgrade button will be disable any error will get display on UI:**

![Screenshot from 2024-04-23 14-00-05](https://github.com/untangle/ngfw_src/assets/155290371/dccb8132-efde-40dc-a913-87c560965999)

