### PR TITLE
NGFW-14717 Removed insecure flag while uploading backup file

### DIFF
--- a/configuration-backup/hier/usr/share/untangle/bin/configuration-backup-upload-backup.sh
+++ b/configuration-backup/hier/usr/share/untangle/bin/configuration-backup-upload-backup.sh
@@ -51,7 +51,7 @@ function err() {
 }
 
 function doHelp() {
-    echo "$0 -t <timeout> -u <URL> -k <uid> -f <file>"
+    echo "$0 -t <timeout> -u <URL> <uid> -f <file>"
     echo "Options:"
     echo "    -h       help"
     echo "    -v       verbose"
@@ -76,8 +76,8 @@ function callCurl() {
   md5=($(md5sum $1))
   version=($(cat /usr/share/untangle/lib/untangle-libuvm-api/VERSION))
   debug "Backup file MD5: $md5"
-  echo curl "$URL" -k -F uid="$SERVER_UID" -F uploadedfile=@$1 -F md5="$md5" -F version="$version" --dump-header $2 --max-time $TIMEOUT
-  curl "$URL" -k -F uid="$SERVER_UID" -F uploadedfile=@$1 -F md5="$md5" -F version="$version" --dump-header $2 --max-time $TIMEOUT > /dev/null 2>&1
+  echo curl "$URL" -F uid="$SERVER_UID" -F uploadedfile=@$1 -F md5="$md5" -F version="$version" --dump-header $2 --max-time $TIMEOUT
+  curl "$URL" -F uid="$SERVER_UID" -F uploadedfile=@$1 -F md5="$md5" -F version="$version" --dump-header $2 --max-time $TIMEOUT > /dev/null 2>&1
   return $?
 }
 


### PR DESCRIPTION
- We have removed `-k` flag while uploading the backup file to the backup server.
- I tried to do the MITM but it did not work with or without `-k` option.
```
└─$ sudo bettercap -iface eth0    
bettercap v2.32.0 (built for linux amd64 with go1.22.3) [type 'help' for a list of commands]

192.168.56.0/24 > 192.168.56.157  » [07:45:02] [sys.log] [inf] gateway monitor started ...
192.168.56.0/24 > 192.168.56.157  » set dns.spoof.all true
192.168.56.0/24 > 192.168.56.157  » set dns.spoof.domains boxbackup.untangle.com
192.168.56.0/24 > 192.168.56.157  » set dns.spoof.address 192.168.56.157
192.168.56.0/24 > 192.168.56.157  » dns.spoof on
[07:45:12] [sys.log] [inf] dns.spoof boxbackup.untangle.com -> 192.168.56.157
[07:45:12] [sys.log] [inf] dns.spoof enabling forwarding.
192.168.56.0/24 > 192.168.56.157  » [07:45:12] [sys.log] [inf] dns.spoof starting net.recon as a requirement for dns.spoof
192.168.56.0/24 > 192.168.56.157  » set arp.spoof.targets 192.168.56.156
192.168.56.0/24 > 192.168.56.157  » set arp.spoof.fullduplex true
192.168.56.0/24 > 192.168.56.157  » net.probe on
192.168.56.0/24 > 192.168.56.157  » [07:45:39] [sys.log] [inf] net.probe probing 256 addresses on 192.168.56.0/24
192.168.56.0/24 > 192.168.56.157  » [07:45:39] [endpoint.new] endpoint 192.168.56.1 detected as 0a:00:27:00:00:00.
192.168.56.0/24 > 192.168.56.157  » [07:45:41] [endpoint.new] endpoint 192.168.56.156 detected as 08:00:27:6a:5e:cd (PCS Computer Systems GmbH).
192.168.56.0/24 > 192.168.56.157  » arp.spoof on
192.168.56.0/24 > 192.168.56.157  » [07:45:53] [sys.log] [war] arp.spoof full duplex spoofing enabled, if the router has ARP spoofing mechanisms, the attack will fail.
192.168.56.0/24 > 192.168.56.157  » [07:45:53] [sys.log] [inf] arp.spoof arp spoofer started, probing 1 targets.
192.168.56.0/24 > 192.168.56.157  » [07:46:04] [sys.log] [inf] dns.spoof sending spoofed DNS reply for boxbackup.untangle.com (->192.168.56.157) to 192.168.56.156 : 08:00:27:6a:5e:cd (PCS Computer Systems GmbH) - client.example.com..
192.168.56.0/24 > 192.168.56.157  » [07:46:04] [sys.log] [inf] dns.spoof sending spoofed DNS reply for boxbackup.untangle.com (->192.168.56.157) to 192.168.56.156 : 08:00:27:6a:5e:cd (PCS Computer Systems GmbH) - client.example.com..
192.168.56.0/24 > 192.168.56.157  » [07:46:04] [sys.log] [inf] dns.spoof sending spoofed DNS reply for boxbackup.untangle.com (->192.168.56.157) to 192.168.56.157 : 08:00:27:d2:26:79 (PCS Computer Systems GmbH) - eth0.
192.168.56.0/24 > 192.168.56.157  » [07:46:04] [sys.log] [inf] dns.spoof sending spoofed DNS reply for boxbackup.untangle.com (->192.168.56.157) to 192.168.56.157 : 08:00:27:d2:26:79 (PCS Computer Systems GmbH) - eth0.
192.168.56.0/24 > 192.168.56.157  » [07:46:04] [sys.log] [inf] dns.spoof sending spoofed DNS reply for boxbackup.untangle.com (->192.168.56.157) to 192.168.56.157 : 08:00:27:d2:26:79 (PCS Computer Systems GmbH) - eth0.
192.168.56.0/24 > 192.168.56.157  » [07:46:04] [sys.log] [inf] dns.spoof sending spoofed DNS reply for boxbackup.untangle.com (->192.168.56.157) to 192.168.56.100 : 08:00:27:8a:5f:56 (PCS Computer Systems GmbH) - arista.example.com..
```

On the python server, did not get any logs for the file,
```
└─$ python3 server.py
 * Serving Flask app 'server'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on https://127.0.0.1:443
 * Running on https://192.168.56.157:443
Press CTRL+C to quit
```

For now, I hope removing the `-k` flag should avoid MITM attack.