### PR TITLE
NGFW-14227 Exposed java.lang, java.io and sun.rmi.transport packages

### DIFF
--- a/uvm/hier/usr/share/untangle/conf/untangle-vm.conf
+++ b/uvm/hier/usr/share/untangle/conf/untangle-vm.conf
@@ -143,6 +143,11 @@ if not "x" == "x@PREFIX@":
 ## Fixes NGFW-14018 -- sun.util.calendar not exported from java.base
 java_opts += " --add-exports java.base/sun.util.calendar=ALL-UNNAMED "   
 
+## Fixes NGFW-14227
+java_opts += " --add-opens=java.base/java.io=ALL-UNNAMED "
+java_opts += " --add-opens=java.base/java.lang=ALL-UNNAMED "
+java_opts += " --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED "
+
 ## Disable ldap end point identifcation for AD queries
 java_opts += " -Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true"
 ## Need to pad the internal string for the LdapPoolManager to parse.  Otherwise,


### PR DESCRIPTION
Fixed below warnings from console.log
```
Nov  8 14:50:06 arista uvmconsole: Nov 08, 2022 2:50:06 PM org.apache.catalina.loader.WebappClassLoaderBase clearReferencesObjectStreamClassCaches
Nov  8 14:50:06 arista uvmconsole: WARNING: When running on Java 9 or later you need to add "--add-opens=java.base/java.io=ALL-UNNAMED" to the JVM command line arguments to enable ObjectStream cache memory leak protection. Alternatively, you can suppress this warning by disabling ObjectStream class cache memory leak protection.
Nov  8 14:50:06 arista uvmconsole: Nov 08, 2022 2:50:06 PM org.apache.catalina.loader.WebappClassLoaderBase checkThreadLocalsForLeaks
Nov  8 14:50:06 arista uvmconsole: WARNING: When running on Java 9 or later you need to add "--add-opens=java.base/java.lang=ALL-UNNAMED" to the JVM command line arguments to enable ThreadLocal memory leak detection. Alternatively, you can suppress this warning by disabling ThreadLocal memory leak detection.
Nov  8 14:50:06 arista uvmconsole: Nov 08, 2022 2:50:06 PM org.apache.catalina.loader.WebappClassLoaderBase clearReferencesRmiTargets
Nov  8 14:50:06 arista uvmconsole: WARNING: When running on Java 9 or later you need to add "--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED" to the JVM command line arguments to enable RMI Target memory leak detection. Alternatively, you can suppress this warning by disabling RMI Target memory leak detection.