### PR TITLE
ngfw-14744 removed captive portal custom page from UI

### DIFF
--- a/captive-portal/js/MainController.js
+++ b/captive-portal/js/MainController.js
@@ -112,7 +112,7 @@ Ext.define('Ung.apps.captive-portal.MainController', {
 
         if ( (pagetype == 'CUSTOM') && ((custfile == null) || (custfile.length === 0)) ) {
             Ext.MessageBox.alert('Missing Custom Captive Page'.t(),
-                'You must upload a custom captive page to use this feature.'.t());
+                'Custom captive portal has been deprecated. Switch to Basic Message or Basic Logic Configuration.'.t());
             return;
         }
 
@@ -160,45 +160,6 @@ Ext.define('Ung.apps.captive-portal.MainController', {
 
     showMissingServiceWarning: function() {
         Ext.MessageBox.alert('Service Not Installed'.t(), 'The Directory Connector application must be installed to use this feature.'.t());
-    },
-
-    uploadCustomFile: function(cmp) {
-        var form = Ext.ComponentQuery.query('form[name=upload_form]')[0];
-        var file = Ext.ComponentQuery.query('textfield[name=upload_file]')[0].value;
-        if ( file == null || file.length === 0 ) {
-            Ext.MessageBox.alert('Select File'.t(), 'Please choose a file to upload.'.t());
-            return;
-            }
-        form.submit({
-            url: "upload",
-            success: Ext.bind(function( form, action ) {
-                Ext.MessageBox.alert('Custom Page Upload Success'.t(), action.result.msg);
-                this.getViewModel().set('settings.customFilename', action.result.msg);
-                this.setSettings();
-            }, this),
-            failure: Ext.bind(function( form, action ) {
-                Ext.MessageBox.alert('Custom Page Upload Failure'.t(), action.result.msg);
-            }, this)
-        });
-    },
-
-    removeCustomFile: function(cmp) {
-        var form = Ext.ComponentQuery.query('form[name=remove_form]')[0];
-        var file = Ext.ComponentQuery.query('textfield[name=custom_file]')[0].value;
-        if ( file == null || file.length === 0 ) {
-            return;
-            }
-        form.submit({
-            url: "upload",
-            success: Ext.bind(function( form, action ) {
-                Ext.MessageBox.alert('Custom Page Remove Success'.t(), action.result.msg);
-                this.getViewModel().set('settings.customFilename', null);
-                this.setSettings();
-            }, this),
-            failure: Ext.bind(function( form, action ) {
-                Ext.MessageBox.alert('Custom Page Remove Failure'.t(), action.result.msg);
-            }, this)
-        });
     },
 
     logoutUser: function(view, row, col, item, e, record) {

--- a/captive-portal/js/MainController.js
+++ b/captive-portal/js/MainController.js
@@ -107,6 +107,7 @@ Ext.define('Ung.apps.captive-portal.MainController', {
             return;
         }
 
+        // Below custom page condition can be removed when all users have upgraded to v17.2 and no user is having page type - custom
         var custfile = this.getViewModel().get('settings.customFilename');
         var pagetype = vm.get('settings.pageType');
 

--- a/captive-portal/js/view/CaptivePage.js
+++ b/captive-portal/js/view/CaptivePage.js
@@ -28,16 +28,26 @@ Ext.define('Ung.apps.captive-portal.view.CaptivePage', {
         type: 'vbox'
     },
 
+    tbar: [{
+        xtype: 'tbtext',
+        padding: '8 5',
+        style: { fontSize: '12px' },
+        hidden: true,
+        bind: {
+            hidden: '{settings.pageType !== "CUSTOM"}',
+        },
+        html: '<i class="fa fa-exclamation-triangle" style="color: red;"></i> ' + 'Custom captive portal has been deprecated. Switch to Basic Message or Basic Logic Configuration.'.t()
+    }],
+
     items: [{
         xtype: 'radiogroup',
         margin: '0 0 20 0',
         bind: '{settings.pageType}',
         simpleValue: true,
-        columns: 3,
+        columns: 2,
         items: [
             { boxLabel: '<strong>' + 'Basic Message'.t() + '</strong>', inputValue: 'BASIC_MESSAGE', width: 150 },
             { boxLabel: '<strong>' + 'Basic Login'.t() + '</strong>', inputValue: 'BASIC_LOGIN', width: 150 },
-            { boxLabel: '<strong>' + 'Custom'.t() + '</strong>', inputValue: 'CUSTOM', width: 150 },
             { xtype: 'button', iconCls: 'fa fa-eye', text: 'Preview Captive Portal Page'.t(), margin: '10 0 0 0', handler: 'previewCaptivePage' }
         ]
     }, {
@@ -120,73 +130,6 @@ Ext.define('Ung.apps.captive-portal.view.CaptivePage', {
             fieldLabel: 'Lower Text'.t(),
             width: 600,
             bind: '{settings.basicLoginFooter}'
-        }]
-    }, {
-        xtype: 'fieldset',
-        width: '100%',
-        title: 'Captive Portal Page Configuration'.t(),
-        padding: 10,
-        hidden: true,
-        bind: {
-            hidden: '{settings.pageType !== "CUSTOM"}'
-        },
-        items: [{
-            xtype: 'form',
-            name: 'upload_form',
-            border: false,
-            margin: '0 0 0 0',
-            items: [{
-                xtype: 'fileuploadfield',
-                name: 'upload_file',
-                buttonText: 'Upload Custom Captive Page ZIP File'.t(),
-                buttonOnly: true,
-                listeners: { 'change': 'uploadCustomFile' }
-            },{
-                xtype: 'hidden',
-                name: 'type',
-                value: 'CaptivePortal/custom_upload'
-            },{
-                xtype: 'hidden',
-                name: 'argument',
-                bind: {
-                    value: '{instance.id}'
-                }
-            }]
-        }, {
-            xtype: 'form',
-            name: 'remove_form',
-            border: false,
-            margin: '10 0 0 0',
-            items: [{
-                xtype: 'textfield',
-                fieldLabel: 'Active Custom File'.t(),
-                labelAlign: 'top',
-                readOnly: true,
-                name: 'custom_file',
-                bind: '{settings.customFilename}',
-                width: 500
-            },{
-                xtype: 'fileuploadfield',
-                name: 'remove_file',
-                allowBlank: true,
-                hidden: true
-            },{
-                xtype: 'hidden',
-                name: 'type',
-                value: 'CaptivePortal/custom_remove'
-            },{
-                xtype: 'hidden',
-                name: 'argument',
-                bind: {
-                    value: '{instance.id}'
-                }
-            }, {
-                xtype: 'button',
-                formBind: true,
-                name: 'remove',
-                text: 'Remove Custom File'.t(),
-                handler: 'removeCustomFile'
-            }]
         }]
     }, {
         xtype: 'fieldset',

--- a/captive-portal/js/view/CaptivePage.js
+++ b/captive-portal/js/view/CaptivePage.js
@@ -28,6 +28,7 @@ Ext.define('Ung.apps.captive-portal.view.CaptivePage', {
         type: 'vbox'
     },
 
+    // tbar can be removed when all users have upgraded to v17.2 and no user is having page type - custom
     tbar: [{
         xtype: 'tbtext',
         padding: '8 5',


### PR DESCRIPTION
**Changes:** 

1. Removed captive portal custom page configuration from UI
2. For users using custom page added a message in tab bar `Custom captive portal has been deprecated. Switch to Basic Message or Basic Logic Configuration.`
3. If user doesn't switch from Cutom page configuration and clicks on `Preview Captive Portal Page` button and does not have custom page uploaded earlier will get above message in `Missing Custom Captive Page` Message box instead of `You must upload a custom captive page to use this feature.`

**Local Testing:**

- For users not using custom page for captive portal will see captive page tab as shown below.
  
  ![Screenshot from 2024-07-29 20-46-43](https://github.com/user-attachments/assets/35ca93bd-2051-41de-876e-05e12a00a9b7)

-----------------------------------------------------------

- For users already using custom page for captive portal and having `settings.pageType == "CUSTOM"` will see captive page tab as shown below.
  
  ![Screenshot from 2024-07-29 19-59-59](https://github.com/user-attachments/assets/547a4df7-dd0a-4f86-b48b-ba740f1f7c64)


  If user does not switch from custom configuration to any other configuration, clicks on `Preview Captive Portal Page` button and does not have custom page uploaded will see message box as shown below.
  
  ![Screenshot from 2024-07-29 20-18-15](https://github.com/user-attachments/assets/d8f48c7d-9fea-4fc1-b484-8c573df88ddb)

-----------------------------------------------------------

- If user switches to `Basic Message` or `Basic Login` configuration he won't be able to switch back to Custom Page Configuration.
  
  ![Screenshot from 2024-07-29 20-47-49](https://github.com/user-attachments/assets/06b41382-15d3-48fe-a226-c966e02ec08c)

