### PR TITLE
NGFW-14226 : Updated code to remove brightcloud ip after upgrade

### DIFF
--- a/debian/untangle-vm.postinst
+++ b/debian/untangle-vm.postinst
@@ -37,6 +37,13 @@ done
 # Clean out tomcat runtime files
 rm -rf /var/lib/uvm/work
 
+# Check if the IP address 172.217.4.110/32 exists on the loopback interface
+if ip addr show dev lo | grep -q '172.217.4.110' ; then
+    # If it exists, delete the IP address
+    ip addr del 172.217.4.110/32 dev lo
+    rm -rf /etc/untangle/post-network-hook.d/010-brightcloud-fix
+fi
+
 # set up uvm to start at boot
 if [ -x "/etc/init.d/untangle-vm" ]; then
     update-rc.d untangle-vm defaults 95 5 > /dev/null

--- a/debian/untangle-vm.postinst
+++ b/debian/untangle-vm.postinst
@@ -38,7 +38,6 @@ done
 rm -rf /var/lib/uvm/work
 
 # Check if the IP address 172.217.4.110/32 exists on the loopback interface
-echo "CHECKING IP"
 if ip addr show dev lo | grep -q '172.217.4.110' ; then
     # If it exists, delete the IP address
     ip addr del 172.217.4.110/32 dev lo

--- a/debian/untangle-vm.postinst
+++ b/debian/untangle-vm.postinst
@@ -38,6 +38,7 @@ done
 rm -rf /var/lib/uvm/work
 
 # Check if the IP address 172.217.4.110/32 exists on the loopback interface
+echo "CHECKING IP"
 if ip addr show dev lo | grep -q '172.217.4.110' ; then
     # If it exists, delete the IP address
     ip addr del 172.217.4.110/32 dev lo

--- a/debian/untangle-vm.postinst
+++ b/debian/untangle-vm.postinst
@@ -41,7 +41,11 @@ rm -rf /var/lib/uvm/work
 if ip addr show dev lo | grep -q '172.217.4.110' ; then
     # If it exists, delete the IP address
     ip addr del 172.217.4.110/32 dev lo
-    rm -rf /etc/untangle/post-network-hook.d/010-brightcloud-fix
+    
+    # Check if the file exists
+    if ls /etc/untangle/post-network-hook.d/010-brightcloud-fix &> /dev/null; then
+        rm -rf /etc/untangle/post-network-hook.d/010-brightcloud-fix
+    fi
 fi
 
 # set up uvm to start at boot

--- a/debian/untangle-vm.postinst
+++ b/debian/untangle-vm.postinst
@@ -43,7 +43,7 @@ if ip addr show dev lo | grep -q '172.217.4.110' ; then
     ip addr del 172.217.4.110/32 dev lo
     
     # Check if the file exists
-    if ls /etc/untangle/post-network-hook.d/010-brightcloud-fix &> /dev/null; then
+    if [ -f /etc/untangle/post-network-hook.d/010-brightcloud-fix ]; then
         rm -rf /etc/untangle/post-network-hook.d/010-brightcloud-fix
     fi
 fi


### PR DESCRIPTION
**ISSUE**: Brightcloud IP is not removing after update.
**FIX**: Updated the logic to remove brightcloud IP and `/etc/untangle/post-network-hook.d/010-brightcloud-fix` file after updating to latest version.

**TEST**:
**FRESH install:**

- Install ngfw 17.2
- Run command `ip addr show lo`  it should not contain 172.217.4.110/32 IP
- Also `/etc/untangle/post-network-hook.d/010-brightcloud-fix` should not present.
- Now connect to cmd server, enable device from there (It might take sometime to reflect server on cmd)
![Screenshot from 2024-10-03 19-30-08](https://github.com/user-attachments/assets/c9e53685-d9e4-4e1c-a176-c9c4038a319c)
- Run command `ip addr show lo`  again, it should not contain 172.217.4.110/32 IP
![Screenshot from 2024-10-03 19-42-20](https://github.com/user-attachments/assets/7c7e4d54-dfde-4c08-b9e5-dd0485f0a6be)


**UPDATE Scenario:**
- Install 17.1.1, connect to cmd server.
![Screenshot from 2024-10-03 19-30-08](https://github.com/user-attachments/assets/1bf1322f-2ead-4e1e-8ed9-8ea4226ccb46)

- Run command `ip addr show lo`  it should contain 172.217.4.110/32 IP
- Also `/etc/untangle/post-network-hook.d/010-brightcloud-fix` is  present.
![Screenshot from 2024-10-03 19-45-20](https://github.com/user-attachments/assets/706d2c9b-1f9b-4861-8829-2c5118fbbc2b)
- Now update to latest version. 
- Enable the server again from cmd.
- Now check `/etc/untangle/post-network-hook.d/010-brightcloud-fix` should not present.
- Now connect to cmd server, enable device from there (It might take sometime to reflect server on cmd)
![Screenshot from 2024-10-03 19-29-26](https://github.com/user-attachments/assets/af748406-bf41-4812-84cd-db1a10c7441d)