### PR TITLE
ngfw-14732 wireguard-vpn and web-cache test suite failure fix

### DIFF
--- a/web-cache/hier/usr/lib/python3/dist-packages/tests/test_web_cache.py
+++ b/web-cache/hier/usr/lib/python3/dist-packages/tests/test_web_cache.py
@@ -6,7 +6,6 @@ import pytest
 import runtests
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 import tests.global_functions as global_functions
@@ -33,7 +32,7 @@ class WebCacheTests(NGFWTestCase):
         assert (result == 0)
 
     def test_011_license_valid(self):
-        assert(uvmContext.licenseManager().isLicenseValid(self.module_name()))
+        assert(global_functions.uvmContext.licenseManager().isLicenseValid(self.module_name()))
 
     @pytest.mark.slow
     def test_020_testBasicWebCache(self):

--- a/webroot-base/hier/usr/lib/python3/dist-packages/tests/test_webroot.py
+++ b/webroot-base/hier/usr/lib/python3/dist-packages/tests/test_webroot.py
@@ -3,10 +3,8 @@ import re
 import subprocess
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
-import tests.global_functions as global_functions
 
 default_policy_id = 1
 app = None


### PR DESCRIPTION
Restarting UVM test cases causes test failures because it changes the nonce ID for UvmContext. To maintain consistent nonce IDs, we are now retrieving the current reference of UvmContext from global_functions.

Testing:
Run `wireguard-vpn` and `web-cache` test suite, none of test cases should be failed and skipped with below issues.

skipped 'initial_setup exception:'
A little error: {'msg': 'Invalid security nonce', 'code': 595}
Final_tear_down error.

Commands: `/usr/bin/runtests -t email,wireguard-vpn -h <Clinet_ID>` ,  `/usr/bin/runtests -t email,web-cache -h <Clinet_ID>`