### PR TITLE
Ngfw 14704- Fixed spam-blocker,syslog,threat-prevention suite failures

### DIFF
--- a/spam-blocker-base/hier/usr/lib/python3/dist-packages/tests/test_spam_blocker_base.py
+++ b/spam-blocker-base/hier/usr/lib/python3/dist-packages/tests/test_spam_blocker_base.py
@@ -5,7 +5,6 @@ import re
 import unittest
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 import tests.global_functions as global_functions
@@ -94,11 +93,11 @@ class SpamBlockerBaseTests(NGFWTestCase):
         global appData, appSP, appDataSP, appSSL, appSSLData, canRelay
 
         appData = cls._app.getSettings()
-        appSP = uvmContext.appManager().app(cls.appNameSpamCase())
+        appSP = global_functions.uvmContext.appManager().app(cls.appNameSpamCase())
         appDataSP = appSP.getSmtpSettings()
-        if uvmContext.appManager().isInstantiated(cls.appNameSSLInspector()):
+        if global_functions.uvmContext.appManager().isInstantiated(cls.appNameSSLInspector()):
             raise Exception('app %s already instantiated' % cls.appNameSSLInspector())
-        appSSL = uvmContext.appManager().instantiate(cls.appNameSSLInspector(), default_policy_id)
+        appSSL = global_functions.uvmContext.appManager().instantiate(cls.appNameSSLInspector(), default_policy_id)
         # appSSL.start() # leave app off. app doesn't auto-start
         appSSLData = appSSL.getSettings()
         try:
@@ -120,7 +119,7 @@ class SpamBlockerBaseTests(NGFWTestCase):
         assert (result == 0)
 
     def test_011_license_valid(self):
-        assert(uvmContext.licenseManager().isLicenseValid(self.shortName()))
+        assert(global_functions.uvmContext.licenseManager().isLicenseValid(self.shortName()))
 
     def test_020_smtpTest(self):
         if (not self.canRelay):
@@ -321,5 +320,5 @@ class SpamBlockerBaseTests(NGFWTestCase):
     def final_extra_tear_down(cls):
         global appSSL
         if appSSL != None:
-            uvmContext.appManager().destroy( appSSL.getAppSettings()["id"] )
+            global_functions.uvmContext.appManager().destroy( appSSL.getAppSettings()["id"] )
             appSSL = None

--- a/threat-prevention/hier/usr/lib/python3/dist-packages/tests/test_threat_prevention.py
+++ b/threat-prevention/hier/usr/lib/python3/dist-packages/tests/test_threat_prevention.py
@@ -7,7 +7,6 @@ import unittest
 import sys
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 import tests.global_functions as global_functions
@@ -106,7 +105,7 @@ class ThreatpreventionTests(NGFWTestCase):
         assert (result == 0)
             
     def test_011_license_valid(self):
-        assert(uvmContext.licenseManager().isLicenseValid(self.module_name()))
+        assert(global_functions.uvmContext.licenseManager().isLicenseValid(self.module_name()))
 
     @pytest.mark.failure_behind_pihole
     def test_020_basic_block(self):
@@ -176,7 +175,7 @@ class ThreatpreventionTests(NGFWTestCase):
         assert( found )
         
     def test_033_block_by_mac_address(self):
-        entry = uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
+        entry = global_functions.uvmContext.hostTable().getHostTableEntry( remote_control.client_ip )
         self.rules_clear()
         self.rule_add("DST_PORT","53",action="pass")  # allow DNS otherwise bridged configs fail
         self.rule_add("SRC_MAC",entry['macAddress'])

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
@@ -2,7 +2,6 @@ import copy
 import pytest
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import tests.global_functions as global_functions
 import runtests.test_registry as test_registry
 import runtests.remote_control as remote_control
@@ -25,21 +24,21 @@ class SysLogTests(NGFWTestCase):
         return "syslog"
     
     def test_050_disable_syslog(self):
-        syslogSettings = uvmContext.eventManager().getSettings()
+        syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
         syslogSettings["syslogEnabled"] = False
-        uvmContext.eventManager().setSettings( syslogSettings )
-        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        global_functions.uvmContext.eventManager().setSettings( syslogSettings )
+        syslogUpdatedSettings = global_functions.uvmContext.eventManager().getSettings()
         if "syslogServers" in syslogSettings.keys() and syslogSettings['syslogServers']:
             assert (len(syslogUpdatedSettings['syslogServers']['list']) == 0)
         else:
           #No Logservers configured
           pass
-        uvmContext.eventManager().setSettings(orig_settings)
+        global_functions.uvmContext.eventManager().setSettings(orig_settings)
 
     def test_050_enable_syslog(self):
         #covering scenario of setup where default syslog is enabled and configured
-        syslogSettings = uvmContext.eventManager().getSettings()
+        syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
         syslogSettings["syslogEnabled"] = True
         syslogSettings["syslogPort"] = 514
@@ -50,8 +49,8 @@ class SysLogTests(NGFWTestCase):
         for rule in syslogSettings['syslogRules']['list']:
             if "syslogServers" in  rule.keys():
                rule.pop("syslogServers")
-        uvmContext.eventManager().setSettings(syslogSettings)
-        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        global_functions.uvmContext.eventManager().setSettings(syslogSettings)
+        syslogUpdatedSettings = global_functions.uvmContext.eventManager().getSettings()
         assert (len(syslogUpdatedSettings['syslogServers']['list']) == 1)
         #check for description field populated in case of setup where syslog server is enabled
         assert("Default Syslog Server" == syslogUpdatedSettings['syslogServers']['list'][0]['description'])
@@ -59,33 +58,33 @@ class SysLogTests(NGFWTestCase):
         if "syslogServers" in syslogUpdatedSettings['syslogRules']['list'][0].keys() and syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']:
            syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].clear()
            syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'].append(2)
-        uvmContext.eventManager().setSettings(syslogUpdatedSettings)
-        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        global_functions.uvmContext.eventManager().setSettings(syslogUpdatedSettings)
+        syslogUpdatedSettings = global_functions.uvmContext.eventManager().getSettings()
         assert (len(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list']) == 1)
         #server ID should be updated to 2 for the syslogRule
         print(syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'])
         assert (syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'][0] == 2)
-        uvmContext.eventManager().setSettings(orig_settings)
+        global_functions.uvmContext.eventManager().setSettings(orig_settings)
 
     def test_050_enable_syslog_withouthostnameset(self):
         #covering scenario of setup where default syslog is enabled and sysloghost not set configured
-        syslogSettings = uvmContext.eventManager().getSettings()
+        syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
         syslogSettings["syslogEnabled"] = True
         syslogSettings["syslogPort"] = 514
         syslogSettings["syslogProtocol"] = "UDP"
         #Removed sysLogHost, initially sysloghostname is not set in backend, in UI its mandatory
         syslogSettings.pop("syslogHost", None)
-        uvmContext.eventManager().setSettings(syslogSettings)
-        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        global_functions.uvmContext.eventManager().setSettings(syslogSettings)
+        syslogUpdatedSettings = global_functions.uvmContext.eventManager().getSettings()
         assert(len(syslogSettings['syslogRules']['list'][0]['syslogServers']['list']) == 0)
         assert (len(syslogUpdatedSettings['syslogServers']['list']) == 0)
-        uvmContext.eventManager().setSettings(orig_settings)
+        global_functions.uvmContext.eventManager().setSettings(orig_settings)
 
 
     def test_050_multiple_syslogservers(self):
         initial_logservers = 0
-        syslogSettings = uvmContext.eventManager().getSettings()
+        syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
         syslogSettings["syslogEnabled"] = True
         if "syslogServers" not in syslogSettings.keys():
@@ -95,15 +94,15 @@ class SysLogTests(NGFWTestCase):
         syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER1)
         syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER2)
         syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER3)
-        uvmContext.eventManager().setSettings(syslogSettings)
-        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        global_functions.uvmContext.eventManager().setSettings(syslogSettings)
+        syslogUpdatedSettings = global_functions.uvmContext.eventManager().getSettings()
         assert (len(syslogUpdatedSettings['syslogServers']['list']) == initial_logservers + 3)
-        uvmContext.eventManager().setSettings(orig_settings)
+        global_functions.uvmContext.eventManager().setSettings(orig_settings)
 
 
     def test_050_delete_syslogservers(self):
         initial_logservers = 0
-        syslogSettings = uvmContext.eventManager().getSettings()
+        syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
         syslogSettings["syslogEnabled"] = True
         #Default setup list will not be present. UI payload will contain server list, need to generate for unittest
@@ -115,8 +114,8 @@ class SysLogTests(NGFWTestCase):
         syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER1)
         syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER2)
         syslogSettings['syslogServers']['list'].append(SYSLOG_SERVER3)
-        uvmContext.eventManager().setSettings(syslogSettings)
-        syslogUpdatedSettings = uvmContext.eventManager().getSettings()
+        global_functions.uvmContext.eventManager().setSettings(syslogSettings)
+        syslogUpdatedSettings = global_functions.uvmContext.eventManager().getSettings()
         assert (len(syslogUpdatedSettings['syslogServers']['list']) == initial_logservers +3)
         key = 'host'
         # Fetch Added SyslogServers
@@ -129,9 +128,9 @@ class SysLogTests(NGFWTestCase):
         for server in syslog_list:
            syslogUpdatedSettings['syslogServers']['list'].append(server)
         syslogUpdatedSettings['syslogServers']['list'].append(SYSLOG_SERVER4)
-        uvmContext.eventManager().setSettings(syslogUpdatedSettings)
+        global_functions.uvmContext.eventManager().setSettings(syslogUpdatedSettings)
         assert (len(syslogUpdatedSettings['syslogServers']['list']) == initial_logservers + 2)
-        uvmContext.eventManager().setSettings(orig_settings)
+        global_functions.uvmContext.eventManager().setSettings(orig_settings)
 
 
 


### PR DESCRIPTION
Restarting UVM test cases causes test failures because it changes the nonce ID for UvmContext. To maintain consistent nonce IDs, we are now retrieving the current reference of UvmContext from global_functions.

Testing:
Run ssl-inspector test suite, none of test cases should be failed and skipped with below issues.

**skipped 'initial_setup exception:'
A little error: {'msg': 'Invalid security nonce', 'code': 595}
Final_tear_down error.**

Command: /usr/bin/runtests -t email,spam-blocker,syslog,threat-prevention -h <Clinet_ID>