### PR TITLE
ngfw-14760: VRRP is not changing the master flag.

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -1143,7 +1143,12 @@ class NetworkTests(NGFWTestCase):
             pingResult = remote_control.run_command("ping -c 1 %s" % str(vrrpIP))
             if pingResult == 0:
                 break
-        isMaster = global_functions.uvmContext.networkManager().isVrrpMaster(interfaceId)
+        #Fix for ATS server, recheck if isVrrpMaster is taking time
+        for x in range(4):
+            isMaster = global_functions.uvmContext.networkManager().isVrrpMaster(interfaceId)
+            if isMaster:
+                print("VRRP master is enabled after {} iterations".format(str(x)))
+                break
         onlineResults = remote_control.is_online()
 
         # Return to default network state


### PR DESCRIPTION
After repeatedly running test case for n times locally , 
Two possible root causes:

A. Need to wait for check of isVRRPMaster was not present.
![Screenshot from 2024-07-31 20-01-08](https://github.com/user-attachments/assets/2f8f2c36-64b9-4ec1-b71c-0098972e4b3c)
here Master1 represents the isVRRPMaster was enabled in second iteration
B. frr was giving error frr.service: Start request repeated too quickly. However on the box using journalctl commands for frr service, it didn’t indicate any same behavior.  Manual testing from UI shows vrrp enabled, and master status correctly.


Fix applied:
1. Added modification before frr stop, start method added reset-failed before it.
reset-failed manually clears out failed state before start , stop frr.
2. Modified the deletion of added vrrp interface, earlier network settings file was being referred,
now we are checking the interfaces on the ngfw directly. PR (https://github.com/untangle/sync-settings/pull/879)
3. Added iteration to wait in test, till  vrrp master is enabled. PR (https://github.com/untangle/ngfw_src/compare/ngfw-14760?expand=1)

PFA test results:

![image](https://github.com/user-attachments/assets/9a1caa40-d289-4e02-bdd3-43ae86bae25c)

Added iteration log inorder to check on iteration number.
![image](https://github.com/user-attachments/assets/00d6f781-1d27-40bc-a6b7-d85325977452)

