### PR TITLE
ngfw-14580: Automatic queue email queue clearing

### DIFF
--- a/uvm/hier/etc/cron.daily/untangle-email-cleaner
+++ b/uvm/hier/etc/cron.daily/untangle-email-cleaner
@@ -1,0 +1,43 @@
+#! /bin/bash
+
+MAIL_JS=/usr/share/untangle/settings/untangle-vm/mail.js
+#2 hrs set as default
+MAIL_ELAPSED_SECS="${1:-7200}"
+if [ -f "$MAIL_JS" ]; then
+    FROM_ADDRESS=$(grep -Po 'fromAddress": "\K[^"]+' $MAIL_JS)
+    #Check if FROM_ADDRESS is set
+    if ! [ -z "$FROM_ADDRESS" ]; then
+
+        #-r represents recieving mail address
+        RECIPIENT_IDS=$(exiqgrep -o $MAIL_ELAPSED_SECS -i -r "$FROM_ADDRESS")
+        if ! [ -z "$RECIPIENT_IDS" ]; then
+            #This will ensure locked messages are deleted 
+            for r_id in $RECIPIENT_IDS; do
+                r_pid=`ps -ef | grep "exim4 -Mc $r_id" | grep -v "grep" | awk '{print $2}'`
+                # Check if process ids is empty (each message has parent and child process)
+                if ! [ -z "$r_pid" ]; then
+                    echo "$r_pid" | xargs kill -9
+                fi
+            done
+            # Deleting Recipient Messages from exim queue
+            echo "$RECIPIENT_IDS" | xargs exim -Mrm
+        fi
+        # -f represents from email address
+        FROM_IDS=$(exiqgrep -o $MAIL_ELAPSED_SECS -i -f "$FROM_ADDRESS")
+        if ! [ -z "$FROM_IDS" ]; then
+            #This will ensure locked messages are deleted
+            for f_id in $FROM_IDS; do
+                f_pid=`ps -ef | grep "exim4 -Mc $f_id" | grep -v "grep" | awk '{print $2}'`
+                # Check if process ids is empty (each message has parent and child process)
+                if ! [ -z "$f_pid" ]; then
+                    echo "$f_pid" | xargs kill -9
+                fi
+            done
+            # Deleting From Messages from exim queue
+            echo "$FROM_IDS" | xargs exim -Mrm
+        fi
+
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
Acceptance Criteria
Add cron script to delete the emails which are having TO or FROM the Outgoing Email FROM_EMAIL address from email tab.

Added Testcase for the scenario, which implements following points
 1. Modify FROM_EMAIL to non deliverable mail
 2. Send emails to non deliverable email, note the count of messages using exim -bpc
 3. Run cron script explicitly to delete the emails which are having TO or FROM the Outgoing Email FROM_EMAIL address.
 4. Verify the count of messages should decrease after cron script is run
 
![image](https://github.com/untangle/ngfw_src/assets/154513962/386aefd1-1a6e-4c53-94c5-91720dde1c3f)

 
Please note that queue is run periodically to send messages, there is retry mechanism if message delivery fails and during message being delivered, it cannot be deleted as the exim server locks the message or process. 
![Screenshot from 2024-05-03 16-42-20](https://github.com/untangle/ngfw_src/assets/154513962/260562a8-6d94-41b9-9f7a-44b512a33bc0)

https://itsmeanee.wordpress.com/2010/12/01/removing-a-locked-mail-from-exim-mailqueue/

- The Cron script will look for locked messages and if it finds process id related to that message delivery , it will kill the process resulting in releasing the lock and deletion of message  
-  For few messages process id will not be available , and  they cannot be deleted due locking, those messages will be killed by the Cron Script in next run, when lock is released.
