### PR TITLE
NGFW-14853: WAN failover with an enabled but non-active WAN interface

### DIFF
--- a/wan-failover/src/com/untangle/app/wan_failover/WanFailoverTester.java
+++ b/wan-failover/src/com/untangle/app/wan_failover/WanFailoverTester.java
@@ -5,6 +5,7 @@
 package com.untangle.app.wan_failover;
 
 import java.util.LinkedList;
+import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -21,12 +22,18 @@ import com.untangle.uvm.network.InterfaceSettings;
 public class WanFailoverTester implements Runnable
 {
     private static final int SLEEP_DELAY_MS = 5000;
-
     private static final String ARP_TEST = System.getProperty("uvm.bin.dir") + "/wan-failover-arp-test.sh";
     private static final String PING_TEST = System.getProperty("uvm.bin.dir") + "/wan-failover-ping-test.sh";
     private static final String HTTP_TEST = System.getProperty("uvm.bin.dir") + "/wan-failover-http-test.sh";
     private static final String DNS_TEST = System.getProperty("uvm.bin.dir") + "/wan-failover-dns-test.sh";
-
+    private static final Set<String> ERROR_MESSAGES = Set.of(
+        "FIB table does not exist",
+        "Dump terminated",
+        "does not exist",
+        "No such device"
+    );
+    private static final String WAN_INT_MESSAGE = "Wan interface is not connected or reachable. \n";
+    private static final String SPLIT_PATTERN = "\\r?\\n";
     private static final Logger logger = LogManager.getLogger(WanFailoverTester.class);
 
     private WanFailoverTesterMonitor monitor;
@@ -292,7 +299,7 @@ public class WanFailoverTester implements Runnable
 
             if (result.output.length() > 0) {
                 logger.debug("Test failed with message: " + result.output);
-                result.message = result.output;
+                result.message = sanitizeMessage(result.output);
                 result.success = false;
             } else {
                 result.message = I18nUtil.marktr("Test Successful.");
@@ -306,6 +313,33 @@ public class WanFailoverTester implements Runnable
         }
 
         return result;
+    }
+
+
+    /**
+     * Sanitize Error message
+     * 
+     * @param message
+     *        The error message
+     * 
+     * @return 
+     *        sanitized message
+     */
+    private static String sanitizeMessage (String message)
+    {
+        for (String errorMessage : ERROR_MESSAGES) {
+            if (message.contains(errorMessage)) {
+                //on first message return the last message
+                String[] lines = message.split(SPLIT_PATTERN);
+                //fetch the last message
+                for (int i = lines.length - 1; i >= 0; i--) {
+                    if (!lines[i].isBlank()) {
+                        return WAN_INT_MESSAGE + lines[i].trim(); // Return last message in the list
+                    }
+                }
+            }
+        }
+        return message;
     }
 
     /**


### PR DESCRIPTION
Scenario:  If Wan related tests are run on Wan interface which has some connectivity issues, or is not connected (for example PPPOE interface ,  configured but not reachable or connected). The message in this case is not user friendly. Added test case for the fix.

![Screenshot from 2024-10-17 21-26-27](https://github.com/user-attachments/assets/1ad6c614-23b0-48ba-9df0-821f890cb447)


Current Result:
`Error: ipv4: FIB table does not exist.
Dump terminated
Device "ppp0" does not exist.
ppp0: error fetching interface information: Device not found
PPPoE ppp0 Interface is down`

![image](https://github.com/user-attachments/assets/a26bfd82-3d9c-467d-8878-b180c2dd1b01)

Something similar for all tests DNS, ARP, HTTP, PING

Expected result:
Proper message mentioning connectivity of reachability issue along with test failed message. 

![image](https://github.com/user-attachments/assets/fb37ea08-5bb7-4100-bc86-1ceda6a27270)





