### PR TITLE
ngfw-14745 log4j upgrade escape characters issue fix

### DIFF
--- a/uvm/bootstrap/com/untangle/uvm/UvmContextSelector.java
+++ b/uvm/bootstrap/com/untangle/uvm/UvmContextSelector.java
@@ -35,7 +35,7 @@ public class UvmContextSelector implements ContextSelector {
     private static final String LOG4J_XML = "log4j2.xml";
     private static final String SYSLOG = "SYSLOG";
     private static final String LOCALHOST = "localhost";
-    private static final String APP_PATTERN_TEMPLATE = "CONTEXTNAME: [%c{1}] &lt;%X{SessionID}&gt; %-5p %m%n%uvm{CONTEXTNAME}";
+    private static final String APP_PATTERN_TEMPLATE = "CONTEXTNAME: [%c{1}] <%X{SessionID}> %-5p %m%n%uvm{CONTEXTNAME}";
     private static final String UVM_PATTERN_TEMPLATE = "uvm: [%c{1}] %-5p %m%n%uvm{CONTEXTNAME}";
     private static final String CONTEXTNAME = "CONTEXTNAME";
 


### PR DESCRIPTION
**Changes:** We can directly use < and > in Log4j 2.x `PatternLayout` without them being escaped. and no need to use `&lt;` and `&gt;`

**Local Testing:** 
Logs in app log file does not contain `&lt;` and `&gt;` symbols now.

![Screenshot from 2024-07-24 18-23-12](https://github.com/user-attachments/assets/b6a24b87-a16e-4a69-962f-f2bb1a1ee13c)
