### PR TITLE
NGFW-14711: Fixed report/csv deserializarion vulnerability

### DIFF
--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -1028,8 +1028,6 @@ class ReportsTests(NGFWTestCase):
         
         subprocess.call(global_functions.build_wget_command(output_file=csv_tmp, post_data=post_data, uri="http://localhost/admin/download"), shell=True)
         result = subprocess.check_output('wc -l /tmp/test_50_export_report_events.csv', shell=True)
-        print("           ")
-        print(result)
         print("Result of wc on %s : %s" % (csv_tmp,str(result)))
         assert(int.from_bytes(result,byteorder='little') > 3)
 

--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -16,6 +16,8 @@ import sys
 import unittest
 import pytest
 import datetime
+import urllib.parse
+import json
 
 from io import BytesIO as BytesIO
 from datetime import datetime
@@ -939,6 +941,61 @@ class ReportsTests(NGFWTestCase):
             
         assert(found_count == num_string_find)
 
+    def test_045_report_csv_vulnerability(self):
+        """
+        Test report CSV to only allow valid bean i.e ReportEntry
+        """
+        #invalid bean argument
+        arg2_invalid = {"javaClass": "com.untangle.uvm.LocalDirectoryImpl", "users": {"javaClass": "java.util.LinkedList", "list": [{"firstName": "khush", "lastName": "te9999jjt", "password": "", "passwordShaHash": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3", "javaClass": "com.untangle.uvm.LocalDirectoryUser", "expirationTime": 0, "passwordBase64Hash": "dGVzdA==", "passwordMd5Hash": "098f6bcd4621d373cade4e832627b4f6", "mfaEnabled": False, "email": "te@gmail.com", "twofactorSecretKey": "", "username": "test", "localEmpty": False, "localExpires": {"javaClass": "java.util.Date", "time": 1720107932503}, "localForever": True, "_id": "extModel916-1"}, {"username": "khush\" Injection:", "firstName": "khush", "lastName": "khush", "email": "khush@gmail.com", "password": "", "passwordBase64Hash": "YW1tYW1h", "twofactorSecretKey": "", "localExpires": {"javaClass": "java.util.Date", "time": 1720107817551}, "localForever": True, "localEmpty": True, "mfaEnabled": False, "expirationTime": 0, "javaClass": "com.untangle.uvm.LocalDirectoryUser", "markedForDelete": False, "markedForNew": True, "_id": "Ung.model.Rule-2"}]}}
+        #valid bean argument
+        arg2_valid = {"javaClass": "com.untangle.app.reports.ReportEntry", "displayOrder": 1010, "description": "Shows all scanned web requests.", "units": None, "orderByColumn": None, "title": "All Web Events", "colors": None, "enabled": True, "defaultColumns": ["time_stamp", "c_client_addr", "s_server_addr", "s_server_port", "username", "hostname", "host", "uri", "web_filter_blocked", "web_filter_flagged", "web_filter_reason", "web_filter_category"], "pieNumSlices": None, "seriesRenderer": None, "timeDataDynamicAggregationFunction": None, "pieStyle": None, "pieSumColumn": None, "timeDataDynamicAllowNull": None, "orderDesc": None, "table": "http_events", "approximation": None, "timeDataInterval": None, "timeStyle": None, "timeDataDynamicValue": None, "readOnly": True, "timeDataDynamicLimit": None, "timeDataDynamicColumn": None, "pieGroupColumn": None, "timeDataColumns": None, "textColumns": None, "category": "Web Filter", "conditions": [], "uniqueId": "web-filter-SRSZBBKXLN", "textString": None, "type": "EVENT_LIST", "localizedTitle": "All Web Events", "localizedDescription": "Shows all scanned web requests.", "slug": "all-web-events", "url": "web-filter/all-web-events", "icon": "fa-list-ul", "_id": "Ung.model.Report-390"}
+        arg3 = []
+        arg4 = "time_stamp,load_1,mem_free,disk_free"
+        arg5 = "1720463400000"
+        arg6 = "-1"
+
+        # Build the curl command for invalid arg2
+        curl_command_invalid = global_functions.build_curl_command(
+            uri="http://localhost/reports/csv",
+            user_agent="Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0",
+            extra_arguments=f"--data-raw 'type=eventLogExport&arg1=System-Server_Status_Events-09.07.2024-00%3A00-09.07.2024-18%3A08&arg2={urllib.parse.quote(json.dumps(arg2_invalid))}&arg3={urllib.parse.quote(json.dumps(arg3))}&arg4={arg4}&arg5={arg5}&arg6={arg6}'",
+            verbose=True
+        )
+
+        # Build the curl command for valid arg2
+        curl_command_valid = global_functions.build_curl_command(
+            uri="http://localhost/reports/csv",
+            user_agent="Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0",
+            extra_arguments=f"--data-raw 'type=eventLogExport&arg1=System-Server_Status_Events-09.07.2024-00%3A00-09.07.2024-18%3A08&arg2={urllib.parse.quote(json.dumps(arg2_valid))}&arg3={urllib.parse.quote(json.dumps(arg3))}&arg4={arg4}&arg5={arg5}&arg6={arg6}'",
+            verbose=True
+        )
+
+         # Execute curl commands and capture the output
+        try:
+            output_invalid = subprocess.check_output(curl_command_invalid, shell=True, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            output_invalid = e.output
+
+        try:
+            output_valid = subprocess.check_output(curl_command_valid, shell=True, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            output_valid = e.output
+
+        # Check for specific error message in outputs
+        error_message = "Internal Server Error - java.lang.RuntimeException: org.jabsorb.serializer.UnmarshallException: Failed to parse JSON bean has no matches"
+
+        # Test for invalid arg2
+        if error_message in output_invalid.decode('utf-8'):
+            print("Passed: Invalid jsonObject is not acceptable")
+        else:
+            assert False, "Invalid jsonObject should not be acceptable"
+
+        # Test for valid arg2
+        if error_message not in output_valid.decode('utf-8'):
+            print("Passed:: Valid jsonObject not forming any exception")
+        else:
+            assert False, "Valid jsonObject should not produce any error message"
+
     def test_050_export_report_events(self):
         """
         Test export of events to CSV file
@@ -971,6 +1028,8 @@ class ReportsTests(NGFWTestCase):
         
         subprocess.call(global_functions.build_wget_command(output_file=csv_tmp, post_data=post_data, uri="http://localhost/admin/download"), shell=True)
         result = subprocess.check_output('wc -l /tmp/test_50_export_report_events.csv', shell=True)
+        print("           ")
+        print(result)
         print("Result of wc on %s : %s" % (csv_tmp,str(result)))
         assert(int.from_bytes(result,byteorder='little') > 3)
 

--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -45,6 +45,7 @@ import com.untangle.uvm.app.HostnameLookup;
 import com.untangle.uvm.servlet.DownloadHandler;
 import com.untangle.uvm.servlet.UploadHandler;
 import com.untangle.uvm.util.I18nUtil;
+import com.untangle.uvm.util.ObjectMatcher;
 import com.untangle.uvm.app.AppBase;
 import com.untangle.uvm.vnet.PipelineConnector;
 import org.apache.commons.codec.binary.Base64;
@@ -1298,21 +1299,23 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
                 String arg5 = req.getParameter("arg5");
                 String arg6 = req.getParameter("arg6");
 
-                if ( "".equals(arg2) || arg2 == null )
+                if ( arg2 == null || "".equals(arg2))
                     throw new RuntimeException("Invalid arguments");
 
                 String name = arg1;
-                ReportEntry query = (ReportEntry) UvmContextFactory.context().getSerializer().fromJSON( arg2 );
+                ReportEntry query = null;
+                query = ObjectMatcher.parseJson(arg2,ReportEntry.class);
                 SqlCondition[] conditions;
                 String columnListStr = arg4;
 
                 Date startDate = getDate(arg5);
                 Date endDate = getDate(arg6);
 
-                if ( "".equals(arg3) || "[]".equals(arg3) || arg3 == null )
+                if ( arg3 == null || "".equals(arg3) || "[]".equals(arg3) )
                     conditions = null;
-                else
-                    conditions = (SqlCondition[]) UvmContextFactory.context().getSerializer().fromJSON( req.getParameter("arg3") );
+                else{
+                    conditions = ObjectMatcher.parseJsonArray(arg3, SqlCondition[].class);
+                }
 
                 if (name == null || query == null || columnListStr == null) {
                     logger.warn("Invalid parameters: " + name + " , " + query + " , " + columnListStr);

--- a/uvm/api/com/untangle/uvm/util/ObjectMatcher.java
+++ b/uvm/api/com/untangle/uvm/util/ObjectMatcher.java
@@ -1,0 +1,60 @@
+/**
+ * $Id$
+ */
+package com.untangle.uvm.util;
+
+import org.jabsorb.serializer.SerializerState;
+import org.jabsorb.serializer.UnmarshallException;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.untangle.uvm.UvmContextFactory;
+
+/**
+ * Utility class for parsing JSON strings and arrays into Java objects after bean validation.
+ */
+public class ObjectMatcher {
+    /**
+         * Parse the Json and check for bean equality
+         * @param json  The JSON string to parse
+         * @param clazz The class type to unmarshall the JSON into.
+         * @return The parsed Java object.
+         * @throws JSONException    If there is an error parsing the JSON.
+         * @throws UnmarshallException If there is an error unmarshalling the JSON into the specified class.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T parseJson(String json, Class<T> clazz) throws JSONException, UnmarshallException {
+        try {
+            SerializerState state = new SerializerState();
+            Object jsonObject = new JSONObject(json);
+            UvmContextFactory.context().getSerializer().tryUnmarshall(state, clazz, jsonObject);
+            return (T) UvmContextFactory.context().getSerializer().fromJSON(json);
+        } catch (UnmarshallException e) {
+            throw new UnmarshallException("Failed to parse JSON " + e.getMessage());
+        }
+    }
+
+    /**
+         * Parse the JsonArray and check for bean equality
+         * @param json The JSON array string to parse.
+         * @param arrayClazz The class type of the array elements to unmarshall the JSON into.
+         * @return The parsed array of Java objects.
+         * @throws JSONException    If there is an error parsing the JSON.
+         * @throws UnmarshallException If there is an error unmarshalling the JSON into the specified array class.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] parseJsonArray(String json, Class<T[]> arrayClazz) throws JSONException, UnmarshallException {
+        if (json == null || json.isEmpty() || "[]".equals(json)) {
+            return null;
+        }
+
+        try {
+            SerializerState state = new SerializerState();
+            Object jsonObject = new JSONObject(json);
+            UvmContextFactory.context().getSerializer().tryUnmarshall(state, arrayClazz, jsonObject);
+            return (T[]) UvmContextFactory.context().getSerializer().fromJSON(json);
+        }catch (UnmarshallException e) {
+            throw new UnmarshallException("Failed to parse JSON " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
**ISSUE:** /reports/csv endpoint is quite promising and might  prone to SQL Injection.

Fixed as discuused in https://awakesecurity.atlassian.net/wiki/spaces/ngfw/pages/2554527751/Arista+NG+Firewall+Authenticated+Jabsorb+Java+Unmarshalling+Vulnerability
Also added unit test cases for the same

**Test :** 
Run the POST request with invalid argument it should failed with exception given in below screenshots.

![Screenshot from 2024-07-10 20-01-27](https://github.com/untangle/ngfw_src/assets/155290371/408d21c8-b3cc-4916-afb0-661d82a07ede)
![Screenshot from 2024-07-10 20-01-19](https://github.com/untangle/ngfw_src/assets/155290371/2bffc7fd-5631-4ad9-920e-da9f9d62995a)


For valid data it should return valid response.

![Screenshot from 2024-07-10 20-31-00](https://github.com/untangle/ngfw_src/assets/155290371/cf0bb9fa-4c7e-4a41-bd79-6d384eb51ba6)
