### PR TITLE
ngfw-14648: FRR-VRRP: Support VRRP changes with FRR

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -1105,14 +1105,6 @@ class NetworkTests(NGFWTestCase):
         print(("using interface: %i %s\n" % (interfaceId, interface.get('name'))))
         # get next IP not used
 
-        # verify that this NIC is connected (otherwise keepalive wont claim address)
-        try:
-            result = subprocess.check_output("mii-tool " + interface.get('symbolicDev') + " 2>/dev/null", shell=True)
-            if not "link ok" in result:
-                raise unittest.SkipTest('LAN not connected')
-        except:
-            raise unittest.SkipTest('LAN not connected')
-
         ipStep = 1
         loopCounter = 10
         vrrpIP = None

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -599,11 +599,11 @@ public class NetworkManagerImpl implements NetworkManager
             logger.warn("VRRP alias not found on interface " + interfaceId );
             return false;
         }
-
-        String command = "ip add list " + intfSettings.getSymbolicDev() + " | grep '" + vrrpAddress.getHostAddress() + "/'";
+        //Frr uses vtysh to verify the status ,verify output result > 0 -> VRRP Master
+        String command = "vtysh -c 'show vrrp' | grep Backup";
         int retCode = UvmContextFactory.context().execManager().execResult( command );
 
-        if ( retCode == 0 )
+        if ( retCode > 0 )
             return true;
         else
             return false;


### PR DESCRIPTION
Modified test case to support frr with vrrp.
Dependant PR https://github.com/untangle/sync-settings/pull/837
PFA image

![Screenshot from 2024-06-21 16-22-32](https://github.com/untangle/ngfw_src/assets/154513962/387ae10d-a93d-4fe4-82e6-22fc4d863c15)


Manual Testing Configuration

- vrrp id will be same for both ngfw
- vrrp priority of primary should be greater than backup ngfw
- Add  VRRP alias as per the internal interface network and use ip which is free. Repeat the same for second ngfw.

Primary NGFW
Go to config/network/interfaces/internal/Redundant (VRRP) Configuration
Refer following image for configuration
![Screenshot from 2024-06-21 16-17-55](https://github.com/untangle/ngfw_src/assets/154513962/891d74c9-8453-4d51-a9b2-69b7b3d92352)

Backup NGFW
Go to config/network/interfaces/internal/Redundant (VRRP) Configuration
Refer following image for configuration
![Screenshot from 2024-06-21 16-21-15](https://github.com/untangle/ngfw_src/assets/154513962/99281bf5-b467-4121-8736-6d25a14f2433)

Result: 
Primary NGFW (is Master radio button) will become green where as for secondary it will become grey
run following command in shell,
vtysh -c "show vrrp"

Master output will be as following
![Screenshot from 2024-06-21 17-03-58](https://github.com/untangle/ngfw_src/assets/154513962/10aa3ef4-8e13-4ec5-bbf4-41a8fefcc21a)

Backup output will be as following 
![image](https://github.com/untangle/ngfw_src/assets/154513962/db230ce8-eced-4d6f-92cf-73734b049a95)
