### PR TITLE
ngfw-14800 exec vulnerability fix

### DIFF
--- a/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalApp.java
+++ b/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalApp.java
@@ -1390,9 +1390,9 @@ public class CaptivePortalApp extends AppBase
              * expect so clean up any existing custom page that may already
              * exist and extract the file into our custom directory
              */
-            UvmContextFactory.context().execManager().exec(CAPTURE_CUSTOM_REMOVE_SCRIPT + " " + customPath);
-            UvmContextFactory.context().execManager().exec(CAPTURE_CUSTOM_CREATE_SCRIPT + " " + customPath);
-            UvmContextFactory.context().execManager().exec("unzip -o " + CAPTURE_TEMPORARY_UPLOAD + " -d " + customPath);
+            UvmContextFactory.context().execManager().execSafe(CAPTURE_CUSTOM_REMOVE_SCRIPT + " " + customPath);
+            UvmContextFactory.context().execManager().execSafe(CAPTURE_CUSTOM_CREATE_SCRIPT + " " + customPath);
+            UvmContextFactory.context().execManager().execSafe("unzip -o " + CAPTURE_TEMPORARY_UPLOAD + " -d " + customPath);
 
             tempFile.delete();
             logger.debug("Custom zip uploaded to: " + customPath);
@@ -1431,8 +1431,8 @@ public class CaptivePortalApp extends AppBase
             String customPath = (System.getProperty("uvm.web.dir") + "/capture/custom_" + argument);
 
             // use our existing remove and create scripts to wipe any existing custom page
-            UvmContextFactory.context().execManager().exec(CAPTURE_CUSTOM_REMOVE_SCRIPT + " " + customPath);
-            UvmContextFactory.context().execManager().exec(CAPTURE_CUSTOM_CREATE_SCRIPT + " " + customPath);
+            UvmContextFactory.context().execManager().execSafe(CAPTURE_CUSTOM_REMOVE_SCRIPT + " " + customPath);
+            UvmContextFactory.context().execManager().execSafe(CAPTURE_CUSTOM_CREATE_SCRIPT + " " + customPath);
 
             logger.debug("Custom zip removed from: " + customPath);
             return new ExecManagerResult(0, "The custom captive portal page has been removed");

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnManager.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnManager.java
@@ -222,7 +222,7 @@ public class TunnelVpnManager
             throw new RuntimeException("Failed to find available tunnel ID");
         }
 
-        ExecManagerResult result = UvmContextFactory.context().execManager().exec(IMPORT_SCRIPT + " \"" + filename + "\" \"" + provider + "\" " + tunnelId);
+        ExecManagerResult result = UvmContextFactory.context().execManager().execSafe(IMPORT_SCRIPT + " \"" + filename + "\" \"" + provider + "\" " + tunnelId);
 
         try {
             String lines[] = result.getOutput().split("\\r?\\n");
@@ -264,7 +264,7 @@ public class TunnelVpnManager
             throw new RuntimeException("Failed to find available tunnel ID");
         }
 
-        ExecManagerResult result = UvmContextFactory.context().execManager().exec(VALIDATE_SCRIPT + " \"" + filename + "\" \"" + provider + "\" " + tunnelId);
+        ExecManagerResult result = UvmContextFactory.context().execManager().execSafe(VALIDATE_SCRIPT + " \"" + filename + "\" \"" + provider + "\" " + tunnelId);
 
         try {
             String lines[] = result.getOutput().split("\\r?\\n");

--- a/uvm/api/com/untangle/uvm/ExecManager.java
+++ b/uvm/api/com/untangle/uvm/ExecManager.java
@@ -18,6 +18,11 @@ public interface ExecManager
      */
     ExecManagerResult exec( String cmd, boolean rateLimit );
 
+    /**
+     * Execute the specified command if safe and return the result
+     */
+    ExecManagerResult execSafe( String cmd );
+
     void setLevel( Level level );
     
     /**

--- a/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
@@ -157,7 +157,7 @@ public class BackupManagerImpl implements BackupManager
 
         // run same command with nohup and without -c check-only flag
         logger.info("Restore Backup: launching restore " + restoreFile);
-        UvmContextFactory.context().execManager().exec(System.getProperty("uvm.bin.dir") + "/ut-backup-restore-helper.sh restore " + restoreFile.getAbsolutePath() + "  \"" + maintainRegex +"\"");
+        UvmContextFactory.context().execManager().execSafe(System.getProperty("uvm.bin.dir") + "/ut-backup-restore-helper.sh restore " + restoreFile.getAbsolutePath() + "  \"" + maintainRegex +"\"");
 
         logger.info("Restore Backup: returning");
         return new ExecManagerResult(0, i18nUtil.tr("The restore procedure is running. This may take several minutes. The server may be unavailable during this time. Once the process is complete you will be able to log in again."));

--- a/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
@@ -214,7 +214,7 @@ public class CertificateManagerImpl implements CertificateManager
             fileStream.close();
             ExecManagerResult result;
             // call the external utility to parse the uploaded file
-            String certData = UvmContextFactory.context().execManager().execOutput(CERTIFICATE_PARSER_SCRIPT + " " + CERTIFICATE_PARSER_FILE + " " + argument);
+            String certData = UvmContextFactory.context().execManager().execOutputSafe(CERTIFICATE_PARSER_SCRIPT + " " + CERTIFICATE_PARSER_FILE + " " + argument);
             if (certData != null && certData.contains("errorData")) {
                 JSONObject jsonCertData = new JSONObject(certData);
                 //errorData is present, fetch the value
@@ -289,7 +289,7 @@ public class CertificateManagerImpl implements CertificateManager
                 argList[1] = req.getParameter("arg2"); // cert subject
                 argList[2] = req.getParameter("arg3"); // alt names
                 String argString = UvmContextFactory.context().execManager().argBuilder(argList);
-                UvmContextFactory.context().execManager().exec(CERTIFICATE_GENERATOR_SCRIPT + argString);
+                UvmContextFactory.context().execManager().execSafe(CERTIFICATE_GENERATOR_SCRIPT + argString);
 
                 try {
                     File certFile = new File(EXTERNAL_REQUEST_FILE);
@@ -588,7 +588,7 @@ public class CertificateManagerImpl implements CertificateManager
         argList[0] = baseName;
         argList[1] = certSubject;
         String argString = UvmContextFactory.context().execManager().argBuilder(argList);
-        UvmContextFactory.context().execManager().exec(ROOT_CA_CREATOR_SCRIPT + argString);
+        UvmContextFactory.context().execManager().execSafe(ROOT_CA_CREATOR_SCRIPT + argString);
 
         // Symlink generated certs to the CERT_STORE_PATH (ROOT_KEY_FILE and ROOT_CERT_FILE)
         symlinkRootCerts(CERT_STORE_PATH, CERT_STORE_PATH + baseName + "/", false);
@@ -622,7 +622,7 @@ public class CertificateManagerImpl implements CertificateManager
         argList[2] = altNames;
         argList[3] = baseName;
         String argString = UvmContextFactory.context().execManager().argBuilder(argList);
-        ExecManagerResult result = UvmContextFactory.context().execManager().exec(CERTIFICATE_GENERATOR_SCRIPT + argString);
+        ExecManagerResult result = UvmContextFactory.context().execManager().execSafe(CERTIFICATE_GENERATOR_SCRIPT + argString);
         if (result.getResult() != 0) return (false);
         return (true);
     }

--- a/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
@@ -145,6 +145,18 @@ public class ExecManagerImpl implements ExecManager
     }
 
     /**
+     * Executes only safe command and returns the result object
+     *
+     * @param cmd
+     *        The String command to execute and optionally the rate limit flag
+     * @return The execution result object
+     */
+    public synchronized ExecManagerResult execSafe(String cmd)
+    {
+        return exec(cmd, false, true);
+    }
+
+    /**
      * Executes a command and returns the result object
      * 
      * @param cmd
@@ -165,7 +177,7 @@ public class ExecManagerImpl implements ExecManager
         cmd = cmd.replace("\n", "");
         cmd = cmd.replace("\r", "");
 
-        if (cmd.contains(";") || cmd.contains("&&") || cmd.contains("|") || cmd.contains(">")) {
+        if (cmd.contains(";") || cmd.contains("&&") || cmd.contains("|") || cmd.contains(">") || cmd.contains("$(")) {
             if(safe){
                 logger.log(this.level, "Suspicious command (" + cmd + "), blocked");
                 return new ExecManagerResult();


### PR DESCRIPTION
**Changes:** 
1. Added a condition in safe command execution flow to check if `$(` is present in the command.
2. Added `execSafe` which will call exec method with safe boolean as true.
3. Using this safe execution method for below actions(requests) which were vulnerable and could be attacked with methods provided in ticket description.
    - Captive portal upload and delete custom captive page (Functionality is already removed from UI but API's are active)
    - Tunnel VPN upload config fie on page (Tunnel VPN --> Tunnels --> Select VPN Config File)
    - Backup restore using backup file upload (Config --> System --> Restore --> Restore from file)
    - Upload server certificate (Config --> Administration --> Certificates --> Upload Server Certificate)
    - csr Certificate Download (Original Issue/Method given in ticket description)
    - Generate Certificate Authority (Config --> Administration --> Certificates --> Generate Certificate Authority)
    - Generate Server Certificate (Config --> Administration --> Certificates --> Generate Server Certificate)


**Local Testing**  
Followed [ZDI-CAN-24015- Report.pdf](https://awakesecurity.atlassian.net/jira/software/c/projects/NGFW/boards/77/backlog?assignee=712020%3A339cb527-96ad-4daa-81da-374650781698&selectedIssue=NGFW-14800)  to reproduce the issue and attack was successful.

After implementing these changes command containing `$(` are getting skipped as we are using `safeExec` method and remote host is not able to get control of the ngfw.

![Screenshot from 2024-09-03 19-13-55](https://github.com/user-attachments/assets/c21d6712-cda5-4b86-a124-fabee13889f0)

![Screenshot from 2024-09-03 19-11-49](https://github.com/user-attachments/assets/b42425ad-8c4b-4ff5-8905-28d5aa0e7dbc)


Tested above mentioned all actions where change has been applied by debugging command sent in request. None of those contain `$(` and are able to execute successfully. and if we manually change argument to launch attack from postman or python script then the execution is skipped and remote host does not get control of ngfw. 
