### PR TITLE
NGFW-13774: Youtube retry option bypasses blocked search terms

### DIFF
--- a/web-filter-base/src/com/untangle/app/web_filter/DecisionEngine.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/DecisionEngine.java
@@ -551,7 +551,7 @@ public abstract class DecisionEngine
                 host = clientIp.getHostAddress();
             }
         }
-        String term = SearchEngine.getQueryTerm(clientIp, host, uri.toString(), header);
+        String term = SearchEngine.getQueryTerm(clientIp, host, uri.toString(), header, requestLine);
 
         if(isItemUnblocked(term, clientIp)) {
             if (logger.isDebugEnabled()) logger.debug("LOG: " + term + " in unblock list for " + clientIp);

--- a/web-filter-base/src/com/untangle/app/web_filter/SearchEngine.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/SearchEngine.java
@@ -48,7 +48,6 @@ public class SearchEngine
 
         SearchEngines = new ArrayList<Pattern>();
         SearchEngines.add(Pattern.compile(".*youtube\\.[a-z]+(\\.[a-z]+)?/results\\?search_query=([^&]+).*"));
-       // SearchEngines.add(Pattern.compile(".*youtube\\.[a-z]+(\\.[a-z]+)?/api/stats/qoe\\?*(\\?|&)q=([^&]+).*"));
         SearchEngines.add(Pattern.compile(".*(youtube|google)\\.[a-z]+(\\.[a-z]+)?/(complete/|)search.*(\\?|&)q=([^&]+).*"));
         SearchEngines.add(Pattern.compile(".*(youtube|google)\\.[a-z]+(\\.[a-z]+)?/gen_204(\\?|&)oq=([^&]+).*"));
         SearchEngines.add(Pattern.compile(".*ask\\.[a-z]+(\\.[a-z]+)?/web.*(\\?|&)q=([^&]+).*"));
@@ -134,7 +133,7 @@ public class SearchEngine
                 }
             }
         }
-
+        //For YouTube Retry button fetching URL from RequestLine referer to match with patterns
         if(host.contains(WebFilterDecisionEngine.YOUTUBE_HEADER_FIELD_FIND_NAME) ) {
            String referer = requestLine.getRequestLine().getHttpRequestEvent().getReferer();
             if (referer == null) {

--- a/web-filter-base/src/com/untangle/app/web_filter/SearchEngine.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/SearchEngine.java
@@ -48,6 +48,7 @@ public class SearchEngine
 
         SearchEngines = new ArrayList<Pattern>();
         SearchEngines.add(Pattern.compile(".*youtube\\.[a-z]+(\\.[a-z]+)?/results\\?search_query=([^&]+).*"));
+       // SearchEngines.add(Pattern.compile(".*youtube\\.[a-z]+(\\.[a-z]+)?/api/stats/qoe\\?*(\\?|&)q=([^&]+).*"));
         SearchEngines.add(Pattern.compile(".*(youtube|google)\\.[a-z]+(\\.[a-z]+)?/(complete/|)search.*(\\?|&)q=([^&]+).*"));
         SearchEngines.add(Pattern.compile(".*(youtube|google)\\.[a-z]+(\\.[a-z]+)?/gen_204(\\?|&)oq=([^&]+).*"));
         SearchEngines.add(Pattern.compile(".*ask\\.[a-z]+(\\.[a-z]+)?/web.*(\\?|&)q=([^&]+).*"));
@@ -80,10 +81,12 @@ public class SearchEngine
      *        URL URI.
      * @param header
      *        The header token
+    * @param requestLine
+     *        The requestLine token
      *
      * @return The query term
      */
-    public static String getQueryTerm(InetAddress clientIp, String host, String uri, HeaderToken header)
+    public static String getQueryTerm(InetAddress clientIp, String host, String uri, HeaderToken header, RequestLineToken requestLine)
     {
         boolean hostFound = false;
         for(String hostPiece : SearchEngineHosts){
@@ -132,6 +135,25 @@ public class SearchEngine
             }
         }
 
+        if(host.contains(WebFilterDecisionEngine.YOUTUBE_HEADER_FIELD_FIND_NAME) ) {
+           String referer = requestLine.getRequestLine().getHttpRequestEvent().getReferer();
+            if (referer == null) {
+                return term;
+            }
+            for (Pattern p : SearchEngines) {
+                Matcher m = p.matcher(referer);
+                if (m.matches()) {
+                    try {
+                        term = m.group(m.groupCount());
+                        term = URLDecoder.decode(term, "UTF-8");
+                    } catch (Exception e) {
+    
+                    }
+                    return term;
+                }
+            }
+            
+        }
         return term;
     }
 

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterDecisionEngine.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterDecisionEngine.java
@@ -114,7 +114,7 @@ public class WebFilterDecisionEngine extends DecisionEngine
                 }
             }
 
-            String term = SearchEngine.getQueryTerm(clientIp, host, uri.toString(), header);
+            String term = SearchEngine.getQueryTerm(clientIp, host, uri.toString(), header, requestLine);
 
             if (term != null) {
 


### PR DESCRIPTION
**ISSUE:**    Youtube allows you to "retry" and access blocked search results.

**ROOT_CAUSE:** Youtube retry URL does not contain the search term hence does not cause any blockage and blocked term can be accessed while retrying.

**FIX:** The search term is present in request payload hence adding one additional condition to fetch the term through referer and match the pattern.

**TESTING:**

-  You will get the option of retry for the blocked term only if you use the default root_cert.
              1.           Configure SSL Inspector with default root cert.
              2.           Configure Web Filter with search term blocks
              3.           Verify Safe Search is on in Web Filter
              4.           Install SSL Certificate on test computer behind NGFW
              5.           Test blocks on youtube.com search
              6.           When presented with "Connect to the internet; You're offline. Check your connection." Click the presented "RETRY" button.
              7.           Clicking retry should not load the blocked content.

                     
[Screencast from 13-06-24 06:27:08 PM IST.webm](https://github.com/untangle/ngfw_src/assets/155290371/aa42bdb5-92ec-4f93-bfb4-118c212b6c38)
