### PR TITLE
ngfw-14821 added password mask for password fields

### DIFF
--- a/directory-connector/js/view/Radius.js
+++ b/directory-connector/js/view/Radius.js
@@ -103,6 +103,7 @@ Ext.define('Ung.apps.directoryconnector.view.Radius', {
                 xtype:'textfield',
                 name: 'radiusTestPassword',
                 fieldLabel: 'Password'.t(),
+                inputType: 'password',
                 _neverDirty: true
             },{
                 xtype: 'button',

--- a/reports/js/view/Data.js
+++ b/reports/js/view/Data.js
@@ -189,6 +189,7 @@ Ext.define('Ung.apps.reports.view.Data', {
         }, {
             xtype: 'textfield',
             fieldLabel: 'Password'.t(),
+            inputType: 'password',
             width: 300,
             bind: '{settings.dbPassword}',
             allowBlank: false,

--- a/uvm/js/common/ungrid/GridController.js
+++ b/uvm/js/common/ungrid/GridController.js
@@ -1343,12 +1343,14 @@ Ext.define('Ung.cmp.GridController', {
                 },
                 items: [{
                     fieldLabel: 'Password'.t(),
+                    inputType: 'password',
                     name: 'pass1',
                     enableKeyEvents: true,
                     // minLength: 3,
                     // minLengthText: Ext.String.format('The password is shorter than the minimum {0} characters.'.t(), 3),
                 }, {
                     fieldLabel: 'Confirm Password'.t(),
+                    inputType: 'password',
                     name: 'pass2',
                     enableKeyEvents: true
                 }],

--- a/uvm/servlets/admin/config/local-directory/view/RadiusServer.js
+++ b/uvm/servlets/admin/config/local-directory/view/RadiusServer.js
@@ -39,6 +39,7 @@ Ext.define('Ung.config.local-directory.view.RadiusServer', {
         }, {
             xtype: 'textfield',
             fieldLabel: 'RADIUS password'.t(),
+            inputType: 'password',
             labelWidth: 120,
             width: '100%',
             allowBlank: false,

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -896,6 +896,7 @@ Ext.define('Ung.config.network.Interface', {
                     disabled: '{!(intf.wirelessEncryption !== "NONE" && intf.wirelessEncryption !== null)}'
                 },
                 fieldLabel: 'Password'.t(),
+                inputType: 'password',
                 allowBlank: false,
                 maxLength: 63,
                 minLength: 8,

--- a/uvm/servlets/admin/config/network/view/DynamicRouting.js
+++ b/uvm/servlets/admin/config/network/view/DynamicRouting.js
@@ -759,6 +759,7 @@ Ext.define('Ung.config.network.view.DynamicRouting', {
                     },{
                         xtype: 'textfield',
                         fieldLabel: 'Password'.t(),
+                        inputType: 'password',
                         disabled: true,
                         hidden: true,
                         allowBlank: false,

--- a/uvm/servlets/setup/app/view/step/Wireless.js
+++ b/uvm/servlets/setup/app/view/step/Wireless.js
@@ -52,6 +52,7 @@ Ext.define('Ung.Setup.Wireless', {
         }, {
             xtype: 'textfield',
             fieldLabel: 'Password'.t(),
+            inputType: 'password',
             width: 350,
             maxLength: 63,
             minLength: 8,


### PR DESCRIPTION
**Changes:**
Added `inputType: 'password'` property in Password fields to mask value on below mentioned pages:

1. Config --> Network --> Interfaces --> Edit Interface --> Wireless Interface Configuration
2. Config --> Network --> Dynamic Routing --> OSPF --> Interface Overrides
3. Config --> Local Directory --> Radius Server
4. Directory Connector --> Radius
5. Reports --> Data (ExpertMode)
6. Grids with Change Password Functionality (e.g. Reports --> Reports Users)
7. NGFW Initial Setup --> Wireless Settings
