### PR TITLE
ngfw : 14634 - Import/Export option removed from devices grid

### DIFF
--- a/uvm/servlets/admin/app/view/extra/Devices.js
+++ b/uvm/servlets/admin/app/view/extra/Devices.js
@@ -40,7 +40,7 @@ Ext.define('Ung.view.extra.Devices', {
             }
         },
 
-        tbar: ['@add', '->', '@import', '@export'],
+        tbar: ['@add'],
         recordActions: ['edit', 'delete'],
         emptyRow: {
             macAddress: '',


### PR DESCRIPTION
Import/Export option removed from devices grid as it's not required.

![image](https://github.com/untangle/ngfw_src/assets/154496583/e3a71520-281d-4c91-8e4b-a826b38c9c2e)
