### PR TITLE
ngfw-14746 Syslog tab unsaved changes message box bug fix

### DIFF
--- a/uvm/servlets/admin/app/controller/Global.js
+++ b/uvm/servlets/admin/app/controller/Global.js
@@ -138,7 +138,7 @@ Ext.define('Ung.controller.Global', {
         // check for grids changes
         Ext.Array.each(cmp.query('ungrid'), function (grid) {
             var store = grid.getStore();
-            if (store.type === 'chained') { return; }
+            if (store.type === 'chained' || store.skipDetectGridChanges) { return; }
             if (store.getModifiedRecords().length > 0 || store.getRemovedRecords().length > 0 || store.getNewRecords().length > 0 && !dirtyGrids) {
                 dirtyGrids = true;
             }

--- a/uvm/servlets/admin/config/events/MainController.js
+++ b/uvm/servlets/admin/config/events/MainController.js
@@ -324,6 +324,18 @@ Ext.define('Ung.config.events.MainController', {
                 store.getNewRecords().length > 0 ||
                 store.getRemovedRecords().length > 0)) {
             vm.set('syslogRuleGridDisabled', true);
+            // Check if modified records only have reserved boolean modified 
+            // and accordingly set skipDetectGridChanges flag
+            var isGridPropertyChanged;
+            store.getModifiedRecords().forEach(function(modifiedRecord) {
+                if(modifiedRecord.modified) {
+                    var keys = Object.keys(modifiedRecord.modified);
+                    if(!(keys.length == 1 && keys[0] == 'reserved')) {
+                        isGridPropertyChanged = true;
+                    }
+                }
+            });
+            store.skipDetectGridChanges = !isGridPropertyChanged;
         } else {
             vm.set('syslogRuleGridDisabled', false);
         }

--- a/uvm/servlets/admin/config/events/MainController.js
+++ b/uvm/servlets/admin/config/events/MainController.js
@@ -330,7 +330,7 @@ Ext.define('Ung.config.events.MainController', {
             store.getModifiedRecords().forEach(function(modifiedRecord) {
                 if(modifiedRecord.modified) {
                     var keys = Object.keys(modifiedRecord.modified);
-                    if(!(keys.length == 1 && keys[0] == 'reserved')) {
+                    if(!(keys.length === 1 && keys[0] === 'reserved')) {
                         isGridPropertyChanged = true;
                     }
                 }


### PR DESCRIPTION
**Root Cause:** On every syslog rule grid change we are setting/updating the `reserved` property to syslog servers store records. It causes change in state of record even if we don't change any actual property of syslog server grid.
Hence in `detectChanges` method which checks for state change for all grids on page was catching the syslog servers grid every time and we were getting unsaved changes message box.

**Changes:** In `dataChange/update` handler of `syslogServer` store (`onSyslogServersGridChange`) added a condition to find if actual properties of grid record is modified or not and accordingly setting `skipDetectGridChanges` flag on the store object.

**Local Testing:**
Tested below scenarios:

Added multiple syslog servers in syslog server grid, added multiple syslog rules in syslog rules grid.
- If any of the syslog server is added/deleted/updated then on pressing `Back to Config` button without saving changes getting message as shown below.
  ![Screenshot from 2024-07-31 12-29-22](https://github.com/user-attachments/assets/c9f6eaf4-354a-42ef-832f-f7e79ecba4cc)

- Same message appears if any of the syslog rules is added/deleted/updated and settings are not saved

- If there is no change in any of the grid (i.e. syslog server or syslog rules) then on clicking `Back to Config` button user is directly navigate to `Configuration` page.
