### PR TITLE
NGFW-14662: firewall and email test failures

### DIFF
--- a/firewall/hier/usr/lib/python3/dist-packages/tests/test_firewall.py
+++ b/firewall/hier/usr/lib/python3/dist-packages/tests/test_firewall.py
@@ -7,7 +7,6 @@ import traceback
 import socket
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 import tests.global_functions as global_functions
@@ -101,7 +100,7 @@ class FirewallTests(NGFWTestCase):
         assert (result == 0)
 
     def test_011_license_valid(self):
-        assert(uvmContext.licenseManager().isLicenseValid(self.module_name()))
+        assert(global_functions.uvmContext.licenseManager().isLicenseValid(self.module_name()))
 
     # verify client is online
     def test_012_defaultIsPass(self):
@@ -532,9 +531,9 @@ class FirewallTests(NGFWTestCase):
     # verify bogus user agent match is blocked after setting agent
     @pytest.mark.failure_behind_ngfw
     def test_121_clientUserAgent2(self):
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         entry['httpUserAgent'] = "Mozilla foo bar"
-        uvmContext.hostTable().setHostTableEntry( remote_control.client_ip, entry )
+        global_functions.uvmContext.hostTable().setHostTableEntry( remote_control.client_ip, entry )
 
         rules_clear()
         rule_append( create_rule_single_condition( "HTTP_USER_AGENT", "*Mozilla*" ) )
@@ -542,7 +541,7 @@ class FirewallTests(NGFWTestCase):
         assert (result != 0)
 
         entry['httpUserAgent'] = None
-        uvmContext.hostTable().setHostTableEntry( remote_control.client_ip, entry )
+        global_functions.uvmContext.hostTable().setHostTableEntry( remote_control.client_ip, entry )
 
     # verify bogus hostname match not blocked
     def test_130_clientHostnameBogus(self):
@@ -718,7 +717,7 @@ class FirewallTests(NGFWTestCase):
 
     # verify block by client MAC
     def test_160_clientMacAddress(self):
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         if entry.get('macAddress') == None:
             raise unittest.SkipTest('MAC not known')
         mac = entry.get('macAddress')
@@ -730,7 +729,7 @@ class FirewallTests(NGFWTestCase):
 
     # verify block client MAC by *
     def test_161_clientMacAddressStar(self):
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         if entry.get('macAddress') == None:
             raise unittest.SkipTest('MAC not known')
 
@@ -741,7 +740,7 @@ class FirewallTests(NGFWTestCase):
 
     # verify block by client MAC in list
     def test_162_clientMacAddressMultiple(self):
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         if entry.get('macAddress') == None:
             raise unittest.SkipTest('MAC not known')
         mac = entry.get('macAddress')

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/common.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/common.py
@@ -143,6 +143,8 @@ class NGFWTestCase(TestCase):
             if cls._app or uvmContext.appManager().isInstantiated(name):
                 uvmContext.appManager().destroy(cls.get_app_id())
             cls._app = None
+        
+        cls.final_extra_tear_down()
 
     @classmethod
     def setup_class(cls):

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_email.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_email.py
@@ -11,7 +11,6 @@ import runtests
 import unittest
 import runtests.test_registry as test_registry
 
-from .global_functions import uvmContext
 from uvm import Uvm
 
 @pytest.mark.email_tests
@@ -27,7 +26,7 @@ class EmailTests(NGFWTestCase):
     @classmethod
     def initial_extra_setup(cls):
         if EmailTests.original_mail_settings is None:
-            EmailTests.original_mail_settings = uvmContext.mailSender().getSettings()
+            EmailTests.original_mail_settings = global_functions.uvmContext.mailSender().getSettings()
 
     @pytest.mark.slow
     def test_010_mail_send_method_modes(self):
@@ -84,6 +83,7 @@ class EmailTests(NGFWTestCase):
         exim_log_filename = "/var/log/exim4/mainlog"
 
         tester_email_address = "tester@domain.com"
+        orig_mail_settings = EmailTests.original_mail_settings
 
         # uvm_context_timeout = 60
         uvm_context_timeout = 30
@@ -199,10 +199,11 @@ class EmailTests(NGFWTestCase):
         assert found_event, "found event"
         assert found_delivery_attempt, "found delivery attempt"
         assert elapsed_time < uvm_context_timeout, f"network settings completed in under {uvm_context_timeout}s"
+        global_functions.uvmContext.mailSender().setSettings(orig_mail_settings)
 
     @classmethod
     def final_extra_tear_down(cls):
         if EmailTests.original_mail_settings is not None:
-            uvmContext.mailSender().getSettings(EmailTests.original_mail_settings)
+            global_functions.uvmContext.mailSender().setSettings(EmailTests.original_mail_settings)
 
 test_registry.register_module("email", EmailTests)


### PR DESCRIPTION
**Issue:** Restarting UVM test cases causes test failures because it changes the nonce ID for UvmContext. To maintain consistent nonce IDs, we are now retrieving the current reference of UvmContext from global_functions.

**Additional Fix:**

In the EMAIL - test_100_blocked_queue, the value was not restored to its original state. It is now being set back to its original value after the test run.
cls.final_extra_tear_down() was previously called only at the app level. It has been modified to be called at the class level so that the network and email suites can reach their final versions.

**Testing:**
Run email and firewall TCs it should be passed without any failure.

`/usr/bin/runtests -t email,firewall -h <Clinet_ID>`

![Screenshot from 2024-06-20 19-15-14](https://github.com/untangle/ngfw_src/assets/155290371/a2f011bd-24e6-4f5d-90b0-322a8bfd456a)
