### PR TITLE
ngfw-14756 Update restore script to restore 17.1

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-restore.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-restore.sh
@@ -158,7 +158,7 @@ function expandFile()
     echo $BACKUP_VERSION | grep -qE "$ACCEPTED_PREVIOUS_VERSION"
     PREV_VERSION_CHECK=$?
     if [ "$BACKUP_VERSION" != "$CURRENT_VERSION" ] && [ $PREV_VERSION_CHECK != 0 ] ; then
-        err "Backup file version not supported. ($BACKUP_VERSION)"
+        err "Backup file version $BACKUP_VERSION is not supported, supported version(s) = $ACCEPTED_PREVIOUS_VERSION and $CURRENT_VERSION" 
         return 1
     fi
 

--- a/uvm/hier/usr/share/untangle/bin/ut-restore.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-restore.sh
@@ -12,7 +12,7 @@ TARBALL_FILE=""
 VERSION_FILE=""
 # To support multiple versions, separate with pipe character like:
 #ACCEPTED_PREVIOUS_VERSION="15.1|16.0"
-ACCEPTED_PREVIOUS_VERSION="17.0"
+ACCEPTED_PREVIOUS_VERSION="17.1"
 
 function debug() {
   if [ "true" == $VERBOSE ]; then


### PR DESCRIPTION
Update restore script to restore 17.1
Changed `ACCEPTED_PREVIOUS_VERSION` variable value to `17.1`

**Local Testing:** 
- On a NGFW server with `v17.0` downloaded a backup file and upgraded it to `v17.1.1`
- After upgrade is completed again took backup and upgraded NGFW to `v17.2` (with above mentioned changes)
- On `v17.2` tried to restore `v17.0` backup file and got the error message as shown below.

  ![Screenshot from 2024-08-01 18-34-13](https://github.com/user-attachments/assets/4bbb03ab-ad64-4096-b807-dbd76248d2e0)


- When tried to restore the backup file of `v17.1.1` NGFW was able to restore it.

  ![Screenshot from 2024-08-01 12-35-51](https://github.com/user-attachments/assets/47af0fe0-4061-4def-81c0-bb476b81fe85)
