### PR TITLE
ngfw-14737 intfc -> dhcp configuration window UI Issue

### DIFF
--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -1026,6 +1026,7 @@ Ext.define('Ung.config.network.Interface', {
                 }]
             },{
                 xtype: 'container',
+                itemId: 'intfdhcpserver',
                 flex: 1,
                 padding: 10,
                 scrollable: 'y',

--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -53,7 +53,7 @@ Ext.define('Ung.config.network.MainController', {
     },
 
     validateRange: function () {
-        var rangeEnd = this.getView().up('container').down('[itemId=rangeEnd]');
+        var rangeEnd = this.getView().down('container[itemId=intfdhcpserver]').down('[itemId=rangeEnd]');
         if(rangeEnd.getValue() !== "" ) rangeEnd.isValid();
     },
 


### PR DESCRIPTION
**Changes:** Modified component query code in `validateRange` method for `rangeEnd` property of Add/Edit Interface --> DHCP Configuration.

The old query was selecting different rangeEnd property from DHCP Server Tab and hence javascript exception.

**Local Testing Screenshots:**

Verified on chrome and firefox web browsers.

![Screenshot from 2024-07-23 16-54-52](https://github.com/user-attachments/assets/516e1b3a-a372-40e1-a1bf-95be4c4aff98)
----------------------------------------------
![Screenshot from 2024-07-23 16-54-19](https://github.com/user-attachments/assets/470a1f71-99ae-49c5-9a3a-752d5c8436cc)
----------------------------------------------
![Screenshot from 2024-07-23 16-54-26](https://github.com/user-attachments/assets/c3f8b1e4-7c16-491c-8d4c-0674510421f6)
----------------------------------------------
![Screenshot from 2024-07-23 16-54-32](https://github.com/user-attachments/assets/27f9672f-17a1-4dfc-ad36-3e50206f2ed9)


