### PR TITLE
NGFW-14629 Fixed mod_python publisher CVE

### DIFF
--- a/captive-portal/hier/usr/share/untangle/web/capture/handler.py
+++ b/captive-portal/hier/usr/share/untangle/web/capture/handler.py
@@ -16,11 +16,6 @@ import uvm.i18n_helper
 
 from urllib.parse import urlparse
 
-from uvm.settings_reader import get_app_settings_item
-from uvm.settings_reader import get_appid_settings
-from uvm.settings_reader import get_app_settings
-from uvm.settings_reader import get_settings_item
-
 _ = uvm.i18n_helper.get_translation('untangle').lgettext
 
 # Dictionary of Oauth providers by name, each with the following fields:
@@ -230,7 +225,7 @@ def index(req):
     # found a custom.py file so load it up, grab the index function reference
     # and call the index function to generate the capture page
     if (os.path.exists(rawpath + "custom.py")):
-        cust = import_file(rawpath + "custom.py")
+        cust = _import_file(rawpath + "custom.py")
         if not cust:
             raise Exception("Unable to locate or import custom.py")
         func = getattr(cust,"index")
@@ -563,20 +558,20 @@ def load_capture_settings(req,appid=None):
     companyName = 'Arista'
 
     # if there is an OEM name configured we use that instead of our company name
-    oemName = get_settings_item("/usr/share/untangle/conf/oem.js","oemName")
+    oemName = uvm.settings_reader.get_settings_item("/usr/share/untangle/conf/oem.js","oemName")
     if (oemName != None):
         companyName = oemName
 
     # if there is a company name in the branding manager it wins over everything else
-    brandco = get_app_settings_item('branding-manager','companyName')
+    brandco = uvm.settings_reader.get_app_settings_item('branding-manager','companyName')
     if (brandco != None):
         companyName = brandco
 
     try:
         if (appid == None):
-            captureSettings = get_app_settings('captive-portal')
+            captureSettings = uvm.settings_reader.get_app_settings('captive-portal')
         else:
-            captureSettings = get_appid_settings(int(appid))
+            captureSettings = uvm.settings_reader.get_appid_settings(int(appid))
     except Exception as e:
         req.log_error("handler.py: Exception loading settings: %s" % str(e))
 
@@ -673,7 +668,7 @@ def custom_handler(req):
     return(page)
 
 #-----------------------------------------------------------------------------
-def import_file(filename):
+def _import_file(filename):
     (path, name) = os.path.split(filename)
     (name, ext) = os.path.splitext(name)
     (file, filename, data) = imp.find_module(name, [path])

--- a/captive-portal/hier/usr/share/untangle/web/capture/logout/logout.py
+++ b/captive-portal/hier/usr/share/untangle/web/capture/logout/logout.py
@@ -9,11 +9,6 @@ from uvm import Uvm
 from mod_python import Cookie
 import uvm.i18n_helper
 
-from uvm.settings_reader import get_app_settings_item
-from uvm.settings_reader import get_appid_settings
-from uvm.settings_reader import get_app_settings
-from uvm.settings_reader import get_settings_item
-
 _ = uvm.i18n_helper.get_translation('untangle').lgettext
 
 #-----------------------------------------------------------------------------
@@ -103,18 +98,18 @@ def load_capture_settings(req,appid=None):
 
     companyName = 'Arista'
 
-    oemName = get_settings_item("/usr/share/untangle/conf/oem.js","oemName")
+    oemName = uvm.settings_reader.get_settings_item("/usr/share/untangle/conf/oem.js","oemName")
     if (oemName != None):
         companyName = oemName
 
-    brandco = get_app_settings_item('branding-manager','companyName')
+    brandco = uvm.settings_reader.get_app_settings_item('branding-manager','companyName')
     if (brandco != None):
         companyName = brandco
 
     if (appid == None):
-        captureSettings = get_app_settings('captive-portal')
+        captureSettings = uvm.settings_reader.get_app_settings('captive-portal')
     else:
-        captureSettings = get_appid_settings(int(appid))
+        captureSettings = uvm.settings_reader.get_appid_settings(int(appid))
 
     # add the company name to the app settings dictionary
     captureSettings['companyName'] = companyName

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_vulnerabilities.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_vulnerabilities.py
@@ -1,0 +1,91 @@
+import subprocess
+import pytest
+
+from tests.common import NGFWTestCase
+import tests.global_functions as global_functions
+import runtests.test_registry as test_registry
+
+
+@pytest.mark.vulnerabilities
+class VulnerabilitiesTests(NGFWTestCase):
+
+    not_an_app= True
+
+    @staticmethod
+    def module_name():
+        return "vulnerabilities"
+    
+    def test_010_mod_python_publisher(self):
+
+        BASE_URL = global_functions.get_http_url()
+        GET_APP_SETTINGS_ITEM_URL = '/get_app_settings_item?appname=reports&itemname=reportsUsers'
+        GET_UVM_SETTINGS_ITEM_URL = '/get_uvm_settings_item?basename=admin&itemname=users'
+        GET_APPID_SETTINGS = '/get_appid_settings?appid=1'
+        GET_APP_SETTINGS = '/get_app_settings?appname=captive-portal'
+        GET_SETTINGS_ITEM = '/get_settings_item?file=/usr/share/untangle/conf/oem.js&itemname=oemName'
+
+        CURL_EXTRA_ARGS = '-s -o /dev/null -w "%{http_code}"'
+
+        # Test auth/index.py
+        AUTH_INDEX_URL = 'auth/index.py'
+        command = global_functions.build_curl_command(uri=BASE_URL + AUTH_INDEX_URL + GET_APP_SETTINGS_ITEM_URL, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+        
+        command = global_functions.build_curl_command(uri=BASE_URL + AUTH_INDEX_URL + GET_UVM_SETTINGS_ITEM_URL, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+
+        # Test handler.py
+        CAPTURE_HANDLER_URL = 'capture/handler.py'
+        command = global_functions.build_curl_command(uri=BASE_URL + CAPTURE_HANDLER_URL + GET_APP_SETTINGS_ITEM_URL, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+        
+        command = global_functions.build_curl_command(uri=BASE_URL + CAPTURE_HANDLER_URL + GET_APPID_SETTINGS, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+        
+        command = global_functions.build_curl_command(uri=BASE_URL + CAPTURE_HANDLER_URL + GET_APP_SETTINGS, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+        
+        command = global_functions.build_curl_command(uri=BASE_URL + CAPTURE_HANDLER_URL + GET_SETTINGS_ITEM, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+        
+        command = global_functions.build_curl_command(uri=BASE_URL + CAPTURE_HANDLER_URL + '/import_file?filename=/usr/share/untangle/bin/ut-enable-support-access.py', 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+
+        # Test logout.py
+        CAPTURE_LOGOUT_URL = 'capture/logout/logout.py'
+        command = global_functions.build_curl_command(uri=BASE_URL + CAPTURE_LOGOUT_URL + GET_APP_SETTINGS_ITEM_URL, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+        
+        command = global_functions.build_curl_command(uri=BASE_URL + CAPTURE_LOGOUT_URL + GET_APPID_SETTINGS, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+        
+        command = global_functions.build_curl_command(uri=BASE_URL + CAPTURE_LOGOUT_URL + GET_APP_SETTINGS, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+        
+        command = global_functions.build_curl_command(uri=BASE_URL + CAPTURE_LOGOUT_URL + GET_SETTINGS_ITEM, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
+
+
+test_registry.register_module("vulnerabilities", VulnerabilitiesTests)

--- a/uvm/hier/usr/share/untangle/web/auth/index.py
+++ b/uvm/hier/usr/share/untangle/web/auth/index.py
@@ -18,17 +18,6 @@ if "@PREFIX@" != '' and '@' not in '@PREFIX@':
 from uvm import login_tools
 import uvm_login
 
-def get_app_settings_item(a,b):
-    return None
-def get_uvm_settings_item(a,b):
-    return None
-
-try:
-    from uvm.settings_reader import get_app_settings_item
-    from uvm.settings_reader import get_uvm_settings_item
-except ImportError:
-    pass
-
 # pages -----------------------------------------------------------------------
 
 def login(req, url=None, realm='Administrator', token=None):
@@ -60,11 +49,11 @@ def login(req, url=None, realm='Administrator', token=None):
     is_local = re.match('127\.', req.useragent_ip)
     if req.useragent_ip == '::1':
         is_local = True
-    if port == 80 and not get_uvm_settings_item('system','httpAdministrationAllowed') and not is_local:
+    if port == 80 and not uvm.settings_reader.get_uvm_settings_item('system','httpAdministrationAllowed') and not is_local:
         write_error_page(req, "Permission denied")
         return
 
-    if token != None and get_uvm_settings_item('system','cloudEnabled'):
+    if token != None and uvm.settings_reader.get_uvm_settings_item('system','cloudEnabled'):
         if login_tools.valid_token(token):
             sess = Session.Session(req, lock=0)
             sess.lock()


### PR DESCRIPTION
- Fixed vulnerabilities as per https://modpython.org/live/current/doc-html/handlers.html#traversal
- Added test case
```

======================================================================
test_010_mod_python_publisher start [2024-05-27T20:46:25]
test_010_mod_python_publisher (tests.test_vulnerabilities.VulnerabilitiesTests) ... build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/auth/index.py/get_app_settings_item?appname=reports&itemname=reportsUsers'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/auth/index.py/get_uvm_settings_item?basename=admin&itemname=users'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/capture/handler.py/get_app_settings_item?appname=reports&itemname=reportsUsers'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/capture/handler.py/get_appid_settings?appid=1'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/capture/handler.py/get_app_settings?appname=captive-portal'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/capture/handler.py/get_settings_item?file=/usr/share/untangle/conf/oem.js&itemname=oemName'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/capture/handler.py/import_file?filename=/usr/share/untangle/bin/ut-enable-support-access.py'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/capture/logout/logout.py/get_app_settings_item?appname=reports&itemname=reportsUsers'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/capture/logout/logout.py/get_appid_settings?appid=1'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/capture/logout/logout.py/get_app_settings?appname=captive-portal'
build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80/capture/logout/logout.py/get_settings_item?file=/usr/share/untangle/conf/oem.js&itemname=oemName'
ok

----------------------------------------------------------------------
Ran 1 test in 0.162s

OK
test_010_mod_python_publisher end   [2024-05-27T20:46:26]



== testing vulnerabilities ==
Test success : test_010_mod_python_publisher [0.2s] 
== testing vulnerabilities [0.7s] ==

Tests complete. [0.7 seconds]
1 passed, 0 skipped, 0 failed

Total          :    1
Passed         :    1
Skipped        :    0
Passed/Skipped :    1 [100.00%]
Failed         :    0 [  0.00%]

More details found in /tmp/unittest.log

