### PR TITLE
NGFW-14742 : Fixed time sync issue

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-force-time-sync
+++ b/uvm/hier/usr/share/untangle/bin/ut-force-time-sync
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+#kill all the current ntpd process
+pkill -9 ntpd
+
 # stop the daemon first
 systemctl stop ntp	
 
-# force time sync now
+# force time sync with time.nist.gov server
 echo "Syncing time..."
-ntpd -q -g
+ntpd -q -g time.nist.gov
 CODE=$?
 
 # start the daemon


### PR DESCRIPTION
**ISSUE:** 
/usr/share/untangle/bin/ut-force-time-sync script is used to run the time sync using ntp service with the default server. Somehow the default server is not configured properly and time sync process stuck.

**FIXED:** 
updated the script to sync the the time using NIST server refernece as NIST (National Institute of Standards and Technology) operates multiple time servers that are synchronized to the same reference time and time.nist.gov is one of their primary NTP (Network Time Protocol) server.
reference : https://tf.nist.gov/tf-cgi/servers.cgi
![Screenshot from 2024-07-30 16-55-20](https://github.com/user-attachments/assets/c903b93b-0bf9-4c47-8c76-b4fb461c83ce)

**TEST:**
1- config->system->synchronize time
                      ![Screenshot from 2024-07-30 16-56-41](https://github.com/user-attachments/assets/a11ab199-7cf0-4750-831d-91e6dd9029f9)
                      
                      ![Screenshot from 2024-07-30 16-56-46](https://github.com/user-attachments/assets/d1a52f3d-431e-4fbd-a4d7-129e5c28c33d)
                      it should not hang and set the settings properly.

2- Run below test case of report suite it should not hang and passed successfully.
`  -t reports -T test_600_session_minutes_referral
`