### PR TITLE
NGFW-14218 Pagination support from LDAP client side

### DIFF
--- a/.vscode/vsbuild.sh
+++ b/.vscode/vsbuild.sh
@@ -95,6 +95,7 @@ for target_address in "${TARGET_ADDRESSES[@]}"; do
     rsync -a -e "ssh -p $port" dist/usr/share/java/uvm/* root@$target_address:/usr/share/java/uvm
     rsync -a -e "ssh -p $port" dist/usr/share/untangle/bin root@$target_address:/usr/share/untangle
     rsync -a -e "ssh -p $port" dist/usr/share/untangle/lib root@$target_address:/usr/share/untangle
+    rsync -a -e "ssh -p $port" dist/usr/share/untangle/conf/log4j.xml root@$target_address:/usr/share/untangle/conf/log4j.xml
     rsync -a -e "ssh -p $port" dist/usr/share/untangle/conf/untangle-vm.conf root@$target_address:/usr/share/untangle/conf/untangle-vm.conf
     rsync -a -e "ssh -p $port" dist/usr/share/untangle/web root@$target_address:/usr/share/untangle
     rsync -a -e "ssh -p $port" dist/usr/share/untangle/lang/lang.cfg root@$target_address:/usr/share/untangle/lang

--- a/uvm/hier/usr/share/untangle/conf/log4j.xml
+++ b/uvm/hier/usr/share/untangle/conf/log4j.xml
@@ -21,7 +21,7 @@
     <param name="Facility" value="LOCAL0"/>
     <param name="Threshold" value="ALL"/>
     <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="[%c{1}] %-5p %m%n"/>
+      <param name="ConversionPattern" value="[%c{1}:%L] %-5p %m%n"/>
     </layout>
   </appender>
 
@@ -39,7 +39,7 @@
     <param name="Facility" value="LOCAL1"/>
     <param name="Threshold" value="ALL"/>
     <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="@AppLogFileName@: [%c{1}] &lt;%X{SessionID}&gt; %-5p %m%n"/>
+      <param name="ConversionPattern" value="@AppLogFileName@: [%c{1}:%L] &lt;%X{SessionID}&gt; %-5p %m%n"/>
     </layout>
   </appender>
 


### PR DESCRIPTION
- We are now using `InitialLdapContext` instead of `InitialDirContext` to query data from LDAP server. `InitialLdapContext` allows us the fetch records in pages.
- Refactored the code to query LDAP data.
- Log4j.xml now logs the line number.
- VS Code build script pushes log4j to NGFW.

References:
https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/view-set-ldap-policy-using-ntdsutil
https://docs.oracle.com/javase/tutorial/jndi/newstuff/paged-results.html

Local AD server validation is done. Azure validation is pending, waiting for Azure access from Helpdesk.