### PR TITLE
NGFW-14626 Added apache status mod vulnerability test case

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_vulnerabilities.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_vulnerabilities.py
@@ -86,6 +86,16 @@ class VulnerabilitiesTests(NGFWTestCase):
                                                       extra_arguments=CURL_EXTRA_ARGS)
         result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
         assert (result == 404)
+    
+    def test_020_mod_apache_status(self):
+
+        URL = global_functions.get_http_url() + '/server-status'
+        CURL_EXTRA_ARGS = '-s -o /dev/null -w "%{http_code}"'
+
+        command = global_functions.build_curl_command(uri=URL, 
+                                                      extra_arguments=CURL_EXTRA_ARGS)
+        result = int(subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode('utf-8'))
+        assert (result == 404)
 
 
 test_registry.register_module("vulnerabilities", VulnerabilitiesTests)


### PR DESCRIPTION
Added `test_020_mod_apache_status` test case

```
test_020_mod_apache_status start [2024-06-05T20:23:38]
test_020_mod_apache_status (tests.test_vulnerabilities.VulnerabilitiesTests) ... build_curl_command: curl --silent --insecure --location --connect-timeout 10 --max-time 20 -s -o /dev/null -w "%{http_code}" 'http://192.168.2.1:80//server-status'
ok

----------------------------------------------------------------------
Ran 1 test in 0.047s

OK
test_020_mod_apache_status end   [2024-06-05T20:23:38]
======================================================================


== testing vulnerabilities ==
Test success : test_020_mod_apache_status [0.0s] 
== testing vulnerabilities [0.5s] ==

Tests complete. [0.5 seconds]
1 passed, 0 skipped, 0 failed

Total          :    1
Passed         :    1
Skipped        :    0
Passed/Skipped :    1 [100.00%]
Failed         :    0 [  0.00%]

More details found in /tmp/unittest.log