### PR TITLE
ngfw-14783-Wireguard-VPN-add-search-domains

### DIFF
--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -90,6 +90,13 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                 value: '{settings.dnsServer}'
             }
         },{
+            xtype: 'textfield',
+            fieldLabel: 'DNS Search Domain'.t(),
+            bind: {
+                value: '{settings.dnsSearchDomain}'
+            },
+            emptyText: '[no domain]'.t()
+        },{
             xtype: 'fieldcontainer',
             layout: 'hbox',
             items: [{

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -91,7 +91,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
             }
         },{
             xtype: 'textfield',
-            fieldLabel: 'DNS Search Domain'.t(),
+            fieldLabel: 'DNS Search Domains'.t(),
             bind: {
                 value: '{settings.dnsSearchDomain}'
             },

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
@@ -65,6 +65,7 @@ public class WireGuardVpnApp extends AppBase
     private final WireguardVpnPreHookCallback wireguardVpnPreHookCallback;
 
     private InetAddress localDnsResolver = null;
+    private String defaultDnsSerachDomain = null;
     private List<InterfaceStatus> lanStatuses = null;
     private Hashtable<InterfaceStatus, WireGuardVpnNetwork> settingsLink = null;
 
@@ -97,6 +98,7 @@ public class WireGuardVpnApp extends AppBase
 
         this.lanStatuses = UvmContextFactory.context().networkManager().getLocalInterfaceStatuses();
         this.localDnsResolver = UvmContextFactory.context().networkManager().getFirstDnsResolverAddress();
+        this.defaultDnsSerachDomain = UvmContextFactory.context().networkManager().getNetworkSettings().getDomainName();
     }
 
     /**
@@ -483,8 +485,11 @@ public class WireGuardVpnApp extends AppBase
             logger.warn(dnsAddress);
             settings.setDnsServer(dnsAddress);
         }
-
-
+        String defaultSearchDomain = this.defaultDnsSerachDomain;
+        if(defaultSearchDomain != null){
+            logger.warn(defaultSearchDomain);
+            settings.setDnsSearchDomain(defaultSearchDomain);
+        }
         settings.setNetworks(buildNetworkList(lanStatuses));
 
         IPMaskedAddress newSpace = UvmContextFactory.context().netspaceManager().getAvailableAddressSpace(IPVersion.IPv4, 1);

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
@@ -350,11 +350,11 @@ public class WireGuardVpnApp extends AppBase
                 }
             }
 
-            // 16.3.2 - add in nat rules by default
-            if (readSettings.getVersion() <= 3) {
-                createNatRules();
+            // 17.3 - add dns search domain by default
+            if(readSettings.getVersion() <= 4) {
+                readSettings.setDnsSearchDomain(this.defaultDnsSerachDomain);
                 writeFlag = true;
-                readSettings.setVersion(4);
+                readSettings.setVersion(5);
             }
 
             if (writeFlag == true) {

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
@@ -19,7 +19,7 @@ import com.untangle.uvm.app.IPMaskedAddress;
 @SuppressWarnings("serial")
 public class WireGuardVpnSettings implements Serializable, JSONString
 {
-    private Integer version = 4;
+    private Integer version = 5;
 
     private Integer keepaliveInterval = 25;
     private Integer listenPort = 51820;

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
@@ -28,6 +28,7 @@ public class WireGuardVpnSettings implements Serializable, JSONString
     private String privateKey = "";
     private String publicKey = "";
     private InetAddress dnsServer;
+    private String dnsSearchDomain = "";
     private List<WireGuardVpnNetwork> networks;
     private boolean autoAddressAssignment = true;
 
@@ -56,6 +57,9 @@ public class WireGuardVpnSettings implements Serializable, JSONString
 
     public InetAddress getDnsServer() { return dnsServer; }
     public void setDnsServer( InetAddress newValue ) { this.dnsServer = newValue; }
+
+    public String getDnsSearchDomain() { return dnsSearchDomain; }
+    public void setDnsSearchDomain(String dnsSearchDomain) { this.dnsSearchDomain = dnsSearchDomain; }
 
     public List<WireGuardVpnNetwork> getNetworks() { return networks; }
     public void setNetworks( List<WireGuardVpnNetwork> newValue ) { this.networks = newValue; }


### PR DESCRIPTION
**Changes:**

1. Modified DNS configuration condition for creating remote client configuration of WireGuard VPN in **sync_settings** [Pull Request](https://github.com/untangle/sync-settings/pull/912)
2. Added **DNS Search Domains** String field in page Wireguard VPN → Settings → Remote Client Configuration
3. Added `dnsSearchDomain` field in WireGuard Vpn Settings in backend to map this field
4. Setting default DNS Search domain to NGFW Domain name and configuring remote client configuration file on App initiation and NGFW Upgrade
5. Added a test case to verify search domain updated in remote client config

**Local Testing:**

1. Built sync settings in local using `Ctl+Shift+B` and `(NGFW) Upload package to ISO` option.
2. On app initiation default search domain value is assigned and configuration file is as shown below.
    ![Screenshot from 2024-08-29 16-57-10](https://github.com/user-attachments/assets/5a2a43c4-e4d5-4d20-9669-d1a4b2e456e5)
    ![Screenshot from 2024-08-29 16-59-26](https://github.com/user-attachments/assets/673e9a1c-c7d2-4d4d-bd72-6af3a25097d5)
3. After changing DNS search domains field on saving the settings remote config files will be updated.
    ![Screenshot from 2024-08-29 17-03-25](https://github.com/user-attachments/assets/c500b047-5daf-4cdb-97d6-9be0f0042809)

4. Upgrade Testing: 
Upgraded NGFW from 17.2 using dev package `deb [trusted=yes] http://package-server.untangle.int/dev/bullseye ngfw_src.ngfw-14783-wireguard-vpn-add-search-domain main`
If Wireguard VPN app is already installed then on upgrade default DNS search domain (Config → Network → Hostname → Domain Name) should be assigned and visible in UI.
