### PR TITLE
Ngfw 14561 Captive Portal fix for TLS 1.2 handshake

### DIFF
--- a/captive-portal/hier/usr/lib/python3/dist-packages/tests/test_captive_portal.py
+++ b/captive-portal/hier/usr/lib/python3/dist-packages/tests/test_captive_portal.py
@@ -1031,7 +1031,7 @@ class CaptivePortalTests(NGFWTestCase):
         self._app.setSettings(appData)
 
         # check that basic captive page is show when secure redirection is enabled
-        result = remote_control.run_command(global_functions.build_curl_command(extra_arguments='--tlsv1.2 --tls-max 1.2', output_file="/tmp/capture_test_071.out", verbose=True))
+        result = remote_control.run_command(global_functions.build_curl_command(extra_arguments='--tlsv1.2 --tls-max 1.2', output_file="/tmp/capture_test_071.out"))
         assert (result == 0)
         search = remote_control.run_command("grep -q 'Captive Portal' /tmp/capture_test_071.out")
         assert (search == 0)

--- a/captive-portal/hier/usr/lib/python3/dist-packages/tests/test_captive_portal.py
+++ b/captive-portal/hier/usr/lib/python3/dist-packages/tests/test_captive_portal.py
@@ -1017,6 +1017,25 @@ class CaptivePortalTests(NGFWTestCase):
         result = remote_control.run_command(global_functions.build_curl_command(output_file="/tmp/capture_test_072.out"))
         assert (result != 0)
 
+    @pytest.mark.failure_for_seb
+    def test_073_check_secure_redirect_enabled_with_tls1_2(self):
+        global app, appData
+
+        # Create Internal NIC capture rule with basic login page
+        appData['captureRules']['list'] = []
+        appData['captureRules']['list'].append(create_capture_non_wan_nic_rule(1))
+        appData['authenticationType']="NONE"
+        appData['pageType'] = "BASIC_MESSAGE"
+        appData['userTimeout'] = 3600  # default
+        appData['disableSecureRedirect'] = False
+        self._app.setSettings(appData)
+
+        # check that basic captive page is show when secure redirection is enabled
+        result = remote_control.run_command(global_functions.build_curl_command(extra_arguments='--tlsv1.2 --tls-max 1.2', output_file="/tmp/capture_test_071.out", verbose=True))
+        assert (result == 0)
+        search = remote_control.run_command("grep -q 'Captive Portal' /tmp/capture_test_071.out")
+        assert (search == 0)
+
     def test_080_check_captive_page_on_non_standard_port(self):
         # Test for captive page when HTTP is set to nonstandard port
         global app, appData

--- a/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalSSLEngine.java
+++ b/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalSSLEngine.java
@@ -325,11 +325,6 @@ public class CaptivePortalSSLEngine
         result = sslEngine.unwrap(data, target);
         logger.debug("EXEC_UNWRAP " + result.toString());
 
-        if(result.getStatus() == SSLEngineResult.Status.OK && data.hasRemaining() == false){
-            // Nothing more to process.
-            return true;
-        }
-
         if (result.getStatus() == SSLEngineResult.Status.BUFFER_UNDERFLOW) {
             // underflow during unwrap means the SSLEngine needs more data
             // but it's also possible it used some of the passed data so we


### PR DESCRIPTION
- Unwrap method of Captive Portal SSLEngine now does not come out of the loop if there is no data. This is to support TLS 1.2 handshake flow.
- Change does not affect TLS 1.3 handshake flow.
- Added test case for TLS 1.2.
```
== testing captive-portal ==
Test success : test_073_check_secure_redirect_enabled_with_tls1_2 [0.8s] 
== testing captive-portal [31.6s] ==

Tests complete. [31.6 seconds]
1 passed, 0 skipped, 0 failed

Total          :    1
Passed         :    1
Skipped        :    0
Passed/Skipped :    1 [100.00%]
Failed         :    0 [  0.00%]
```
- Verified for TLS 1.3 and TLS 1.2 that the Captive Portal page is prompted.
- Verified that the authentication with google, microsoft and facebook works as part of the earlier ticket where this change was made https://awakesecurity.atlassian.net/browse/NGFW-14176
- Verified Captive Portal page is prompted with Web Filter configured.