### PR TITLE
ngfw-14578 TunnelVPN Tunnel Record Editor Done Button bug Resolved

### DIFF
--- a/tunnel-vpn/js/MainController.js
+++ b/tunnel-vpn/js/MainController.js
@@ -464,7 +464,7 @@ Ext.define('Ung.apps.tunnel-vpn.TunnelRecordEditorController', {
             var record = vm.get('record');
             if( ( oldValue != null ) &&
                 ( newValue != oldValue ) &&
-                ( ( typeof record.modified.provider == undefined ) || record.modified.provider != newValue ) ){
+                ( record.modified && (( typeof record.modified.provider == undefined ) || record.modified.provider != newValue )) ){
                 fileButton.setValidation('Provider changed');
             }
 

--- a/tunnel-vpn/js/view/Tunnels.js
+++ b/tunnel-vpn/js/view/Tunnels.js
@@ -171,8 +171,8 @@ Ext.define('Ung.apps.tunnel-vpn.view.Tunnels', {
         allowBlank: false,
         bind: {
             value: '{record.username}',
-            disabled: '{tunnelProviderSelected == false}',
-            hidden: '{tunnelUsernameHidden == true}'
+            disabled: '{tunnelUsernameHidden == true}',
+            hidden: '{tunnelProviderSelected == false}'
         },
         regex: /^(?!\s).*[^\s]$/,
         regexText: 'Invalid Username, whitespaces at beginning or end are not allowed'.t()
@@ -183,8 +183,8 @@ Ext.define('Ung.apps.tunnel-vpn.view.Tunnels', {
         allowOnlyWhitespace: false,
         bind: {
             value: '{record.password}',
-            disabled: '{tunnelProviderSelected == false}',
-            hidden: '{tunnelPasswordHidden == true}'
+            disabled: '{tunnelUsernameHidden == true}',
+            hidden: '{tunnelProviderSelected == false}'
         },
     }, {
         xtype: 'fieldset',


### PR DESCRIPTION
Changes:
Switched the conditions for `hidden` and `disabled` properties of `Username` and `Password` fields to enable/disable Done button according to form validation.

`Username` and `Password` fields will be hidden until `Provider` field is selected from drop-down.
`Username` and `Password` filed will be disabled for providers which don't require authentication (i.e. `provider.auth = false`)

Local Testing 

![Screenshot from 2024-04-24 15-17-47](https://github.com/untangle/ngfw_src/assets/154422821/1fc51bc1-ab3a-48a7-a4c6-ed10df3f78c5)


![Screenshot from 2024-04-24 15-39-42](https://github.com/untangle/ngfw_src/assets/154422821/234920f7-237e-4e19-a361-8cf84e8a1ad1)


![Screenshot from 2024-04-24 15-39-56](https://github.com/untangle/ngfw_src/assets/154422821/e46cb44d-d6c5-4fdf-941c-e6cf6c70384e)


![Screenshot from 2024-04-24 15-40-20](https://github.com/untangle/ngfw_src/assets/154422821/be6f226a-58eb-4653-b483-5d7dd9135380)


![Screenshot from 2024-04-24 15-41-23](https://github.com/untangle/ngfw_src/assets/154422821/635554d6-31d9-4561-a366-f869c296fc43)