### PR TITLE
NGFW-14584/NGFW-14589/NGFW-14585 : Import validation for OpenVPN grids/IPSec VPN and Validation added for OpenVPN Remote Network field

### DIFF
--- a/openvpn/js/MainController.js
+++ b/openvpn/js/MainController.js
@@ -184,34 +184,6 @@ Ext.define('Ung.apps.openvpn.MainController', {
         });
         if (problem != 0) return(false);
 
-        // check for duplicate client names
-        counter = 1;
-        clientStore.each(function(record) {
-            var clientName = record.get('name');
-            if (clientNames[clientName] != null) {
-                message = Ext.String.format("The client name: {0} in row: {1} already exists.", clientName, counter);
-                problem++;
-                Ext.MessageBox.alert("Add Remote Client Failed".t(), message);
-            }
-            if (! record.get('markedForDelete')) clientNames[clientName] = true;
-            counter++;
-        });
-        if (problem != 0) return(false);
-
-        // check for duplicate group names
-        counter = 1;
-        groupStore.each(function(record) {
-            var groupName = record.get('name');
-            if (groupNames[groupName] != null) {
-                message = Ext.String.format("The group name: {0} in row: {1} already exists.", groupName, counter);
-                problem++;
-                Ext.MessageBox.alert("Add Group Failed".t(), message);
-            }
-            if (! record.get('markedForDelete')) groupNames[groupName] = true;
-            counter++;
-        });
-        if (problem != 0) return(false);
-
         // we must not allow port 443 or Apache will get very upset
         var pfield = Ext.ComponentQuery.query('textfield[fieldIndex=listenPort]')[0];
         var pvalue = pfield.getValue();

--- a/openvpn/js/view/Server.js
+++ b/openvpn/js/view/Server.js
@@ -267,7 +267,12 @@ Ext.define('Ung.apps.openvpn.cmp.RemoteClientsGrid', {
         bind: {
             value: '{record.name}',
             readOnly: '{record.existing}'
-        }
+        },
+        validator: function(value, component) {
+            if(component === undefined)
+                    component = this;
+            return Util.isUnique(value, 'remote client', 'name', component," app-openvpn-remote-clients-grid");
+        }    
     }, {
         xtype: 'combobox',
         fieldLabel: 'Group'.t(),
@@ -296,7 +301,12 @@ Ext.define('Ung.apps.openvpn.cmp.RemoteClientsGrid', {
             hidden: '{!record.export}'
         },
         allowBlank: false,
-        vtype: 'cidrBlockList'
+        vtype: 'cidrBlockList',
+        validator: function(value, component) {
+            if(component === undefined)
+                    component = this;
+            return Util.isIpIntersects(value, 'remote client', 'exportNetwork', component," app-openvpn-remote-clients-grid");
+        }
     }]
 
 });
@@ -345,7 +355,12 @@ Ext.define('Ung.apps.openvpn.cmp.GroupsGrid', {
     editorFields: [{
         xtype: 'textfield',
         fieldLabel: 'Group Name'.t(),
-        bind: '{record.name}'
+        bind: '{record.name}',
+        validator: function(value, component) {
+            if(component === undefined)
+                    component = this;
+            return Util.isUnique(value, 'group', 'name', component, 'app-openvpn-groups-grid');
+        }
     }, {
         xtype: 'checkbox',
         fieldLabel: 'Full Tunnel'.t(),

--- a/uvm/js/common/ungrid/GridController.js
+++ b/uvm/js/common/ungrid/GridController.js
@@ -470,7 +470,7 @@ Ext.define('Ung.cmp.GridController', {
         
                             // Currently, custom validator is tailored exclusively for the WG App.
                             // To extend its functionality to other apps, ensure custom validators across each app retrieve stored values during import operations.
-                            if(record.javaClass === 'com.untangle.app.wireguard_vpn.WireGuardVpnTunnel' || record.javaClass === 'com.untangle.app.openvpn.OpenVpnRemoteClient' || record.javaClass === 'com.untangle.app.openvpn.OpenVpnGroup' || record.javaClass === "com.untangle.app.openvpn.OpenVpnExport" || record.javaClass === "com.untangle.app.openvpn.OpenVpnConfigItem" ){
+                            if(record.javaClass === 'com.untangle.app.wireguard_vpn.WireGuardVpnTunnel' || record.javaClass === 'com.untangle.app.openvpn.OpenVpnRemoteClient' || record.javaClass === 'com.untangle.app.openvpn.OpenVpnGroup' || record.javaClass === "com.untangle.app.openvpn.OpenVpnExport" || record.javaClass === "com.untangle.app.openvpn.OpenVpnConfigItem" || record.javaClass === "com.untangle.app.ipsec_vpn.IpsecVpnTunnel" || record.javaClass === "com.untangle.app.ipsec_vpn.IpsecVpnNetwork"  ){
                                 if (fieldConfig.validator && fieldConfig.validator(fieldValue, this) != true) {
                                     validationErrorMsg = fieldConfig.validator(fieldValue, this);
                                 }

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -88,7 +88,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
             vtype: 'isSingleIpValid',
             emptyText: '[enter peer IP address]'.t(),
             validator: function(value) {
-                return peerIpAddrValidator(value, 'peerAddress', this);
+                return peerIpAddrValidator(value, 'peerAddress', this, 'app-wireguard-vpn-server-tunnels-grid');
             }
         }
     }, {
@@ -136,7 +136,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         validator: function(value, component) {
             if(component === undefined)
                     component = this;
-            return isUnique(value, 'description', component);
+            return Util.isUnique(value, 'tunnel', 'description', component, 'app-wireguard-vpn-server-tunnels-grid');
         }
     }, {
         xtype: 'textfield',
@@ -150,7 +150,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
             if(component == undefined){
                 component = this;
             }
-            return isUnique(value, 'publicKey', component);
+            return Util.isUnique(value, 'tunnel', 'publicKey', component, 'app-wireguard-vpn-server-tunnels-grid');
         }
     }, {
         xtype: 'fieldset',
@@ -215,7 +215,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
             if(component == undefined){
                 component = this;
             }
-            return peerIpAddrValidator(value, 'peerAddress', component);
+            return peerIpAddrValidator(value, 'peerAddress', component, 'app-wireguard-vpn-server-tunnels-grid');
         }
     }, {
         xtype: 'textarea',
@@ -367,8 +367,8 @@ function isIPAddressUnderNWRange(value, component) {
     }       
 }
 
-function peerIpAddrValidator(value, field, component) {
-    var uniqueError = isUnique(value, field, component);
+function peerIpAddrValidator(value, field, component, grid) {
+    var uniqueError = Util.isUnique(value, 'tunnel', field, component, grid);
     var rangeError = isIPAddressUnderNWRange(value, component);
     
     if (rangeError !== true) {


### PR DESCRIPTION
**ISSUE:**  This PR resolves 2 issues:

1. Import function has no validation.
2. RemoteNetwork validator should be handled at UI level so save button should not get disabled.

**FIX:**
1. Added all validator at field level to validate data at import, edit and add operation.
2. Implemented validator for RemoteNetwork field to validate IPs should not insect each other.

**TEST:**  

**1. OpenVPN -> Server -> Remote Clients** 
-   Create a new client record with name already existed it should show error.
![Screenshot from 2024-04-26 11-30-38](https://github.com/untangle/ngfw_src/assets/155290371/890d0875-bfc1-4569-ba79-41b3953788a5)
- Create a new record or try to edit a record with Type:Network and try to put the invalid IP which intersect with already exited remote network in other records, It will show error.
![Screenshot from 2024-04-26 11-35-16](https://github.com/untangle/ngfw_src/assets/155290371/23322070-c9ed-4a5c-8dc9-5462c7a9d5b5)
- Try to edit record of Type:Network and put the already existed value in same row, it will show error.
![Screenshot from 2024-04-26 11-36-53](https://github.com/untangle/ngfw_src/assets/155290371/e8312cbd-ea34-43be-abd9-1f4529c88887)
- Try to import the file with invalid records, it will allow only valid data to be store and show pop up for invalid data.
![Screenshot from 2024-04-26 11-28-35](https://github.com/untangle/ngfw_src/assets/155290371/e16c364f-7bfc-4561-a77f-bff528e16124)

**2. OpenVPN -> Server -> Groups**
- Create a new client record with name already existed it should show error.
![Screenshot from 2024-04-26 11-40-46](https://github.com/untangle/ngfw_src/assets/155290371/e099a383-6eba-4826-a615-0e7025a41335)
- Try to import the file with invalid records, it will allow only valid data to be store and show pop up for invalid data.
![Screenshot from 2024-04-26 11-41-21](https://github.com/untangle/ngfw_src/assets/155290371/68e34fee-5c6f-4fd1-82a5-745b3d5fe1c5)

**3. OpenVPN -> Server -> Exported Networks**
- Try to import the file with invalid records, it will allow only valid data to be store and show pop up for invalid data.
![Screenshot from 2024-04-26 11-43-20](https://github.com/untangle/ngfw_src/assets/155290371/c922dcad-fe52-4f0e-b8ae-fbc405c32eed)

**4. OpenVPN -> Advanced -> Server Configuration and Client Configuration**
- Try to import the file, functionality should work properly.
![image](https://github.com/untangle/ngfw_src/assets/155290371/0dc828a2-1e8a-4b98-b63b-e4d247ecd0a6)

**Note: Performed the sanity test for WireGuardVPN as well.**
