### PR TITLE
NGFW-14785 add realtek flag to ignore EEE processing.  In theory once…

### DIFF
--- a/uvm/hier/usr/share/untangle/conf/flags/set-link-media--is_ignore_eee_vendor
+++ b/uvm/hier/usr/share/untangle/conf/flags/set-link-media--is_ignore_eee_vendor
@@ -1,0 +1,1 @@
+Realtek


### PR DESCRIPTION
… this driver is updated in the Linux kernel and the issue is resolved, we can remove.