### PR TITLE
ngfw-13995 UPnP conditional removal

### DIFF
--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -113,6 +113,7 @@ Ext.define('Ung.config.network.MainController', {
 
             me.setPortForwardWarnings();
             me.setInterfaceConditions(); // update dest/source interfaces conditions from grids
+            me.setUpnpVisible();         // update upnpVisible flag on load settings
 
             vm.set('companyName', result[3]);
             vm.set('dnsTestHost', result[4].dnsTestHost);
@@ -1178,6 +1179,17 @@ Ext.define('Ung.config.network.MainController', {
     networkTestRender: function (view) {
         view.down('form').insert(0, view.commandFields);
     },
+
+    setUpnpVisible: function() {
+        var v = this.getView(),
+            vm = this.getViewModel(),
+            upnpVisisble = Rpc.directData('rpc.isExpertMode') || vm.get('settings.upnpSettings.upnpEnabled'),
+            upnpTabpanel = v.down('panel[itemId=upnp]');
+
+        if(upnpTabpanel) upnpTabpanel.setHidden(!upnpVisisble);
+        vm.set('settings.upnpSettings.upnpVisible', upnpVisisble);
+    },
+
     runTest: function (btn) {
         var v = btn.up('networktest'),
             vm = v.getViewModel(),

--- a/uvm/servlets/admin/config/network/view/Advanced.js
+++ b/uvm/servlets/admin/config/network/view/Advanced.js
@@ -543,12 +543,37 @@ Ext.define('Ung.config.network.view.Advanced', {
             title: 'UPnP'.t(),
             itemId: 'upnp',
             scrollable: true,
+            tabConfig: {
+                hidden: true,
+                bind: {
+                    hidden: '{!settings.upnpSettings.upnpVisible}'
+                }
+            },
+
+            tbar: [{
+                xtype: 'tbtext',
+                padding: '8 5',
+                style: { fontSize: '12px' },
+                hidden: Rpc.directData('rpc.isExpertMode'),
+                html: '<i class="fa fa-exclamation-triangle" style="color: red;"></i> ' + 'Warning: Disabling UPnP will remove this feature.'.t()
+            }],
 
             items:[{
                 xtype: 'checkbox',
                 fieldLabel: 'UPnP Enabled'.t(),
                 labelAlign: 'right',
-                bind: '{settings.upnpSettings.upnpEnabled}'
+                bind: '{settings.upnpSettings.upnpEnabled}',
+                listeners: {
+                    change: function (checkbox, newValue) {
+                        var upnpTab = this.up('panel[itemId=upnp]'),
+                            configPanel = this.up('tabpanel[itemId=configCard]'),
+                            vm = configPanel.getViewModel(),
+                            upnpVisible = Rpc.directData('rpc.isExpertMode') || newValue;
+
+                        upnpTab.setHidden(!upnpVisible);
+                        vm.set('settings.upnpSettings.upnpVisible', upnpVisible);
+                    }
+                }
             }, {
                 xtype: 'checkbox',
                 fieldLabel: 'Secure Mode'.t(),


### PR DESCRIPTION
**Changes:** Removing UPnP functionality with below conditions.

If `expert mode` is active then at all conditions UPnP tab will be visible and user will be able to enable or disable the functionality.

![Screenshot from 2024-10-22 23-06-54](https://github.com/user-attachments/assets/3afe8904-ac79-424c-ab7e-9c79e447ed26)

![Screenshot from 2024-10-22 23-07-05](https://github.com/user-attachments/assets/da5080e3-75af-45f5-b7ee-bd2c4a1ce3bf)

-----------------------------------------

In normal mode (i.e. without expert mode) on upgrade if user is already using UPnP functionality and it is enabled then only UPnP tab will be visible. With message `Warning: Disabling UPnP will remove this feature.`
If user disables the UPnP then tab will be hidden.

![Screenshot from 2024-10-22 23-09-28](https://github.com/user-attachments/assets/cd61d6fb-0dc7-4d24-9f31-32d8e41e9745)
![Screenshot from 2024-10-22 23-09-39](https://github.com/user-attachments/assets/eb226d78-0f66-42f2-a031-9e5b0fc2a7f5)

-----------------------------------------
