### PR TITLE
NGFW-14710: Fixed Report Compilation Error

### DIFF
--- a/reports/servlets/reports/root/index.jsp
+++ b/reports/servlets/reports/root/index.jsp
@@ -1,4 +1,4 @@
-<%@ page language="java" import="com.untangle.app.reports.*,com.untangle.uvm.*,com.untangle.uvm.util.*,com.untangle.uvm.reports.*,com.untangle.uvm.app.AppSettings,com.untangle.uvm.app.*,com.untangle.uvm.vnet.*,org.apache.log4j.helpers.AbsoluteTimeDateFormat,java.util.Properties, java.util.Map, java.net.URL, java.io.PrintWriter, javax.naming.*"
+<%@ page language="java" import="com.untangle.app.reports.*,com.untangle.uvm.*,com.untangle.uvm.util.*,com.untangle.uvm.reports.*,com.untangle.uvm.app.AppSettings,com.untangle.uvm.app.*,com.untangle.uvm.vnet.*,java.util.Properties, java.util.Map, java.net.URL, java.io.PrintWriter, javax.naming.*"
 %><!DOCTYPE html>
 
 <%


### PR DESCRIPTION
**ISSUE:** While hitting reports (https://192.168.56.140/reports) link  and trying to logging in getting compilation error for `org.apache.log4j.helpers.AbsoluteTimeDateFormat` import statement as we have update log4j library.

**FIXED:** There is no such usage in ngfw_src library of this package, so removed the import statement.

**TEST:** 
- After fix no report UI should load properly. (https://server-ip/reports)
- Check for Console/UVM log date formate, it should ne remain same as previous log date formate.