### PR TITLE
NGFW-14721: Resolve additional SQL injection vulnerabilities

### DIFF
--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -230,6 +230,8 @@ Sql_field_injects = overrides.get(
             "character-casting": "chr(97)",
             "system-catalog": "from pg_catalog",
             "always-true": "or 1=1",
+            "lo_prefix_tables": "admin_logins RIGHT JOIN (SELECT lo_export('123456', '/var/lib/postgresql/custom.py') AS dummy_column) AS dummy ON 1 = 1 ",
+
         },
         "parameters": {
             "ReportEntry":{

--- a/reports/src/com/untangle/app/reports/ReportEntry.java
+++ b/reports/src/com/untangle/app/reports/ReportEntry.java
@@ -53,6 +53,21 @@ public class ReportEntry implements Serializable, JSONString
         Injections.add(Pattern.compile("(?i).*from\\s+pg_.*"));
         // Always true
         Injections.add(Pattern.compile("(?i).*OR\\s+(['\\w]+)=\\1.*"));
+        // patterns for classical SQL injection 1=1 , 2=2 with ON, OR, AND 
+        Injections.add(Pattern.compile(".*\\bOR\\b.*\\b\\d+=\\d+\\b.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*'\\s*OR\\s*'\\d+'=\\d+\\s*--.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*\\bON\\b\\s*\\d+\\s*=\\s*\\d+.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*\\bAND\\b.*\\b\\d+=\\d+\\b.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*UNION.*SELECT.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*EXEC\\s+.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*INSERT\\s+INTO.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*DROP\\s+TABLE.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*\\bUPDATE\\b.*\\bSET\\b.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*\\bDELETE\\b.*\\bFROM\\b.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*\\bCREATE\\b.*\\bTABLE\\b.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*\\bALTER\\b.*\\bTABLE\\b.*", Pattern.CASE_INSENSITIVE));
+        // pattern for lo_prefix function tables
+        Injections.add(Pattern.compile(".*\\blo_\\w+\\b.*", Pattern.CASE_INSENSITIVE)); 
     };
 
 


### PR DESCRIPTION
The 1=1 condition is used in SQL injection attacks to manipulate the logic of SQL queries. Attackers can use various SQL keywords in conjunction with 1=1 to exploit vulnerabilities. Some common keywords and techniques include:

Common SQL Keywords
OR: Used to create tautologies.
Example: username' OR 1=1 --
AND: Used to bypass conditions.
Example: username' AND 1=1 --
UNION: Used to combine the results of two queries.
Example: UNION SELECT username, password FROM users
SELECT: Used to retrieve data.
Example: SELECT * FROM users WHERE '1'='1
INSERT: Used to insert data.
Example: INSERT INTO users (username, password) VALUES ('admin', 'pass'); --
UPDATE: Used to update data.
Example: UPDATE users SET password='newpass' WHERE username='admin' AND 1=1
DELETE: Used to delete data.
Example: DELETE FROM users WHERE username='admin' AND 1=1
DROP: Used to drop tables or databases.
Example: DROP TABLE users; --
EXEC: Used to execute stored procedures or commands.
Example: EXEC sp_executesql N'SELECT * FROM users WHERE username = ''admin'' AND 1=1'
--: Used to comment out the rest of the SQL query.
Example: username' OR 1=1 --
/*: Used to comment out parts of the SQL query.
Example: username' OR 1=1 /*


Added regex to check  for lo_ prefix tables, inorder to stop sql injections

Added sql injection with lo_prefix in test case and ran the test.
![Screenshot from 2024-07-17 16-01-07](https://github.com/user-attachments/assets/d8c6934a-6cde-431b-9e0b-573382766301)

