### PR TITLE
NGFW-14712: Implementation of Vulnerability Fix for Networksettings and ExecuteManagerImpl Endpoint

### DIFF
--- a/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
@@ -16,10 +16,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Level;
 import org.jabsorb.JSONSerializer;
 import org.jabsorb.serializer.UnmarshallException;
+import org.json.JSONException;
 
 import com.untangle.uvm.ExecManager;
 import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.ExecManagerResultReader;
+import com.untangle.uvm.util.ObjectMatcher;
 
 /**
  * ExecManagerImpl is a simple manager for all exec() calls.
@@ -189,7 +191,7 @@ public class ExecManagerImpl implements ExecManager
             long t0 = System.currentTimeMillis();
             String line = in.readLine();
             Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-            ExecManagerResult result = (ExecManagerResult) serializer.fromJSON(line);
+            ExecManagerResult result  = ObjectMatcher.parseJson(line, ExecManagerResult.class); 
             long t1 = System.currentTimeMillis();
 
             if (result == null) {
@@ -212,7 +214,7 @@ public class ExecManagerImpl implements ExecManager
             logger.warn("Exception during ut-exec-launcher", exn);
             initDaemon();
             return new ExecManagerResult(-1, exn.toString());
-        } catch (UnmarshallException exn) {
+        } catch (JSONException | UnmarshallException exn) {
             logger.warn("Exception during ut-exec-launcher", exn);
             initDaemon();
             return new ExecManagerResult(-1, exn.toString());

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -36,8 +36,10 @@ import com.untangle.uvm.network.DynamicRouteNetwork;
 import com.untangle.uvm.network.DynamicRouteOspfArea;
 import com.untangle.uvm.network.DynamicRouteOspfInterface;
 import com.untangle.uvm.servlet.DownloadHandler;
+import com.untangle.uvm.util.ObjectMatcher;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jabsorb.serializer.UnmarshallException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -652,12 +654,17 @@ public class NetworkManagerImpl implements NetworkManager
         String output = UvmContextFactory.context().execManager().execOutput(deviceStatusScript + argStr);
         List<DeviceStatus> entryList = null;
         try {
-            entryList = (List<DeviceStatus>) ((UvmContextImpl)UvmContextFactory.context()).getSerializer().fromJSON(output);
-        } catch (Exception e) {
-            logger.warn("Unable to parse device status: ", e);
-            logger.warn("Unable to parse device status: " + output);
-            return null;
-        }
+            //expected Java class type
+            Class<List<DeviceStatus>> ListOfDeviceStatusClass = (Class<List<DeviceStatus>>) (Class<?>) List.class;
+            entryList = ObjectMatcher.parseJson(output, ListOfDeviceStatusClass); 
+            } catch (JSONException | UnmarshallException e) {
+                logger.warn("Unable to parse device status: ", e);
+                logger.warn("Unable to parse device status: " + output);
+                return null;
+            } catch (Exception e) {
+                logger.error("Unexpected exception while getting device status: ", e);
+                return null; 
+            }
         return entryList;
     }
     


### PR DESCRIPTION
There is no direct exposure for both the functions - getDeviceStatus() in NetworkManagerImpl and exec() in ExecManagerImpl, But still making deserialization process secure by apply check of tryUnmarshall.
 