### PR TITLE
ngfe-14703 : Fixed test suites failure for shield, test_smtp and test_wizard

### DIFF
--- a/shield/hier/usr/lib/python3/dist-packages/tests/test_shield.py
+++ b/shield/hier/usr/lib/python3/dist-packages/tests/test_shield.py
@@ -6,7 +6,6 @@ import unittest
 import pytest
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 import tests.global_functions as global_functions
@@ -46,14 +45,14 @@ class ShieldTests(NGFWTestCase):
         assert (result == 0)
 
     def test_011_license_valid(self):
-        assert(uvmContext.licenseManager().isLicenseValid(self.module_name()))
+        assert(global_functions.uvmContext.licenseManager().isLicenseValid(self.module_name()))
 
     def test_020_shieldDetectsNmap(self):
         # enable logging of blocked settings
-        netsettings = uvmContext.networkManager().getNetworkSettings()
+        netsettings = global_functions.uvmContext.networkManager().getNetworkSettings()
         netsettings['logBlockedSessions'] = True
         netsettings['logBypassedSessions'] = True
-        uvmContext.networkManager().setNetworkSettings(netsettings)
+        global_functions.uvmContext.networkManager().setNetworkSettings(netsettings)
 
         settings = app.getSettings()
         settings['shieldEnabled'] = True
@@ -72,10 +71,10 @@ class ShieldTests(NGFWTestCase):
 
     def test_021_shieldOffNmap(self):
         # enable logging of blocked settings
-        netsettings = uvmContext.networkManager().getNetworkSettings()
+        netsettings = global_functions.uvmContext.networkManager().getNetworkSettings()
         netsettings['logBlockedSessions'] = True
         netsettings['logBypassedSessions'] = True
-        uvmContext.networkManager().setNetworkSettings(netsettings)
+        global_functions.uvmContext.networkManager().setNetworkSettings(netsettings)
 
         settings = app.getSettings()
         settings['shieldEnabled'] = False

--- a/smtp-casing/hier/usr/lib/python3/dist-packages/tests/test_smtp.py
+++ b/smtp-casing/hier/usr/lib/python3/dist-packages/tests/test_smtp.py
@@ -5,7 +5,6 @@ import pytest
 
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 import tests.global_functions as global_functions

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_wizard.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_wizard.py
@@ -2,9 +2,9 @@ import pytest
 import re
 
 from tests.common import NGFWTestCase
-from tests.global_functions import uvmContext
 import runtests.test_registry as test_registry
 import runtests.remote_control as remote_control
+import tests.global_functions as global_functions
 
 @pytest.mark.setup_wizard
 class SetupWizard(NGFWTestCase):
@@ -21,11 +21,11 @@ class SetupWizard(NGFWTestCase):
 
     # Checks the oem url and license agreement url
     def test_020_about_license_agreement(self):
-        oem_url = uvmContext.oemManager().getOemUrl()
+        oem_url = global_functions.uvmContext.oemManager().getOemUrl()
         match = re.search('^.*edge.arista.com$', oem_url)
         assert(match)
         
-        license_url = uvmContext.oemManager().getLicenseAgreementUrl();
+        license_url = global_functions.uvmContext.oemManager().getLicenseAgreementUrl();
         match = re.search('^.*edge.arista.com/legal$', license_url)
         assert(match)
 


### PR DESCRIPTION
Restarting UVM test cases causes test failures because it changes the nonce ID for UvmContext. To maintain consistent nonce IDs, we are now retrieving the current reference of UvmContext from global_functions.

Testing:
Run shield,test-smtp,test-wizard  test suite, none of test cases should be failed and skipped with below issues.

skipped 'initial_setup exception:'
A little error: {'msg': 'Invalid security nonce', 'code': 595}
Final_tear_down error.

Command: /usr/bin/runtests -t email,shield,test-smtp,test-wizard -h <Clinet_ID>