### PR TITLE
ngfw-14673: Log4j Upgrade Enhancements: Analysis and implementation alternative of ThrowableRenderer

### DIFF
--- a/uvm/bootstrap/com/untangle/uvm/UvmContextSelector.java
+++ b/uvm/bootstrap/com/untangle/uvm/UvmContextSelector.java
@@ -35,8 +35,9 @@ public class UvmContextSelector implements ContextSelector {
     private static final String LOG4J_XML = "log4j2.xml";
     private static final String SYSLOG = "SYSLOG";
     private static final String LOCALHOST = "localhost";
-    private static final String APP_PATTERN_TEMPLATE = ": [%c{1}:%L] &lt;%X{SessionID}&gt; %-5p %m%n";
-    private static final String UVM_PATTERN_TEMPLATE = "uvm: [%c{1}:%L] %-5p %m%n";
+    private static final String APP_PATTERN_TEMPLATE = ": [%c{1}:%L] &lt;%X{SessionID}&gt; %-5p %m%n%uvm{CONTEXTNAME}";
+    private static final String UVM_PATTERN_TEMPLATE = "uvm: [%c{1}:%L] %-5p %m%n%uvm{CONTEXTNAME}";
+    private static final String CONTEXTNAME = "CONTEXTNAME";
 
     private static final UvmContextSelector INSTANCE;
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
@@ -203,13 +204,15 @@ public class UvmContextSelector implements ContextSelector {
                 Facility facility;
                 if (contextName != null && !contextName.equals(UVM_LOG)) {
                     newPatternLayout = PatternLayout.newBuilder()
-                        .withPattern(contextName + APP_PATTERN_TEMPLATE)
+                        .withPattern(contextName + APP_PATTERN_TEMPLATE.replaceAll(CONTEXTNAME, contextName))
+                        .withAlwaysWriteExceptions(false)
                         .withConfiguration(config)
                         .build();
                     facility = Facility.LOCAL1;
                 } else {
                     newPatternLayout = PatternLayout.newBuilder()
-                        .withPattern(UVM_PATTERN_TEMPLATE)
+                        .withPattern(UVM_PATTERN_TEMPLATE.replaceAll(CONTEXTNAME, contextName))
+                        .withAlwaysWriteExceptions(false)
                         .withConfiguration(config)
                         .build();
                     facility = Facility.LOCAL0;

--- a/uvm/bootstrap/com/untangle/uvm/UvmExceptionPatternConverter.java
+++ b/uvm/bootstrap/com/untangle/uvm/UvmExceptionPatternConverter.java
@@ -1,0 +1,64 @@
+/**
+ * $Id$
+ */
+package com.untangle.uvm;
+
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.pattern.ConverterKeys;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
+import org.apache.logging.log4j.core.pattern.PatternConverter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+/**
+ * This class converts exception stacktrace by adding the app name and formats it.
+ * The error message is supplied by either setting the system property
+ */
+@Plugin(name = "UvmExceptionPatternConverter", category = PatternConverter.CATEGORY)
+@ConverterKeys({"uvm"})
+public class UvmExceptionPatternConverter extends LogEventPatternConverter {
+
+    private final String prefix;
+    private final SimpleDateFormat dateFormat;
+    private static final String LOGGINGHOST = "localhost ";
+    private static final String DATETIMEPATTERN= "MMM dd HH:mm:ss";
+
+    /**
+     * @param name
+     * @param style
+     * @param prefix
+     */
+    protected UvmExceptionPatternConverter(String name, String style, String prefix) {
+        super(name, style);
+        this.prefix = prefix;
+        this.dateFormat = new SimpleDateFormat(DATETIMEPATTERN);
+    }
+
+    /**
+     * @param options
+     * @return  UvmExceptionPatternConverter      
+     */
+    public static UvmExceptionPatternConverter newInstance(String[] options) {
+        String prefix = (options != null && options.length > 0) ? options[0] : "";
+        return new UvmExceptionPatternConverter("uvm", "uvm", prefix);
+    }
+
+
+    /**
+     * @param event
+     * @param builder      
+     */
+    @Override
+    public void format(LogEvent event, StringBuilder builder) {
+        Throwable throwable = event.getThrown();
+        String timestamp = dateFormat.format(new Date(event.getInstant().getEpochMillisecond()));
+        if (throwable != null) {
+            builder.append(timestamp).append(" ").append(LOGGINGHOST).append(this.prefix).append(":      ").append(throwable).append(System.lineSeparator());
+            for (StackTraceElement element : throwable.getStackTrace()) {
+                builder.append(timestamp).append(" ").append(LOGGINGHOST).append(this.prefix).append(":      ").append(element.toString()).append(System.lineSeparator());
+            }
+        }
+    }
+
+}

--- a/uvm/hier/usr/share/untangle/conf/log4j2.xml
+++ b/uvm/hier/usr/share/untangle/conf/log4j2.xml
@@ -23,14 +23,16 @@
     <Syslog name="SYSLOG" host="localhost" port="514" protocol="UDP" facility="LOCAL0">
       <!-- <ThresholdFilter level="ALL"/> -->
       <PatternLayout>
-	      <pattern>uvm: [%c{1}:%L] %-5p %m%n</pattern>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+	      <pattern>uvm: [%c{1}:%L] %-5p %m%n%uvm{uvm}</pattern>
       </PatternLayout>
     </Syslog>
 
     <Syslog name="EVENTS" host="localhost" port="514" protocol="UDP" facility="LOCAL5">
       <ThresholdFilter level="ALL"/>
       <PatternLayout>
-	      <pattern>%-5p %m%n</pattern>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+	      <pattern>%-5p %m%n%uvm{uvm}</pattern>
       </PatternLayout>
     </Syslog>
 


### PR DESCRIPTION
The exception stacktraces were printed in following format,
![Screenshot from 2024-06-28 18-14-09](https://github.com/untangle/ngfw_src/assets/154513962/b6ee0967-1450-45e8-92ed-a0418632b329)

This was made possible by ThrowableInterface in log4j1.x, however in logj2.x this interface is deprecated.
LogEventPatternConverter needs to implemented to achieve the same in log4j2.x.

Dependent PR
https://github.com/untangle/ngfw_pkgs/pull/109

After changes PF screenshot, Added temporary custom error for testing
![image](https://github.com/untangle/ngfw_src/assets/154513962/f3b26952-f446-43a2-a139-8ae85e5befdd)
