### PR TITLE
ngfw-14095  Updated the target state when apps are shut down for invalid license

### DIFF
--- a/uvm/api/com/untangle/uvm/app/AppBase.java
+++ b/uvm/api/com/untangle/uvm/app/AppBase.java
@@ -268,14 +268,14 @@ public abstract class AppBase implements App
     /**
      * Stop the application if it's running
      */
-    public void stopIfRunning()
+    public void stopIfRunning(boolean saveNewTargetState)
     {
         UvmContextFactory.context().loggingManager().setLoggingApp(appSettings.getId());
 
         switch (currentState)
         {
         case RUNNING:
-            stop(false);
+            stop(saveNewTargetState);
             break;
         case LOADED:
             break;

--- a/uvm/impl/com/untangle/uvm/AppManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/AppManagerImpl.java
@@ -1105,7 +1105,7 @@ public class AppManagerImpl implements AppManager
                     logger.info("Stopping  : " + name + " [" + id + "]");
 
                     long startTime = System.currentTimeMillis();
-                    ((AppBase) app).stopIfRunning();
+                    ((AppBase) app).stopIfRunning(false);
                     long endTime = System.currentTimeMillis();
 
                     logger.info("Stopped   : " + name + " [" + id + "] [" + (((float) (endTime - startTime)) / 1000.0f) + " seconds]");
@@ -1156,7 +1156,7 @@ public class AppManagerImpl implements AppManager
                         logger.info("Stopping  : " + name + " [" + id + "] because of invalid license");
 
                         long startTime = System.currentTimeMillis();
-                        ((AppBase) app).stopIfRunning();
+                        ((AppBase) app).stopIfRunning(true);
                         long endTime = System.currentTimeMillis();
 
                         logger.info("Stopped   : " + name + " [" + id + "] [" + (((float) (endTime - startTime)) / 1000.0f) + " seconds]");


### PR DESCRIPTION
-**RunState** and **TargetState** should be the same for making inconsistent false. 
-In the shutdownAppsWithInvalidLicense function, it always calls the stopIfRunning function to stop the app when its AppState is in the Running state. 
-However, it does not change the TargetState value, as saveNewTargetState is always set to false. 
-As a result, this causes Inconsistent to be true, and the app appears in red due to the inconsistency.
Code Snippet:
if(data.inconsistent){
    return 'Enabled but is not active'.t();
    
 Apps colour should be red only when license is expired or inconsistent
 Code snippet :
  calculate: function(data){
            if(data.inconsistent || data.expired){
                return '**fa-red'**;
