### PR TITLE
NGFW-14858: Updated Wan-failover-dns-test script as per fix under  NGFW-14568

### DIFF
--- a/wan-failover/hier/usr/share/untangle/bin/wan-failover-dns-test.sh
+++ b/wan-failover/hier/usr/share/untangle/bin/wan-failover-dns-test.sh
@@ -12,7 +12,7 @@ if [ -z "$DNS_SERVER" ] || [ "${DNS_SERVER}x" = "0.0.0.0x" ] ; then
     if [ -z "${DNS_SERVER}" ] && [ -f /etc/dnsmasq.d/dhcp-upstream-dns-servers ]; then
         DNS_SERVER=`awk '/^.*server=.*uplink.'${WAN_FAILOVER_NETD_INTERFACE_ID}'/ { sub( /^.*server=/, "" ) ; print $1 ; next ; exit }' /etc/dnsmasq.d/dhcp-upstream-dns-servers | head -n 1`
     fi
-    # extract DNS server from this pppoe dnsmasq file 
+    # extract DNS server from pppoe dnsmasq file 
     if [ -z "${DNS_SERVER}" ] && [ -f /etc/dnsmasq.d/pppoe-upstream-dns-servers ]; then
         DNS_SERVER=`awk '/^.*server=.*uplink.'${WAN_FAILOVER_NETD_INTERFACE_ID}'/ { sub( /^.*server=/, "" ) ; print $1 ; next ; exit }' /etc/dnsmasq.d/pppoe-upstream-dns-servers | head -n 1`
     fi

--- a/wan-failover/hier/usr/share/untangle/bin/wan-failover-dns-test.sh
+++ b/wan-failover/hier/usr/share/untangle/bin/wan-failover-dns-test.sh
@@ -7,10 +7,14 @@ HOSTNAME="www.untangle.com"
 
 if [ -z "$DNS_SERVER" ] || [ "${DNS_SERVER}x" = "0.0.0.0x" ] ; then
     # extract DNS server for this interface from the dnsmasq.conf file
-    DNS_SERVER=`awk '/^.*server=.*uplink.'${WAN_FAILOVER_NETD_INTERFACE_ID}'/ { sub( /^.*server=/, "" ) ; print $1 ; next ; exit }' /etc/dnsmasq.conf | head -n 1`
-    # extract DNS server for this dhcp dnsmasq file if it wasnt in dnsmasq.conf 
+    DNS_SERVER=`awk -F'=' '/^server=/ {split($2, a, "@"); print a[1]; exit}' /etc/dnsmasq.conf`
+    # extract DNS server from dhcp dnsmasq file  
     if [ -z "${DNS_SERVER}" ] && [ -f /etc/dnsmasq.d/dhcp-upstream-dns-servers ]; then
         DNS_SERVER=`awk '/^.*server=.*uplink.'${WAN_FAILOVER_NETD_INTERFACE_ID}'/ { sub( /^.*server=/, "" ) ; print $1 ; next ; exit }' /etc/dnsmasq.d/dhcp-upstream-dns-servers | head -n 1`
+    fi
+    # extract DNS server from this pppoe dnsmasq file 
+    if [ -z "${DNS_SERVER}" ] && [ -f /etc/dnsmasq.d/pppoe-upstream-dns-servers ]; then
+        DNS_SERVER=`awk '/^.*server=.*uplink.'${WAN_FAILOVER_NETD_INTERFACE_ID}'/ { sub( /^.*server=/, "" ) ; print $1 ; next ; exit }' /etc/dnsmasq.d/pppoe-upstream-dns-servers | head -n 1`
     fi
     if [ -z "${DNS_SERVER}" ]; then
         echo "Unable to determine current DNS server for interface ${WAN_FAILOVER_NETD_INTERFACE_ID}."


### PR DESCRIPTION
**ISSUE**
Under [NGFW-14568](https://awakesecurity.atlassian.net/browse/NGFW-14568), we have updated the way dnsmasq.conf generates server names for static DNS. The new format for Ethernet connections will appear as follows:

server=address5@device
For example:
server=192.168.25.65@eth2
Also updated PPOE DNS WAN failover test in script.

Note: For PPPoE-DNS and DHCP-DNS, we are continuing to use the previous format. The server names will reside under pppoe-upstream-dns-servers and dhcp-upstream-dns-servers, respectively. Thus, the PPPoE and DHCP server configurations will look like:
server=172.17.18.1 # uplink.1

**FIX**
The script has been updated to test WAN failover for all DNS servers.

**TEST**
Set up static, DHCP, and PPPoE WAN DNS servers one by one and perform the following steps for each:

1. Configure a system with only one WAN as shown in Figure 1 below.
2. Install WAN Failover and create a DNS test rule.
3. Click "Done" and save the failover test.
4. Click "Edit" for the most recent test and then click "Run Test." The test should pass.

[NGFW-14568]: https://awakesecurity.atlassian.net/browse/NGFW-14568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ