### PR TITLE
ngfw-14612 setting default mtu while getting nic status

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-uvm-device-status.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-uvm-device-status.sh
@@ -34,8 +34,12 @@ function getInterfaceStatus()
     local t_duplex=${FLAG_UNKNOWN}
     local t_eee_enabled=${FLAG_UNKNOWN}
     local t_eee_active=${FLAG_UNKNOWN}
-    local t_mtu=$(cat /sys/class/net/${t_intf}/mtu)
+    local t_mtu=1500
     local t_link_supported=${FLAG_UNKNOWN}
+
+    if [ -f /sys/class/net/${t_intf}/mtu ]; then
+        t_mtu=$(cat /sys/class/net/${t_intf}/mtu)
+    fi
 
     if [ ! -z "${t_comma}" ] ; then 
         echo "    ${t_comma}" ; 


### PR DESCRIPTION
**Issue:** On restoring backup of four physical interfaces (i.e. eth0, eth1, eth2, eth3) on device with two interfaces, system did not show NIC status.

**Fix:**  Added a condition in `ut-uvm-device-status.sh` file (used to get Connection status of interfaces) such that if `/sys/class/net/${t_intf}/mtu` file not found then `mtu` value will be by default `1500`

**Local Testing:** 

1. Added four adapters to create four physical interfaces.
2. Taking backup of configuration settings
3. Removed two physical interfaces from device
4. Restoring backup settings

It would give status output as given below

> {
  "javaClass": "java.util.LinkedList",
  "list": [
    {
      "javaClass": "com.untangle.uvm.network.DeviceStatus",
      "deviceName": "eth0",
      "connected": "CONNECTED",
      "mbit": 1000,
      "duplex": "FULL_DUPLEX",
      "eeeEnabled": "UNKNOWN",
      "eeeActive": "UNKNOWN",
      "mtu": 1500,
      "vendor": "Intel Corporation",
      "macAddress": "08:00:27:a5:cb:95",
      "supportedLinkModes": "10_HALF_DUPLEX,10_FULL_DUPLEX,100_HALF_DUPLEX,100_FULL_DUPLEX,1000_FULL_DUPLEX"
    },
    {
      "javaClass": "com.untangle.uvm.network.DeviceStatus",
      "deviceName": "eth1",
      "connected": "CONNECTED",
      "mbit": 1000,
      "duplex": "FULL_DUPLEX",
      "eeeEnabled": "UNKNOWN",
      "eeeActive": "UNKNOWN",
      "mtu": 1500,
      "vendor": "Intel Corporation",
      "macAddress": "08:00:27:65:f4:aa",
      "supportedLinkModes": "10_HALF_DUPLEX,10_FULL_DUPLEX,100_HALF_DUPLEX,100_FULL_DUPLEX,1000_FULL_DUPLEX"
    },
**cat: /sys/class/net/eth3/mtu: No such file or directory**
	{
	  "javaClass": "com.untangle.uvm.network.DeviceStatus",
	  "deviceName": "eth2",
	  "connected": "MISSING",
	  "mbit": 0,
	  "duplex": "UNKNOWN",
	  "eeeEnabled": "UNKNOWN",
	  "eeeActive": "UNKNOWN",
	  "mtu": ,
	  "vendor": "",
	  "macAddress": "08:00:27:65:f4:aa",
	  "supportedLinkModes": "UNKNOWN"
	},
**cat: /sys/class/net/eth4/mtu: No such file or directory**
	{
	  "javaClass": "com.untangle.uvm.network.DeviceStatus",
	  "deviceName": "eth3",
	  "connected": "MISSING",
	  "mbit": 0,
	  "duplex": "UNKNOWN",
	  "eeeEnabled": "UNKNOWN",
	  "eeeActive": "UNKNOWN",
	  "mtu": 1,
	  "vendor": "",
	  "macAddress": "08:00:27:65:f4:aa",
	  "supportedLinkModes": "UNKNOWN"
	}
   ]
}

Errors `No such file or directory` would cause trouble in parsing Json and status was shown as gien below

![Screenshot from 2024-05-16 11-29-09](https://github.com/untangle/ngfw_src/assets/154422821/0f6f88fb-9b40-43f8-b558-9eb7420b79d8)

-----------------------------------------------------------------

After implementing Fix system is able to parse json output of `ut-uvm-device-status.sh` file and status is as shown below

![Screenshot from 2024-05-16 11-19-47](https://github.com/untangle/ngfw_src/assets/154422821/26cf1853-d114-4f00-aac9-9924709ca24b)

-----------------------------------------------------------------

On Adding all physical interfaces status is shown as below


![Screenshot from 2024-05-16 11-38-53](https://github.com/untangle/ngfw_src/assets/154422821/7495604c-a5a9-4903-92d0-78be21ff8ef5)

