### PR TITLE
NGFW-14642: Updating test case to resolve invalid security nonce issue

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -2710,7 +2710,7 @@ class NetworkTests(NGFWTestCase):
         """
         Verify we can get vendors for the mac addresses
         """
-        deviceStatus = uvmContext.networkManager().getDeviceStatus()
+        deviceStatus = global_functions.uvmContext.networkManager().getDeviceStatus()
         interfaceList = deviceStatus["list"]
         if(len(interfaceList) <= 0): 
             raise unittest.SkipTest('Interface Not Known')
@@ -2719,7 +2719,7 @@ class NetworkTests(NGFWTestCase):
         mac_address_list = { 'javaClass': 'java.util.LinkedList', 'list': [interfaceList[0]["macAddress"]] }
 
         # Get vendor for mac Address
-        mac_address_vendor_map = uvmContext.networkManager().lookupMacVendorList(mac_address_list)
+        mac_address_vendor_map = global_functions.uvmContext.networkManager().lookupMacVendorList(mac_address_list)
         assert(len(mac_address_vendor_map) > 0)
 
     @classmethod


### PR DESCRIPTION
**ISSUE:** While running network test suite getting below error
```
 Verify we can get vendors for the mac addresses ... A little error:  {'msg': 'Invalid security nonce', 'code': 595}
ERROR

======================================================================
ERROR: test_705_mac_address_vendor_lookup_list (tests.test_network.NetworkTests)
Verify we can get vendors for the mac addresses

Traceback (most recent call last):
  File "/usr/lib//python3/dist-packages/tests/test_network.py", line 2611, in test_705_mac_address_vendor_lookup_list
    deviceStatus = uvmContext.networkManager().getDeviceStatus()
  File "/usr/lib//python3/dist-packages/jsonrpc/proxy.py", line 81, in call
    raise JSONRPCException(resp['error'])
jsonrpc.proxy.JSONRPCException
```

**FIXED:** Fixed the uvmContext from global_function resolved the issue.

**TEST:** Run network test suite It should not fail with Invalid security nonce issue.