### PR TITLE
NGFW-14790 Fixed backup upload failure handling for 0.0.0.0

### DIFF
--- a/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
+++ b/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
@@ -253,8 +253,8 @@ public class ConfigurationBackupApp extends AppBase
                                     "-t",TIMEOUT_SEC,
                                     "-f",backupFile.getAbsoluteFile().toString()};
 
-        logger.info("Backing up " + backupFile.getAbsoluteFile() + " to " + backupUri);
-        logger.info("Backup command: " + Arrays.toString(cmd));
+        logger.info("Backing up {} to {}", backupFile.getAbsoluteFile(), backupUri);
+        logger.info("Backup command: {}", Arrays.toString(cmd));
 
         Integer exitCode = 0;
         try {
@@ -266,7 +266,7 @@ public class ConfigurationBackupApp extends AppBase
         }
 
         if(exitCode != 0) {
-            logger.error("Backup returned non-zero error code (" + exitCode + ")");
+            logger.error("Backup returned non-zero error code ({})", exitCode);
 
             String reason = null;
             switch(exitCode) {
@@ -291,7 +291,7 @@ public class ConfigurationBackupApp extends AppBase
             default:
                 reason = "Unknown error";
             }
-            logger.info("Backup failed: " + reason);
+            logger.error("Backup failed: {}", reason);
             this.logEvent( new ConfigurationBackupEvent(false, reason, I18nUtil.marktr("My Account")) );
         }
         else {

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_alerts.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_alerts.py
@@ -142,7 +142,7 @@ class AlertTests(NGFWTestCase):
 
         # trigger configuration backup
         app_conf_backup.sendBackup()
-        time.sleep(4)
+        time.sleep(10)
 
         # verify configuration backup failure event log
         events = global_functions.get_events('Events','Alert Events',None,10)


### PR DESCRIPTION
- Backup upload script now handles curl return status code 60 which is returned when backup upload server is 0.0.0.0.
- Also, for any other failures where script could not get the HTTP status code, we are now treating that as a failure.
- Needed to increase the test wait time to get the event.

Getting failure event with 0.0.0.0 as backup server DNS entry.
![Screenshot from 2024-08-28 15-20-54](https://github.com/user-attachments/assets/abe40374-ad30-45a9-b396-de47682ef2e5)

Test case:
```
== testing alerts ==
Test success : test_070_configuration_backup_fail_alert [13.7s] 
== testing alerts [14.4s] ==

Tests complete. [14.4 seconds]
1 passed, 0 skipped, 0 failed

Total          :    1
Passed         :    1
Skipped        :    0
Passed/Skipped :    1 [100.00%]
Failed         :    0 [  0.00%]

======================================================================
test_070_configuration_backup_fail_alert start [2024-08-28T00:46:42]
test_070_configuration_backup_fail_alert (tests.test_alerts.AlertTests)
Verify alert on configuration backup failure ... XXX: 2024-08-28 00:46:42.475349
event:
key=description expectedValue=Configuration backup failed == actualValue=Configuration backup failed True
ok

----------------------------------------------------------------------
Ran 1 test in 13.652s

OK
test_070_configuration_backup_fail_alert end   [2024-08-28T00:46:56]
======================================================================
```