### PR TITLE
NGFW-14062/ NGFW-14640: Enforce safe search on popular search engines is not working for Yahoo and Bing test is failing 

### DIFF
--- a/web-filter/hier/usr/lib/python3/dist-packages/tests/test_web_filter.py
+++ b/web-filter/hier/usr/lib/python3/dist-packages/tests/test_web_filter.py
@@ -176,7 +176,7 @@ class WebFilterTests(WebFilterBaseTests):
 
         settings["enforceSafeSearch"] = True
         self._app.setSettings(settings)
-        google_result_with_safe = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri="http://www.google.com/search?hl=en&q=boobs&safe=off", user_agent="Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)") + " | grep -q 'safe=strict'")
+        google_result_with_safe = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri="http://www.google.com/search?hl=en&q=boobs", user_agent="Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)") + " | grep -q 'safe=strict'")
 
         assert( google_result_without_safe == 0 )
         assert( google_result_with_safe == 0 )
@@ -187,7 +187,7 @@ class WebFilterTests(WebFilterBaseTests):
 
         settings["enforceSafeSearch"] = True
         self._app.setSettings(settings)
-        bing_result_with_safe = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri="http://www.bing.com/search?q=boobs&adlt=off", user_agent="Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)") + " | grep -q 'adlt=strict'")
+        bing_result_with_safe = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri="http://www.bing.com/search?q=boobs", user_agent="Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)") + " | grep -q 'adlt=strict'")
 
         assert(bing_result_without_safe == 0)
         assert(bing_result_with_safe == 0)
@@ -198,7 +198,7 @@ class WebFilterTests(WebFilterBaseTests):
 
         settings["enforceSafeSearch"] = True
         self._app.setSettings(settings)
-        yahoo_result_with_safe = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri="http://search.yahoo.com/search?p=boobs&vm=p", user_agent="Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)") + " | grep -q 'vm=r'")
+        yahoo_result_with_safe = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri="http://search.yahoo.com/search?p=boobs", user_agent="Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)") + " | grep -q 'vm=r'")
 
         assert(yahoo_result_with_safe == 0)
         assert(yahoo_result_without_safe == 0)


### PR DESCRIPTION
**ISSUE**: test_700_safe_search_enabled is failing and Enforce safe search on popular search engines is not working for Yahoo/bing while hitting through wget.

**ANALYSIS:**
On UI the code is working as expected for bad terms while the safe search is enforced by webfilter.
[UI enforcing safesearch using ngfw](https://github.com/untangle/ngfw_src/assets/155290371/d6e3e553-eb43-49ba-acf9-45cee2d02582)

Only the test cases are failing as it usage incorrect URL.The URL we are sending as part of testing, somehow would not allow to fetch the appended safe search param for specific sites.


**FIX:** updated URL in case of safe search enforced is true.

**TEST:**
Can be test in 2 ways option one through UI and 2nd through testcase.

**1 - Through UI:**
- On windows client end disable default safe search option.
- Now install web filter and install SSL inspector and perform certification task as mentioned [here](https://wiki.edge.arista.com/index.php/Web_Filter#Safe_Browsing).
- Try to hit the URL with bad terms you will see extra param is appended in URL after Searching the term and the content is in default safe search mode.

 [UI enforcing safesearch using ngfw](https://github.com/untangle/ngfw_src/assets/155290371/d6e3e553-eb43-49ba-acf9-45cee2d02582)

**2- Run Below TestCase**
```
== testing web-filter ==
Test success : test_700_safe_search_enabled [7.0s] 
== testing web-filter [16.2s] ==

Tests complete. [16.2 seconds]
1 passed, 0 skipped, 0 failed

Total          :    1
Passed         :    1
Skipped        :    0
Passed/Skipped :    1 [100.00%]
Failed         :    0 [  0.00%]

More details found in /tmp/unittest.log
```

Result should be as below in /tmp/unittest.log file
```

initial_setup for app web-filter
starting web-filter



======================================================================
test_700_safe_search_enabled start [2024-06-05T16:32:16]
test_700_safe_search_enabled (tests.test_web_filter.WebFilterTests)
Check google/bing/yahoo safe search ... build_wget_command: wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://www.google.co
m/search?hl=en&q=boobs&safe=off'

Client  : 192.168.56.200
Command : wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://www.google.com/search?hl=en&q=boobs&safe=off' | grep -q 'safe=o
ff'
Result  : 0
Output  :
build_wget_command: wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://www.google.com/search?hl=en&q=boobs'

Client  : 192.168.56.200
Command : wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://www.google.com/search?hl=en&q=boobs' | grep -q 'safe=strict'
Result  : 0
Output  :
build_wget_command: wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://www.bing.com/search?q=boobs&adlt=off'

Client  : 192.168.56.200
Command : wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://www.bing.com/search?q=boobs&adlt=off' | grep -q 'adlt=off'
Result  : 0
Output  :
build_wget_command: wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://www.bing.com/search?q=boobs'

Client  : 192.168.56.200
Command : wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://www.bing.com/search?q=boobs' | grep -q 'adlt=strict'
Result  : 0
Output  :
build_wget_command: wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://search.yahoo.com/search?p=boobs&vm=p'

Client  : 192.168.56.200
Command : wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://search.yahoo.com/search?p=boobs&vm=p' | grep -q 'vm=p'
Result  : 0
Output  :
build_wget_command: wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://search.yahoo.com/search?p=boobs'

Client  : 192.168.56.200
Command : wget --no-hsts --inet4-only --quiet --tries=2 --timeout=5 --output-document=- --user-agent='Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7) Gecko/20040613 Firefox/0.8.0+)' 'http://search.yahoo.com/search?p=boobs' | grep -q 'vm=r'
Result  : 0
Output  :
ok

----------------------------------------------------------------------
Ran 1 test in 7.032s

OK
test_700_safe_search_enabled end   [2024-06-05T16:32:23]
======================================================================
~




```