### PR TITLE
NGFW-13424 - Fixed ovpn test_035_createVPNTunnel_userpass test case 

### DIFF
--- a/openvpn/hier/usr/lib/python3/dist-packages/tests/test_openvpn.py
+++ b/openvpn/hier/usr/lib/python3/dist-packages/tests/test_openvpn.py
@@ -302,8 +302,8 @@ class OpenVpnTests(NGFWTestCase):
         appData = self._app.getSettings()
         appData["serverEnabled"]=True
         appData["remoteServers"]["list"][0]["authUserPass"]=True
-        appData["remoteServers"]["list"][0]["authUsername"]=ovpnlocaluser
-        appData["remoteServers"]["list"][0]["authPassword"]=ovpnPasswd
+        appData["remoteServers"]["list"][0]["authUsername"]="ovpnlocaluser"
+        appData["remoteServers"]["list"][0]["authPassword"]="passwd"
         #enable user/password authentication, set to local directory
         appData['authUserPass']=True
         appData["authenticationType"]="LOCAL_DIRECTORY"


### PR DESCRIPTION

ISSUE : AS mentioned in JIRA comment https://awakesecurity.atlassian.net/browse/NGFW-13424?focusedCommentId=247212, the password present previously is incorrect in TC, so updated the password.

Also the LAN_IP mentioned [https://github.com/untangle/ngfw_src/blob/18963003241c083c3fd17db5a2ca1b6c9bba976d[…]vm/hier/usr/lib/python3/dist-packages/tests/global_functions.py](https://github.com/untangle/ngfw_src/blob/18963003241c083c3fd17db5a2ca1b6c9bba976d/uvm/hier/usr/lib/python3/dist-packages/tests/global_functions.py#L53) here is not reachable from any of ATS server hence test case is failing.

I tried using VPN_SERVER_USER_PASS_IP = "10.112.56.93" in place of VPN_SERVER_USER_PASS_LAN_IP, it worked fine.

![Screenshot from 2024-08-07 18-23-06](https://github.com/user-attachments/assets/fb16f66e-f893-45ee-9d61-92900187ad6f)
