### PR TITLE
Ngfw 13782 threat prevention anynet relay domain issue

### DIFF
--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
@@ -5,7 +5,9 @@
 package com.untangle.app.web_filter;
 
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.BufferUnderflowException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
@@ -250,13 +252,14 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             logger.debug("Using existing requestLine: " + requestLine.toString());
         }
 
+        String encodedDomain = URLEncoder.encode(domain, StandardCharsets.UTF_8);
         URI fakeUri;
         try {
             fakeUri = new URI("/");
             /**
              * Test that https://domain/ is a valid URL
              */
-            URI uri = new URI("https://" + domain + "/");
+            URI uri = new URI("https://" + encodedDomain + "/");
 
             // Attach the domain as the HTTP:URL here
             if(sess.globalAttachment(AppSession.KEY_HTTP_URL) == null)
@@ -317,7 +320,7 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
         evt = (HttpRequestEvent) sess.globalAttachment(AppSession.KEY_HTTPS_SNI_HTTP_REQUEST_EVENT);
 
         if (evt == null) {
-            evt = new HttpRequestEvent(requestLine, domain, null, 0);
+            evt = new HttpRequestEvent(requestLine, encodedDomain, null, 0);
             requestLine.setHttpRequestEvent(evt);
             this.app.logEvent(evt);
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_HTTP_REQUEST_EVENT, evt);
@@ -327,10 +330,10 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
         }
 
         // attach the hostname we extracted to the session
-        sess.globalAttach(AppSession.KEY_HTTP_HOSTNAME, domain);
+        sess.globalAttach(AppSession.KEY_HTTP_HOSTNAME, encodedDomain);
 
         HeaderToken h = new HeaderToken();
-        h.addField("host", domain);
+        h.addField("host", encodedDomain);
 
         // pass the info to the decision engine to see if we should block
         HttpRedirect redirect = app.getDecisionEngine().checkRequest(sess, sess.getClientAddr(), 443, rlt, h);

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
@@ -264,7 +264,7 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             // Attach the domain as the HTTP:URL here
             if(sess.globalAttachment(AppSession.KEY_HTTP_URL) == null)
             {
-                sess.globalAttach(AppSession.KEY_HTTP_URL, domain + "/");
+                sess.globalAttach(AppSession.KEY_HTTP_URL, encodedDomain + "/");
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
While trying to process the traffic, domain for **AnyDesk** connection is `anynet relay`. 
We check for URL validity using java.net.URI. 
`http://anynet relay/` is not a valid Url and hence exception was thrown.

Using `java.net.URLEncoder` to avoid this and using encoded domain.