### PR TITLE
NGFW-14609 Allowing comma separated integers with spaces for custom rule condition

### DIFF
--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -24,6 +24,7 @@ Ext.define('Ung.overrides.form.field.VTypes', {
     },
 
     isSinglePortValid: function(val) {
+        val = val.trim();
         /* check for values between 0 and 65536 */
         if (val < 1 || val > 65535) { return false; }
         /* verify its an integer (not a float) */


### PR DESCRIPTION
We are now allowing comma separated list of integers that contain spaces in custom rule condition.
Earlier, no spaces were allowed in the list.

![image](https://github.com/untangle/ngfw_src/assets/154527616/42e4bc4b-7b45-456a-9ac6-e513f74204fb)

Backend also trims the value 
IntMatcher.java
```
    private void initialize(String matcher)
    {
        matcher = matcher.toLowerCase().trim().replaceAll("\\s", "");
        this.matcher = matcher;
```
And `iptables` translated the rule, 
```
[root @ arista] ~ # iptables -S | grep 30072
-A access-rules -p udp -m comment --comment "Rule #25" -m multiport --dports 30072,30073,30074 -j RETURN
-A access-rules -p tcp -m comment --comment "Rule #25" -m multiport --dports 30072,30073,30074 -j RETURN
```

Hence no backend change was required.
