### PR TITLE
 NGFW-14701: Fixed live-support test suite

### DIFF
--- a/live-support/hier/usr/lib/python3/dist-packages/tests/test_live_support.py
+++ b/live-support/hier/usr/lib/python3/dist-packages/tests/test_live_support.py
@@ -3,7 +3,7 @@
 import pytest
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
+import tests.global_functions as global_functions
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 
@@ -28,7 +28,7 @@ class LiveSupportTests(NGFWTestCase):
         assert (result == 0)
 
     def test_011_license_valid(self):
-        assert(uvmContext.licenseManager().isLicenseValid(self.module_name()))
+        assert(global_functions.uvmContext.licenseManager().isLicenseValid(self.module_name()))
 
 test_registry.register_module("live-support", LiveSupportTests)
 


### PR DESCRIPTION
Restarting UVM test cases causes test failures because it changes the nonce ID for UvmContext. To maintain consistent nonce IDs, we are now retrieving the current reference of UvmContext from global_functions.

Testing:
Run below testcase suites, none of testcase should be failed and skipped with below issues.
`/usr/bin/runtests -t  email,live-support -h client-IP
`skipped 'initial_setup exception:'
A little error: {'msg': 'Invalid security nonce', 'code': 595}
Final_tear_down error.
/usr/bin/runtests -t email,policy-manager -h <Clinet_ID>