### PR TITLE
NGFW-14815: Fixed Java exception coming for looking up MAC address vendor

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -2755,6 +2755,84 @@ server=dynupdate.no-ip.com
         mac_address_vendor_map = global_functions.uvmContext.networkManager().lookupMacVendorList(mac_address_list)
         assert(len(mac_address_vendor_map) > 0)
 
+    def test_706_lookup_vendor_for_mac_address_list(self):
+        """
+        Verify we can get vendors for the mac addresses.
+        """
+        # MAC address list in string format
+        mac_address_list_string = "f0:35:75:af:2e:72,84:47:09:02:41:e6,00:23:81:52:e4:1e,5c:61:99:42:44:5e,48:25:67:01:e4:e9"
+
+        mac_address_vendor_map = global_functions.uvmContext.deviceTable().lookupMacVendor(mac_address_list_string)
+
+        # Check if result is None
+        self.assertIsNotNone(mac_address_vendor_map, "The result should not be None.")
+        self.assertIsInstance(mac_address_vendor_map, list, "The result should be a list.")
+
+        # Verify the output contains expected fields
+        for entry in mac_address_vendor_map:
+            self.assertIsInstance(entry, dict, "Each entry should be a dictionary.")
+            self.assertIn('MAC', entry, "Each entry should contain 'MAC'.")
+            self.assertIn('Organization', entry, "Each entry should contain 'Organization'.")
+
+    def test_707_lookup_vendor_for_single_mac_address(self):
+        """
+        Verify we can get the vendor for a single MAC address.
+        """
+        # Single MAC address
+        mac_address_string = "f0:35:75:af:2e:72"
+
+        mac_address_vendor_map = global_functions.uvmContext.deviceTable().lookupMacVendor(mac_address_string)
+
+        # Check if result is None
+        self.assertIsNotNone(mac_address_vendor_map, "The result should not be None.")
+        self.assertIsInstance(mac_address_vendor_map, list, "The result should be a list.")
+
+        # Check that the list has exactly one entry
+        self.assertEqual(len(mac_address_vendor_map), 1, "The result should contain exactly one entry.")
+
+        # Verify the single entry in the list contains the expected fields
+        entry = mac_address_vendor_map[0]
+        self.assertIsInstance(entry, dict, "The entry should be a dictionary.")
+        self.assertIn('MAC', entry, "The entry should contain 'MAC'.")
+        self.assertIn('Organization', entry, "The entry should contain 'Organization'.")
+
+    def test_708_lookup_vendor_for_empty_mac_address(self):
+        """
+        Verify behavior for an empty MAC address.
+        """
+        # Empty MAC address
+        empty_mac_address = ""
+
+        mac_address_vendor_map = global_functions.uvmContext.deviceTable().lookupMacVendor(empty_mac_address)
+
+        # Check if result is None
+        self.assertIsNone(mac_address_vendor_map, "The result should be None for an empty MAC address.")
+    
+    def test_709_lookup_vendor_for_null_mac_address(self):
+        """
+        Verify behavior for a null MAC address.
+        """
+        # Null MAC address
+        null_mac_address = None
+
+        mac_address_vendor_map = global_functions.uvmContext.deviceTable().lookupMacVendor(null_mac_address)
+
+        # Check if result is None
+        self.assertIsNone(mac_address_vendor_map, "The result should be None for a null MAC address.")
+
+    def test_710_lookup_vendor_for_invalid_mac_address(self):
+        """
+        Verify behavior for an invalid MAC address.
+        """
+        # Invalid MAC address
+        invalid_mac_address = "0:1A:B:3C:"
+
+        mac_address_vendor_map = global_functions.uvmContext.deviceTable().lookupMacVendor(invalid_mac_address)
+
+        # Check if the result contains an 'Organization' field with value 'Unknown'
+        self.assertEqual(mac_address_vendor_map, [{'Organization': 'Unknown', 'MAC': '0:1A:B:3C:'}],
+                        "The result should have an 'Organization' field with value 'Unknown' for an invalid MAC address.")
+
     def test_720_dnsmasq_source(self):
         """
         Verify that DNS resolver addresses are properly "pinned" to their interfaces

--- a/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
@@ -205,7 +205,7 @@ public class DeviceTableImpl implements DeviceTable
                 
                 String body = macAdressList.toString();
                 
-                            // forming the URL
+                // forming the URL
                 URL myurl = new URL(UvmContextFactory.context().uriManager().getUri(CLOUD_LOOKUP_URL));
                 HttpURLConnection mycon;
                 if(myurl.getProtocol().equals("https")){

--- a/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
@@ -208,10 +208,10 @@ public class DeviceTableImpl implements DeviceTable
                             // forming the URL
                 URL myurl = new URL(UvmContextFactory.context().uriManager().getUri(CLOUD_LOOKUP_URL));
                 HttpURLConnection mycon;
-            if(myurl.getProtocol().equals("https")){
-                    mycon = (HttpsURLConnection) myurl.openConnection();
-            }else{
-                    mycon = (HttpURLConnection) myurl.openConnection();
+                if(myurl.getProtocol().equals("https")){
+                        mycon = (HttpsURLConnection) myurl.openConnection();
+                }else{
+                        mycon = (HttpURLConnection) myurl.openConnection();
                 }
                 mycon.setRequestMethod("POST");
                 mycon.setConnectTimeout(5000); // 5 seconds

--- a/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
@@ -19,6 +19,7 @@ import java.io.DataOutputStream;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.json.JSONArray;
 
@@ -37,6 +38,13 @@ public class DeviceTableImpl implements DeviceTable
 {
     private static final String CLOUD_LOOKUP_URL = UvmContextFactory.context().uriManager().getUri("https://labs.untangle.com/Utility/v1/mac");
     private static final String CLOUD_LOOKUP_KEY = "B132C885-962B-4D63-8B2F-441B7A43CD93";
+    private static final String CONTENT_LENGTH = "Content-length";
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String CONTENT_TYPE_VALUE = "application/json";
+    private static final String AUTH_REQUEST = "AuthRequest";
+    private static final String USER_AGENT = "User-Agent";
+    private static final String USER_AGENT_VALUE = "Untangle NGFW Device Table";
+    private static final String HTTP_METHOD = "POST";
     private static final int HIGH_WATER_SIZE = 30000; /* absolute max */
     private static final int LOW_WATER_SIZE = 25000; /*
                                                       * max size to reduce to
@@ -195,13 +203,13 @@ public class DeviceTableImpl implements DeviceTable
      */
     public JSONArray lookupMacVendor(String macAddresses)
     {
-        logger.warn("lookupMacVendor:" + macAddresses);
-        if (macAddresses == null  ||  macAddresses.isEmpty()  && macAddresses.isBlank()) return null;
+        logger.warn("lookupMacVendor: {}", macAddresses);
+        if (StringUtils.isBlank(macAddresses)) return null;
         String[] macAddressList = macAddresses.split(",");
         try {
             if (macAddressList != null) {
                 JSONArray macAdressList = new JSONArray(macAddressList);
-                logger.info("Cloud MAC lookup = " + macAdressList);
+                logger.info("Cloud MAC lookup: {}", macAdressList);
                 
                 String body = macAdressList.toString();
                 
@@ -213,13 +221,13 @@ public class DeviceTableImpl implements DeviceTable
                 }else{
                         mycon = (HttpURLConnection) myurl.openConnection();
                 }
-                mycon.setRequestMethod("POST");
+                mycon.setRequestMethod(HTTP_METHOD);
                 mycon.setConnectTimeout(5000); // 5 seconds
                 mycon.setReadTimeout(5000); // 5 seconds
-                mycon.setRequestProperty("Content-length", String.valueOf(body.length()));
-                mycon.setRequestProperty("Content-Type", "application/json");
-                mycon.setRequestProperty("User-Agent", "Untangle NGFW Device Table");
-                mycon.setRequestProperty("AuthRequest", CLOUD_LOOKUP_KEY);
+                mycon.setRequestProperty(CONTENT_LENGTH, String.valueOf(body.length()));
+                mycon.setRequestProperty(CONTENT_TYPE, CONTENT_TYPE_VALUE);
+                mycon.setRequestProperty(USER_AGENT, USER_AGENT_VALUE);
+                mycon.setRequestProperty(AUTH_REQUEST, CLOUD_LOOKUP_KEY);
                 mycon.setDoOutput(true);
                 mycon.setDoInput(true);
 

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -2811,7 +2811,7 @@ public class NetworkManagerImpl implements NetworkManager
                         }
                     }
                 } else {
-                    logger.info("Vendors not found for MAC addresses; {}", macAddresses);
+                    logger.info("Vendors not found for MAC addresses: {}", macAddresses);
                 }
             } catch (Exception exn) {
                 logger.warn("Exception looking up MAC address vendor:", exn);

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -2796,7 +2796,7 @@ public class NetworkManagerImpl implements NetworkManager
         if (!missingMacAddressList.isEmpty()) {
             try {
                 String macAddresses = String.join(COMMA, missingMacAddressList);
-                logger.info("Cloud MAC lookup = " + macAddresses);
+                logger.info("Cloud MAC lookup: {}", macAddresses);
                 // fetch the vendors for the mac addresses
                 JSONArray macAddrVendorArr = UvmContextFactory.context().deviceTable().lookupMacVendor(macAddresses);
                 if (macAddrVendorArr != null) {
@@ -2805,13 +2805,13 @@ public class NetworkManagerImpl implements NetworkManager
                         if (macAddrVendor.has(MAC) && macAddrVendor.has(ORGANIZATION)) {
                             String macAddr = macAddrVendor.getString(MAC), vendorName = macAddrVendor.getString(ORGANIZATION);
                             if (logger.isDebugEnabled())
-                                logger.debug("Cloud MAC lookup= " + macAddr + " Cloud Vendor lookup= " + vendorName);
+                                logger.debug("Cloud MAC lookup: {} ,Cloud Vendor lookup: {}", macAddr, vendorName);
                             // add the fetched mac address with vendor in our cache
                             cachedMacAddrVendorList.put(macAddr, vendorName);
                         }
                     }
                 } else {
-                    logger.info("Vendors not found for MAC addresses=" + macAddresses);
+                    logger.info("Vendors not found for MAC addresses; {}", macAddresses);
                 }
             } catch (Exception exn) {
                 logger.warn("Exception looking up MAC address vendor:", exn);


### PR DESCRIPTION
**ISSUE:** The API endpoint https://labs.untangle.com/Utility/v1/mac expects a list in the request payload. However, our code is currently sending the list as a string, which is resulting in a 400 Bad Request error.

**FIX:** Updated the implementation of the lookupMacVendor method to send the required input format for the request, which is a list of strings.

**TEST:** Written unit test to verify List of mac address, single mac address, null, empty and malformed value of mac address.
All below tests should passsed.

> /usr/bin/runtests -t network -T test_705_mac_address_vendor_lookup_list,test_706_lookup_vendor_for_mac_address_list,test_707_lookup_vendor_for_single_mac_address,test_708_lookup_vendor_for_empty_mac_address,test_709_lookup_vendor_for_null_mac_address,test_710_lookup_vendor_for_invalid_mac_address -h 192.168.56.162


![Screenshot from 2024-09-16 14-20-09](https://github.com/user-attachments/assets/b9e177bd-086e-4da6-8937-b379a1521837)

No exception should be logged under uvm.log  while fetching the mac vendor.
![Screenshot from 2024-09-16 15-10-35](https://github.com/user-attachments/assets/6485207f-2cae-491a-99dd-e4b0ea80ac76)
