### PR TITLE
NGFW-14601: Bypass Rule import validation

### DIFF
--- a/uvm/servlets/admin/config/network/view/BypassRules.js
+++ b/uvm/servlets/admin/config/network/view/BypassRules.js
@@ -42,6 +42,9 @@ Ext.define('Ung.config.network.view.BypassRules', {
 
         listProperty: 'settings.bypassRules.list',
 
+        importValidationJavaClass: true,
+
+
         emptyRow: {
             ruleId: -1,
             enabled: true,


### PR DESCRIPTION
Import validation changes added for the Bypass Rules on the network tab.

TEST:
1. Go to config -> network -> bypass Rules
2. Add import with invalid content, it should give error for particular field.
![Screenshot from 2024-05-16 15-35-07](https://github.com/untangle/ngfw_src/assets/155290371/bf6b08d6-c353-4f44-b8d1-9fb218ad8ffb)
