### PR TITLE
ngfw-14616: Add Service files for zebra, ospf and bgp daemons

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/network-status.sh
+++ b/uvm/hier/usr/share/untangle/bin/network-status.sh
@@ -57,8 +57,11 @@ get_interface_arp_table()
 # @param None
 get_dynamic_routing_table()
 {
-    ip route show proto zebra | \
-        tr -s " " 
+    ospf_result=$(ip route show proto ospf | tr -s " ")
+    bgp_result=$(ip route show proto bgp | tr -s " ")
+    echo "$ospf_result"
+    echo "$bgp_result"
+
 }
 
 # get_dynamic_routing_bgp

--- a/uvm/hier/usr/share/untangle/bin/ut-routedump.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-routedump.sh
@@ -14,7 +14,8 @@ for i in main balance default local ; do
 done
 
 echo " = IPv4 Dynamic Routing = "
-ip -4 route show proto zebra
+ip -4 route show proto bgp
+ip -4 route show proto ospf
 echo
 
 awk '/uplink/ {print $2}' /etc/iproute2/rt_tables | while read table ; do

--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -140,25 +140,6 @@ def check_dpkg():
         cmd_to_log(dpkg_config)
         return
 
-def install_frr():
-    frr_output = subprocess.call(["dpkg-query", "-W", "frr"])
-    log(frr_output)
-    if frr_output == 0:
-        log("frr is already installed") 
-        return
-    else:
-        log("frr is being installed")
-        '''
-        During upgrade if frr is being installed for first time, sync settings has dependency on quagaa.
-        Quagga  dependency is to be removed from /var/lib/dpkg/status from sync settings.
-        This is done to avoid untangle-sync-settings and its dependant packages being removed when installing frr.
-        For Subsequent Upgrades,  upgrade() method will take care of it as quagga dependency is removed.
-        '''
-        subprocess.call(["sed", "-i", "-e", 's/python3, quagga/python3/g', "/var/lib/dpkg/status"])
-        cmd_to_log("apt install -y frr")
-        return
-
-
 
 log_date( os.path.basename( sys.argv[0]) )
 
@@ -175,8 +156,6 @@ if "2.6.32" in platform.platform():
 
 log_date("")
 log("")
-
-install_frr()
 
 r = check_upgrade();
 if r != 0:

--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -140,6 +140,25 @@ def check_dpkg():
         cmd_to_log(dpkg_config)
         return
 
+def install_frr():
+    frr_output = subprocess.call(["dpkg-query", "-W", "frr"])
+    log(frr_output)
+    if frr_output == 0:
+        log("frr is already installed") 
+        return
+    else:
+        log("frr is being installed")
+        '''
+        During upgrade if frr is being installed for first time, sync settings has dependency on quagaa.
+        Quagga  dependency is to be removed from /var/lib/dpkg/status from sync settings.
+        This is done to avoid untangle-sync-settings and its dependant packages being removed when installing frr.
+        For Subsequent Upgrades,  upgrade() method will take care of it as quagga dependency is removed.
+        '''
+        subprocess.call(["sed", "-i", "-e", 's/python3, quagga/python3/g', "/var/lib/dpkg/status"])
+        cmd_to_log("apt install -y frr")
+        return
+
+
 
 log_date( os.path.basename( sys.argv[0]) )
 
@@ -156,6 +175,8 @@ if "2.6.32" in platform.platform():
 
 log_date("")
 log("")
+
+install_frr()
 
 r = check_upgrade();
 if r != 0:

--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -985,6 +985,9 @@ Ext.define('Ung.config.network.MainController', {
                 if(line.indexOf("Exiting:") > -1){
                     return;
                 }
+                if(line.indexOf("bgpd is not running") > -1){
+                    return;
+                }
                 var columns = line.split(" ");
                 var uptime = 0;
                 if(columns[8] != 'never'){
@@ -1015,6 +1018,9 @@ Ext.define('Ung.config.network.MainController', {
                     return;
                 }
                 if(line.indexOf("Exiting:") > -1){
+                    return;
+                }
+                if(line.indexOf("ospfd is not running") > -1){
                     return;
                 }
                 var columns = line.split(" ");


### PR DESCRIPTION
Inorder to solve dependency issue of sync settings on quagga, did the following
Quagga  dependency is to be removed from /var/lib/dpkg/status from sync settings Depends definition.
This is done to avoid untangle-sync-settings and its dependant packages being removed when installing frr. 
During upgrade frr has to be installed manually (handled in script),  later on check is added to stop frr from getting installed again

Added testcase for BGP routing with two NGFW, there is a test case to check status of configuration for BGP and OSPF it is running fine.

![image](https://github.com/untangle/ngfw_src/assets/154513962/3e962cf1-270f-4368-9d38-092405b93f9d)
![image](https://github.com/untangle/ngfw_src/assets/154513962/aeecd7ec-440c-4c86-852f-b83f47b81226)


