### PR TITLE
ngfw-14666/ ngfw-14665/ ngfw-14670 / - Fixed teardown and initial setup failiure  for web-filter, network and Ipsec-vpn

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -1016,67 +1016,67 @@ class NetworkTests(NGFWTestCase):
         assert(global_functions.ftp_server == ip_address_foobar)
 
     # Test dynamic hostname
-    # @pytest.mark.slow
-    # def test_100_dynamic_dns(self):
-    #     if runtests.quick_tests_only:
-    #         raise unittest.SkipTest("Skipping a time consuming test")
-    #     netsettings = global_functions.uvmContext.networkManager().getNetworkSettings()
-    #     index_of_wans = global_functions.get_wan_tuples()
-    #     if (len(index_of_wans) > 1):
-    #         raise unittest.SkipTest("More than 1 WAN does not work with Dynamic DNS NGFW-5543")
+    @pytest.mark.slow
+    def test_100_dynamic_dns(self):
+        if runtests.quick_tests_only:
+            raise unittest.SkipTest("Skipping a time consuming test")
+        netsettings = global_functions.uvmContext.networkManager().getNetworkSettings()
+        index_of_wans = global_functions.get_wan_tuples()
+        if (len(index_of_wans) > 1):
+            raise unittest.SkipTest("More than 1 WAN does not work with Dynamic DNS NGFW-5543")
 
-    #     # if dynamic name is already in the ddclient cache with the same IP, dyndns is never updates
-    #     # we need a name never used or name with cache IP different than in the cache
-    #     outside_IP = global_functions.get_public_ip_address(base_URL=global_functions.TEST_SERVER_HOST,localcall=True)
+        # if dynamic name is already in the ddclient cache with the same IP, dyndns is never updates
+        # we need a name never used or name with cache IP different than in the cache
+        outside_IP = global_functions.get_public_ip_address(base_URL=global_functions.TEST_SERVER_HOST,localcall=True)
 
-    #     dyn_hostname = get_usable_name(outside_IP)
-    #     if dyn_hostname == "":
-    #         raise unittest.SkipTest("Skipping since all dyndns names already used")
-    #     else:
-    #         print(("Using name: %s" % dyn_hostname))
-    #     dyn_DNS_user_name, dyn_DNS_password = global_functions.get_live_account_info(dyn_hostname)
-    #     # account not found if message returned
-    #     if dyn_DNS_user_name == "message":
-    #         raise unittest.SkipTest("no dyn user")
+        dyn_hostname = get_usable_name(outside_IP)
+        if dyn_hostname == "":
+            raise unittest.SkipTest("Skipping since all dyndns names already used")
+        else:
+            print(("Using name: %s" % dyn_hostname))
+        dyn_DNS_user_name, dyn_DNS_password = global_functions.get_live_account_info(dyn_hostname)
+        # account not found if message returned
+        if dyn_DNS_user_name == "message":
+            raise unittest.SkipTest("no dyn user")
 
-    #     # Clear the ddclient cache and set DynDNS info
-    #     ddclient_cache_file = "/var/cache/ddclient/ddclient.cache"
-    #     if os.path.isfile(ddclient_cache_file):
-    #         os.remove(ddclient_cache_file)        
-    #     set_dyn_dns(dyn_DNS_user_name, dyn_DNS_password, dyn_hostname)
+        # Clear the ddclient cache and set DynDNS info
+        ddclient_cache_file = "/var/cache/ddclient/ddclient.cache"
+        if os.path.isfile(ddclient_cache_file):
+            os.remove(ddclient_cache_file)        
+        set_dyn_dns(dyn_DNS_user_name, dyn_DNS_password, dyn_hostname)
 
-    #     # myip.dnsomatic.com site is sometimes offline so use test. 
-    #     ddclient_file = "/etc/ddclient.conf"
-    #     with open(ddclient_file) as f:
-    #         newText=f.read().replace('myip.dnsomatic.com', 'test.untangle.com/cgi-bin/myipaddress.py')
-    #     with open(ddclient_file, "w") as f:
-    #         f.write(newText)        
-    #     # subprocess.check_output("sed -i \'s/myip.dnsomatic.com/test.untangle.com/\cgi-bin\/myipaddress.py/g\' /etc/ddclient.conf", shell=True)
-    #     subprocess.check_output("systemctl restart ddclient.service", shell=True)
+        # myip.dnsomatic.com site is sometimes offline so use test. 
+        ddclient_file = "/etc/ddclient.conf"
+        with open(ddclient_file) as f:
+            newText=f.read().replace('myip.dnsomatic.com', 'test.untangle.com/cgi-bin/myipaddress.py')
+        with open(ddclient_file, "w") as f:
+            f.write(newText)        
+        # subprocess.check_output("sed -i \'s/myip.dnsomatic.com/test.untangle.com/\cgi-bin\/myipaddress.py/g\' /etc/ddclient.conf", shell=True)
+        subprocess.check_output("systemctl restart ddclient.service", shell=True)
 
-    #     loop_counter = 80
-    #     dyn_IP_found = False
-    #     while loop_counter > 0 and not dyn_IP_found:
-    #         # run force to get it to run now
-    #         try: 
-    #             subprocess.call(["ddclient","--force"],stdout=subprocess.PIPE,stderr=subprocess.PIPE) # force it to run faster
-    #         except subprocess.CalledProcessError:
-    #             print(("Unexpected error:", sys.exc_info()))
-    #         except OSError:
-    #             pass # executable environment not ready
-    #         # time.sleep(10)
-    #         loop_counter -= 1
-    #         dynIP = global_functions.get_hostname_ip_address(hostname=dyn_hostname)
-    #         dynIP = dynIP.decode('utf8')
-    #         print(f"For dyn_hostname={dyn_hostname}, outside_IP={outside_IP}, current dynIP={dynIP}")
-    #         dyn_IP_found = False
-    #         if outside_IP == dynIP:
-    #             dyn_IP_found = True
-    #         else:
-    #             time.sleep(60)
+        loop_counter = 80
+        dyn_IP_found = False
+        while loop_counter > 0 and not dyn_IP_found:
+            # run force to get it to run now
+            try: 
+                subprocess.call(["ddclient","--force"],stdout=subprocess.PIPE,stderr=subprocess.PIPE) # force it to run faster
+            except subprocess.CalledProcessError:
+                print(("Unexpected error:", sys.exc_info()))
+            except OSError:
+                pass # executable environment not ready
+            # time.sleep(10)
+            loop_counter -= 1
+            dynIP = global_functions.get_hostname_ip_address(hostname=dyn_hostname)
+            dynIP = dynIP.decode('utf8')
+            print(f"For dyn_hostname={dyn_hostname}, outside_IP={outside_IP}, current dynIP={dynIP}")
+            dyn_IP_found = False
+            if outside_IP == dynIP:
+                dyn_IP_found = True
+            else:
+                time.sleep(60)
 
-    #     global_functions.uvmContext.networkManager().setNetworkSettings(orig_netsettings)
-    #     assert(dyn_IP_found)
+        global_functions.uvmContext.networkManager().setNetworkSettings(orig_netsettings)
+        assert(dyn_IP_found)
         
     # Test VRRP is active
     @pytest.mark.slow
@@ -2628,6 +2628,7 @@ class NetworkTests(NGFWTestCase):
 
         #*-snort* extension files are present
         snort_files = find_files(dir_path, search_string)
+        print(snort_files)
         assert len(snort_files) > 0
         # Set settings forces sync-settings call
         # Restore original settings to return to initial settings

--- a/web-filter-base/hier/usr/lib/python3/dist-packages/tests/test_web_filter_base.py
+++ b/web-filter-base/hier/usr/lib/python3/dist-packages/tests/test_web_filter_base.py
@@ -9,7 +9,6 @@ import unittest
 import datetime
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import runtests.remote_control as remote_control
 import tests.global_functions as global_functions
 
@@ -172,7 +171,7 @@ class WebFilterBaseTests(NGFWTestCase):
         assert (result == 0)
 
     def test_011_license_valid(self):
-        assert(uvmContext.licenseManager().isLicenseValid(self.module_name()))
+        assert(global_functions.uvmContext.licenseManager().isLicenseValid(self.module_name()))
 
     def test_012_test_untangle_com_reachable(self):
         result = self.get_web_request_results(url="http://test.untangle.com/test/testPage1.html", expected="text123")

--- a/web-filter/hier/usr/lib/python3/dist-packages/tests/test_web_filter.py
+++ b/web-filter/hier/usr/lib/python3/dist-packages/tests/test_web_filter.py
@@ -9,7 +9,6 @@ import copy
 
 import unittest
 import pytest
-from tests.global_functions import uvmContext
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 import tests.global_functions as global_functions
@@ -18,10 +17,10 @@ from .test_web_filter_base import WebFilterBaseTests
 
 
 def setHttpHttpsPorts(httpPort, httpsPort):
-    netsettings = uvmContext.networkManager().getNetworkSettings()
+    netsettings = global_functions.uvmContext.networkManager().getNetworkSettings()
     netsettings['httpPort'] = httpPort
     netsettings['httpsPort'] = httpsPort
-    uvmContext.networkManager().setNetworkSettings(netsettings)
+    global_functions.uvmContext.networkManager().setNetworkSettings(netsettings)
 
 #
 # Just extends the web filter base tests
@@ -747,7 +746,7 @@ class WebFilterTests(WebFilterBaseTests):
     def test_010_0000_rule_condition_host_quota_exceeded(self):
         "test HOST_QUOTA_EXCEEDED"
         global_functions.host_quota_give( 1000, 300 )
-        uvmContext.hostTable().decrementQuota( remote_control.client_ip, 10000 )
+        global_functions.uvmContext.hostTable().decrementQuota( remote_control.client_ip, 10000 )
         self.rule_add("HOST_QUOTA_EXCEEDED",None)
         result = self.get_web_request_results(url="http://test.untangle.com/test/testPage1.html", expected="blockpage")
         self.rules_clear()
@@ -765,7 +764,7 @@ class WebFilterTests(WebFilterBaseTests):
     def test_010_0000_rule_condition_client_quota_exceeded(self):
         "test CLIENT_QUOTA_EXCEEDED"
         global_functions.host_quota_give( 1000, 300 )
-        uvmContext.hostTable().decrementQuota( remote_control.client_ip, 10000 )
+        global_functions.uvmContext.hostTable().decrementQuota( remote_control.client_ip, 10000 )
         self.rule_add("CLIENT_QUOTA_EXCEEDED",None)
         result = self.get_web_request_results(url="http://test.untangle.com/test/testPage1.html", expected="blockpage")
         self.rules_clear()
@@ -791,7 +790,7 @@ class WebFilterTests(WebFilterBaseTests):
         "test USER_QUOTA_EXCEEDED"
         global_functions.host_username_set( remote_control.get_hostname() )
         global_functions.user_quota_give( remote_control.get_hostname(), 1000, 300 )
-        uvmContext.userTable().decrementQuota( remote_control.get_hostname(), 10000 )
+        global_functions.uvmContext.userTable().decrementQuota( remote_control.get_hostname(), 10000 )
         self.rule_add("USER_QUOTA_EXCEEDED",None)
         result = self.get_web_request_results(url="http://test.untangle.com/test/testPage1.html", expected="blockpage")
         self.rules_clear()
@@ -830,7 +829,7 @@ class WebFilterTests(WebFilterBaseTests):
     def test_010_0000_rule_condition_host_quota_attainment(self):
         "test HOST_QUOTA_ATTAINMENT"
         global_functions.host_quota_give( 1000, 300 )
-        uvmContext.hostTable().decrementQuota( remote_control.client_ip, 10000 )
+        global_functions.uvmContext.hostTable().decrementQuota( remote_control.client_ip, 10000 )
         self.rule_add("HOST_QUOTA_ATTAINMENT",">1.1")
         result = self.get_web_request_results(url="http://test.untangle.com/test/testPage1.html", expected="blockpage")
         assert (result == 0)
@@ -849,7 +848,7 @@ class WebFilterTests(WebFilterBaseTests):
     def test_010_0000_rule_condition_client_quota_attainment(self):
         "test CLIENT_QUOTA_ATTAINMENT"
         global_functions.host_quota_give( 1000, 300 )
-        uvmContext.hostTable().decrementQuota( remote_control.client_ip, 10000 )
+        global_functions.uvmContext.hostTable().decrementQuota( remote_control.client_ip, 10000 )
         self.rule_add("CLIENT_QUOTA_ATTAINMENT",">1.1")
         result = self.get_web_request_results(url="http://test.untangle.com/test/testPage1.html", expected="blockpage")
         self.rules_clear()
@@ -875,7 +874,7 @@ class WebFilterTests(WebFilterBaseTests):
         "test USER_QUOTA_ATTAINMENT"
         global_functions.host_username_set( remote_control.get_hostname() )
         global_functions.user_quota_give( remote_control.get_hostname(), 1000, 300 )
-        uvmContext.userTable().decrementQuota( remote_control.get_hostname(), 10000 )
+        global_functions.uvmContext.userTable().decrementQuota( remote_control.get_hostname(), 10000 )
         self.rule_add("USER_QUOTA_ATTAINMENT",">1.1")
         result = self.get_web_request_results(url="http://test.untangle.com/test/testPage1.html", expected="blockpage")
         self.rules_clear()
@@ -913,7 +912,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_host_mac_vendor(self):
         "test HOST_MAC_VENDOR"
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         vendor = entry.get('macVendor')
         if vendor == None:
             raise unittest.SkipTest('No MAC vendor')
@@ -932,7 +931,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_client_mac_vendor(self):
         "test CLIENT_MAC_VENDOR"
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         vendor = entry.get('macVendor')
         if vendor == None:
             raise unittest.SkipTest('No MAC vendor')
@@ -958,7 +957,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_server_mac_vendor_no_entry(self):
         "test SERVER_MAC_VENDOR if no host entry exists - * should not match null"
-        entry = uvmContext.hostTable().getHostTableEntry( socket.gethostbyname("test.untangle.com") )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( socket.gethostbyname("test.untangle.com") )
         if entry != None:
             raise unittest.SkipTest('Entry exists')
         self.rule_add("SERVER_MAC_VENDOR",'*')
@@ -968,7 +967,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_host_mac_vendor(self):
         "test HOST_MAC_VENDOR"
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         vendor = entry.get('macVendor')
         if vendor == None:
             raise unittest.SkipTest('No MAC vendor')
@@ -987,7 +986,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_client_mac_vendor(self):
         "test CLIENT_MAC_VENDOR"
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         vendor = entry.get('macVendor')
         if vendor == None:
             raise unittest.SkipTest('No MAC vendor')
@@ -1013,7 +1012,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_server_mac_vendor_no_entry(self):
         "test SERVER_MAC_VENDOR if no host entry exists - * should not match null"
-        entry = uvmContext.hostTable().getHostTableEntry( socket.gethostbyname("test.untangle.com") )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( socket.gethostbyname("test.untangle.com") )
         if entry != None:
             raise unittest.SkipTest('Entry exists')
         self.rule_add("SERVER_MAC_VENDOR",'*')
@@ -1023,7 +1022,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_host_mac(self):
         "test HOST_MAC"
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         mac = entry.get('macAddress')
         if mac == None:
             raise unittest.SkipTest('No MAC address')
@@ -1041,7 +1040,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_src_mac(self):
         "test SRC_MAC"
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         mac = entry.get('macAddress')
         if mac == None:
             raise unittest.SkipTest('No MAC address')
@@ -1066,7 +1065,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_dst_mac_no_entry(self):
         "test DST_MAC if no host entry exists - * should not match null"
-        entry = uvmContext.hostTable().getHostTableEntry( socket.gethostbyname("test.untangle.com") )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( socket.gethostbyname("test.untangle.com") )
         if entry != None:
             raise unittest.SkipTest('Entry exists')
         self.rule_add("DST_MAC",'*')
@@ -1240,7 +1239,7 @@ class WebFilterTests(WebFilterBaseTests):
 
     def test_010_0000_rule_condition_http_user_agent(self):
         "test HTTP_USER_AGENT"
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         if entry.get('httpUserAgent') == None or not('linux' in entry.get('httpUserAgent')):
             raise unittest.SkipTest('No usable user agent')
         self.rule_add("HTTP_USER_AGENT","*linux*")


### PR DESCRIPTION
Restarting UVM test cases causes test failures because it changes the nonce ID for UvmContext. To maintain consistent nonce IDs, we are now retrieving the current reference of UvmContext from global_functions.

**Testing:**
Run below testcase suites, none of testcase should be failed and skipped with below issues.
- skipped 'initial_setup exception:'
- A little error:  {'msg': 'Invalid security nonce', 'code': 595}
- Final_tear_down error.

`/usr/bin/runtests -t email,ipsec-vpn,network,web-filter,firewall -h  <Clinet_ID>
`



![Screenshot from 2024-06-24 14-41-19](https://github.com/untangle/ngfw_src/assets/155290371/1b20b313-cf24-4f64-9eed-886229685c37)
