### PR TITLE
ngfw:14635 - Import/export option removed from users grid

### DIFF
--- a/uvm/servlets/admin/app/view/extra/Users.js
+++ b/uvm/servlets/admin/app/view/extra/Users.js
@@ -76,7 +76,7 @@ Ext.define('Ung.view.extra.Users', {
 
         bind: '{users}',
 
-        tbar: ['@add', '->', '@import', '@export'],
+        tbar: ['@add'],
         recordActions: ['edit', 'delete'],
         emptyRow: {
             username: '',


### PR DESCRIPTION
The Import/Export option is removed from the grid as it's not needed.

![image](https://github.com/untangle/ngfw_src/assets/154496583/c6268337-7289-4a9d-a1e7-97f428d15a31)
