### PR TITLE
ngfw-14844 IPSec restart routing  issue fix

### DIFF
--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
@@ -414,7 +414,12 @@ public class IpsecVpnApp extends AppBase
 
         UvmContextFactory.context().daemonManager().incrementUsageCount("xl2tpd");
         UvmContextFactory.context().daemonManager().incrementUsageCount("ipsec");
-
+        // Fix for NGFW-14844 there should be waiting time between 
+        // charon daemon restart and STRONGSWAN_CONF_FILE rewrite
+        try {
+            Thread.sleep(2000);
+        } catch (Exception e) {
+        }
         reconfigure();
     }
 


### PR DESCRIPTION
**Changes:** added wait between charon daemon restart and STRONGSWAN_CONF_FILE conf file rewrite.

**Local Testing:** 

1. Setup a `IPSec tunnels` with two other NGFW's and `VPN Config` is disabled.

   ![Screenshot from 2024-10-16 19-17-16](https://github.com/user-attachments/assets/0cbd90bd-4ad4-4ff2-bf22-7d26c277c254)

2. With the fix tried to restart the untangle-vm multiple times, connection was not interrupted and routes were correct.

   ![Screenshot from 2024-10-16 19-24-08](https://github.com/user-attachments/assets/20f13461-219f-4c37-bec7-1c8aab0ba3a6)


   ![Screenshot from 2024-10-16 19-56-10](https://github.com/user-attachments/assets/e5724c14-7acc-4ba2-9229-977684d35e79)

