### PR TITLE
NGFW-14638: Tests which fill the disk do not clean up after end of test.

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/global_functions.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/global_functions.py
@@ -1098,7 +1098,6 @@ def get_wait_for_events(prefix="", report_category="", report_title="", report_c
         tries -= 1
         events = get_events(report_category, report_title, report_conditions, event_limit)
         assert events != None, f"{prefix} total events found"
-        print(events)
         found = check_events( events.get('list'), check_num_events, matches)
         if found is True:
             return True


### PR DESCRIPTION
The issue is with print(events) statement getting logged in /tmp/unittest.log for the test (test_100_blocked_queue) during get_wait_for_events method call which as 60 retries

As per the test there are 60  retries while finding the event in (get_wait_for_events method)  for each print(events) statement 12k space is getting consumed, local tests have shown 108k usage, since test bed has complex configuration retries before success, it must be consuming more.

Fix: Removed the print statement, 

Output before fix:
unittest.log  size 148K
![Screenshot from 2024-06-12 15-49-47](https://github.com/untangle/ngfw_src/assets/154513962/169ecfd9-b8c5-42c4-823a-fc3a58d64bf2)

Output after  adding removing print(events)  fix
unittest.log size is not increasing beyond 12k.
![image](https://github.com/untangle/ngfw_src/assets/154513962/dca8f290-9a6e-4452-a2c2-31384eb8d214)
![image](https://github.com/untangle/ngfw_src/assets/154513962/2ae894ce-abc6-4031-8c66-7ab0fce9b285)


