### PR TITLE
NGFW-13424: Fixed OpenVPN Site to Site user/pass authentication

### DIFF
--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
@@ -375,6 +375,15 @@ public class OpenVpnAppImpl extends AppBase
         // Protocol changes
         if (!oldSettings.getProtocol().equals(newSettings.getProtocol())) { logger.debug("Server Protocol has changed."); return true;}
 
+        // Remote Server changes
+        if (oldSettings.getRemoteServers() == null ||
+                newSettings.getRemoteServers() == null ||
+                oldSettings.getRemoteServers().size() != newSettings.getRemoteServers().size() ||
+                !oldSettings.getRemoteServers().containsAll(newSettings.getRemoteServers())) {
+            logger.debug("Remote servers settings have changed.");
+            return true;
+        }
+
         // Listening Port changes
         if (oldSettings.getPort() != newSettings.getPort()) { logger.debug("Server Port has changed."); return true;}
 


### PR DESCRIPTION
**ISSUE:**  : When trying to connect two NGFW's with OpenVPN site to site connection using user/pass authentication with local directory the server never shows connected while the client does and traffic does not pass.
The issue occurs because when configuring the remote server, the file uploads and settings are immediately set, causing a system restart. However, for authentication with username and password, after uploading the file, manual configuration is needed. Since the app restart logic lacks a condition for remote server updates, these changes aren't reflected, resulting in no connection status being shown at server end.

**FIXED:** Updated restart logic by adding conditions for remote server update.

**TEST:** 
1. Configure OpenVPN for user/pass authentication
2. Create site to site client
3. Uploading the zip file to the client box.
4. Click Edit to add login and password.
5. Click save.
6. Notice the client and server both shows connected and Traffic passes.

Also below test should be passed
== testing openvpn ==
Test success  : test_035_createVPNTunnel_userpass [22.4s]