### PR TITLE
NGFW-14754 Preventing metrics API call after server connection is lost

### DIFF
--- a/uvm/js/common/util/Metrics.js
+++ b/uvm/js/common/util/Metrics.js
@@ -23,6 +23,7 @@ Ext.define('Ung.util.Metrics', {
     },
 
     run: function () {
+        var me = this;
         var data = [];
         Rpc.asyncData('rpc.metricManager.getMetricsAndStats')
         .then( function(result){
@@ -44,6 +45,9 @@ Ext.define('Ung.util.Metrics', {
 
             Ext.getStore('metrics').loadData(data);
         },function(ex){
+            if (Util.isServerConnectionLost(ex)) {
+                me.stop();
+            }
             Util.handleException(ex);
         });
     }

--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -260,6 +260,17 @@ Ext.define('Ung.util.Util', {
         location.reload();
     },
 
+    isServerConnectionLost: function (exception) {
+        return exception.code == 550 || exception.code == 12029 || exception.code == 12019 || exception.code == 0 ||
+        /* handle connection lost (this happens on windows only for some reason) */
+        (exception.name == 'JSONRpcClientException' && exception.fileName != null && exception.fileName.indexOf('jsonrpc') != -1) ||
+        /* special text for "method not found" and "Service Temporarily Unavailable" */
+        (exception.message && exception.message.indexOf('method not found') != -1) ||
+        (exception.message && exception.message.indexOf('Service Unavailable') != -1) ||
+        (exception.message && exception.message.indexOf('Service Temporarily Unavailable') != -1) ||
+        (exception.message && exception.message.indexOf('This application is not currently available') != -1);
+    },
+
     handleException: function (exception) {
         if (Util.ignoreExceptions)
             return;
@@ -309,14 +320,7 @@ Ext.define('Ung.util.Util', {
         }
 
         /* handle connection lost */
-        if( exception.code==550 || exception.code == 12029 || exception.code == 12019 || exception.code == 0 ||
-            /* handle connection lost (this happens on windows only for some reason) */
-            (exception.name == "JSONRpcClientException" && exception.fileName != null && exception.fileName.indexOf("jsonrpc") != -1) ||
-            /* special text for "method not found" and "Service Temporarily Unavailable" */
-            (exception.message && exception.message.indexOf("method not found") != -1) ||
-            (exception.message && exception.message.indexOf("Service Unavailable") != -1) ||
-            (exception.message && exception.message.indexOf("Service Temporarily Unavailable") != -1) ||
-            (exception.message && exception.message.indexOf("This application is not currently available") != -1)) {
+        if( Util.isServerConnectionLost(exception)) {
             message  = "The connection to the server has been lost.".t() + "<br/>";
             message += "Press OK to return to the login page.".t() + "<br/>";
             Util.ignoreExceptions = true;


### PR DESCRIPTION
We are no longer making any API call (especially metrics API) after server connection is lost.
This will prevent any request reaching to the sslrealy server when used from Remote Session.
![Screenshot from 2024-07-29 11-12-49](https://github.com/user-attachments/assets/c11f238d-4665-4f54-b64c-67c8a9383409)
