### PR TITLE
ngfw : 14188 - qosEnabled changes for bandwidth-control

### DIFF
--- a/bandwidth-control/hier/usr/lib/python3/dist-packages/tests/test_bandwidth_control.py
+++ b/bandwidth-control/hier/usr/lib/python3/dist-packages/tests/test_bandwidth_control.py
@@ -658,6 +658,19 @@ class BandwidthControlTests(NGFWTestCase):
             uvmContext.appManager().destroy( cls._app_web_filter.getAppSettings()["id"] )
             cls._app_web_filter = None
 
+    def test_qos_enabled_101(self):
+        """
+        Verify if qosEnabled is disabled and if the app is started then qosEnabled is enabled
+        """
+        global networkSettings,appName, remote_app, test_var, appName
+        self._app.stop()
+        networkSettings = uvmContext.networkManager().getNetworkSettings()
+        networkSettings['qosSettings']['qosEnabled']=False
+        uvmContext.networkManager().setNetworkSettings(networkSettings)
+        self._app.start()
+        networkSettings = uvmContext.networkManager().getNetworkSettings()
+        assert(networkSettings['qosSettings']['qosEnabled'])
+
 
 test_registry.register_module("bandwidth-control", BandwidthControlTests)
 

--- a/bandwidth-control/js/MainController.js
+++ b/bandwidth-control/js/MainController.js
@@ -44,6 +44,19 @@ Ext.define('Ung.apps.bandwidthcontrol.MainController', {
             Util.handleException(ex);
         });
     },
+    
+    /**
+     * Method called to fetch the current value of qosEnabled
+     */
+    fetchQosData: function (){
+        var v = this.getView(), vm = this.getViewModel();
+        try{
+            var qosEnabled = Rpc.directData('rpc.networkManager.getNetworkSettings.qosSettings.qosEnabled');
+            vm.set("qosEnabled",qosEnabled);
+        }catch (error){
+            Util.handleException(error);
+        }
+    },
 
     setSettings: function () {
         var me = this, v = this.getView(), vm = this.getViewModel();

--- a/bandwidth-control/src/com/untangle/app/bandwidth_control/BandwidthControlApp.java
+++ b/bandwidth-control/src/com/untangle/app/bandwidth_control/BandwidthControlApp.java
@@ -14,6 +14,7 @@ import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.HookCallback;
 import com.untangle.uvm.util.I18nUtil;
 import com.untangle.uvm.app.AppMetric;
+import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.vnet.Affinity;
 import com.untangle.uvm.vnet.Fitting;
 import com.untangle.uvm.vnet.PipelineConnector;
@@ -116,6 +117,25 @@ public class BandwidthControlApp extends AppBase
         UvmContextFactory.context().hookManager().registerCallback( com.untangle.uvm.HookManager.USER_TABLE_QUOTA_GIVEN, this.userQuotaGivenHook );
         UvmContextFactory.context().hookManager().registerCallback( com.untangle.uvm.HookManager.USER_TABLE_QUOTA_EXCEEDED, this.userQuotaExceededHook );
         UvmContextFactory.context().hookManager().registerCallback( com.untangle.uvm.HookManager.USER_TABLE_QUOTA_REMOVED, this.userQuotaRemovedHook );
+    }
+
+     /**
+     * Post Bandwith-control App start. Fetch network settings
+     * and set qosEnabled to true.
+     *
+     * @param isPermanentTransition
+     */
+    @Override
+    protected void postStart(boolean isPermanentTransition)
+    {
+        logger.info("Bandwith-control POST START");
+        NetworkSettings networkSettings = UvmContextFactory.context().networkManager().getNetworkSettings();
+        if(networkSettings.getQosSettings().getQosEnabled()){
+            return;
+        }
+        networkSettings.getQosSettings().setQosEnabled(true);
+        UvmContextFactory.context().networkManager().setNetworkSettings(networkSettings);
+        logger.info("QosEnabled set to true");
     }
 
     /**

--- a/uvm/servlets/admin/app/Application.js
+++ b/uvm/servlets/admin/app/Application.js
@@ -119,5 +119,20 @@ Ext.define('Ung.Application', {
             });
 
         }
+    },
+
+    /**
+     * Method called when bandwidth-control app is enabled
+     */
+    qosEnableHandler: function (cb) {
+        // fetching network settings
+        var networkSettings = Rpc.directData('rpc.networkManager.app("bandwidth-control").getNetworkSettings');
+        if(networkSettings.qosSettings.qosEnabled){
+            return;
+        }
+        networkSettings.qosSettings.qosEnabled = true;
+        // settings the qosEnabled to true
+        Rpc.directData('rpc.networkManager.setNetworkSettings', networkSettings);
+        cb();
     }
 });

--- a/uvm/servlets/admin/app/Application.js
+++ b/uvm/servlets/admin/app/Application.js
@@ -119,6 +119,5 @@ Ext.define('Ung.Application', {
             });
 
         }
-    },
-
+    }
 });

--- a/uvm/servlets/admin/app/Application.js
+++ b/uvm/servlets/admin/app/Application.js
@@ -121,18 +121,4 @@ Ext.define('Ung.Application', {
         }
     },
 
-    /**
-     * Method called when bandwidth-control app is enabled
-     */
-    qosEnableHandler: function (cb) {
-        // fetching network settings
-        var networkSettings = Rpc.directData('rpc.networkManager.app("bandwidth-control").getNetworkSettings');
-        if(networkSettings.qosSettings.qosEnabled){
-            return;
-        }
-        networkSettings.qosSettings.qosEnabled = true;
-        // settings the qosEnabled to true
-        Rpc.directData('rpc.networkManager.setNetworkSettings', networkSettings);
-        cb();
-    }
 });

--- a/uvm/servlets/admin/app/cmp/AppState.js
+++ b/uvm/servlets/admin/app/cmp/AppState.js
@@ -81,6 +81,12 @@ Ext.define('Ung.cmp.AppState', {
                         return;
                     }
                     btn.setDisabled(false);
+                    if (appManager.getAppProperties().name === 'bandwidth-control') {
+                        // if app is bandwidth-control and if it's enabled
+                        Ung.app.qosEnableHandler(function(){
+                            appView.getController().fetchQosData();
+                        });
+                    }
                     me.reload();
                 },function(ex){
                     Ext.Msg.alert('Error', ex.message);

--- a/uvm/servlets/admin/app/cmp/AppState.js
+++ b/uvm/servlets/admin/app/cmp/AppState.js
@@ -82,10 +82,8 @@ Ext.define('Ung.cmp.AppState', {
                     }
                     btn.setDisabled(false);
                     if (appManager.getAppProperties().name === 'bandwidth-control') {
-                        // if app is bandwidth-control and if it's enabled
-                        Ung.app.qosEnableHandler(function(){
-                            appView.getController().fetchQosData();
-                        });
+                        // sync the qosEnabled code after app is enabled
+                        appView.getController().fetchQosData();
                     }
                     me.reload();
                 },function(ex){


### PR DESCRIPTION
If qosEnabled is disabled and the user enables/power-on the bandwidth-control app, then qosEnabled will be enabled 
Test case result :
![Screenshot from 2024-04-25 13-57-34](https://github.com/untangle/ngfw_src/assets/154496583/f8c7ffe0-cbbc-47ab-a99b-762287b88f0a)

