### PR TITLE
ngfw-14866 Captive Portal Not Working on Wireguard Tunnel Issue Fix

### DIFF
--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -75,11 +75,11 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
     }, {
         xtype: "checkbox",
         bind: '{settings.mapTunnelDescUser}',
-        fieldLabel: 'Map tunnel description to users'.t(),
+        fieldLabel: 'Set authenticated username as tunnel description'.t(),
         padding: '8 5 5 0',
         autoEl: {
             tag: 'div',
-            'data-qtip': "If enabled tunnel description will be mapped to users table".t()
+            'data-qtip': "If enabled, tunnel description will be set as authenticated user".t()
         },
         checked: false
     }, {

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -9,7 +9,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
     padding: '8 5',
 
     defaults: {
-        labelWidth: 175
+        labelWidth: 200
     },
 
     items: [{
@@ -25,7 +25,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                 value: '{settings.listenPort}'
             },
             allowBlank: false,
-            labelWidth: 175,
+            labelWidth: 200,
             padding: '8 5 5 0',
             listeners: {
                 change: function(field, newValue, oldValue) {
@@ -59,7 +59,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                 value: '{settings.mtu}'
             },
             allowBlank: false,
-            labelWidth: 175,
+            labelWidth: 200,
             padding: '8 5 5 0',
             listeners: {
                 change: function(field, newValue, oldValue) {
@@ -73,13 +73,23 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
             margin: '18 0 5 5'
         }],
     }, {
+        xtype: "checkbox",
+        bind: '{settings.mapTunnelDescUser}',
+        fieldLabel: 'Map tunnel description to users'.t(),
+        padding: '8 5 5 0',
+        autoEl: {
+            tag: 'div',
+            'data-qtip': "If enabled tunnel description will be mapped to users table".t()
+        },
+        checked: false
+    }, {
         xtype: 'fieldset',
         title: 'Remote Client Configuration'.t(),
         layout: {
             type: 'vbox'
         },
         defaults: {
-            labelWidth: 165,
+            labelWidth: 190,
             padding: "0 0 10 0"
         },
         items:[{
@@ -95,7 +105,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
             items: [{
                 xtype: 'label',
                 text: 'Local Networks:'.t(),
-                width: 170
+                width: 195
             },{
                 xtype: 'ungrid',
                 itemId: 'localNetworkGrid',
@@ -165,7 +175,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
             type: 'vbox'
         },
         defaults: {
-            labelWidth: 165
+            labelWidth: 190
         },
         items:[{
             fieldLabel: 'Assignment'.t(),
@@ -184,7 +194,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
             xtype: 'fieldcontainer',
             layout: 'hbox',
             defaults: {
-                labelWidth: 165
+                labelWidth: 190
             },
             items: [{
                     fieldLabel: 'Network Space'.t(),

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnMonitor.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnMonitor.java
@@ -449,7 +449,8 @@ class WireGuardVpnMonitor implements Runnable
      */
     private void addHostTableEntry(WireGuardVpnTunnel tunnel, Boolean createIfNecessary)
     {
-        if (tunnel != null && tunnel.getPeerAddress() != null) {
+        boolean isMappingEnabled = app.getSettings().isMapTunnelDescUser();
+        if (isMappingEnabled && tunnel != null && tunnel.getPeerAddress() != null) {
             HostTableEntry entry = UvmContextFactory.context().hostTable().getHostTableEntry(tunnel.getPeerAddress(), createIfNecessary);
                 entry.setHostnameWireGuardVpn(tunnel.getDescription());
                 //Update username when Tunnel connection is established

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
@@ -24,6 +24,7 @@ public class WireGuardVpnSettings implements Serializable, JSONString
     private Integer keepaliveInterval = 25;
     private Integer listenPort = 51820;
     private Integer mtu = 1500;
+    private boolean mapTunnelDescUser = false;
     private IPMaskedAddress addressPool;
     private String privateKey = "";
     private String publicKey = "";
@@ -44,6 +45,9 @@ public class WireGuardVpnSettings implements Serializable, JSONString
 
     public Integer getMtu() { return mtu; }
     public void setMtu( Integer newValue ) { this.mtu = newValue; }
+
+    public boolean isMapTunnelDescUser() { return mapTunnelDescUser; }
+    public void setMapTunnelDescUser(boolean mapTunnelDescUser) { this.mapTunnelDescUser = mapTunnelDescUser; }
 
     public IPMaskedAddress getAddressPool() { return addressPool; }
     public void setAddressPool( IPMaskedAddress newValue ) { this.addressPool = newValue; }


### PR DESCRIPTION
**Changes:** 
Added a checkbox on `WireGurad VPN --> Settings` Page with label `Map tunnel description to users` with below function.
1. If disabled then tunnel `description` will not be mapped to `Host Table Entry` as `hostname` and `username` field. So Captive Portal and Firewall apps will be able to capture the traffic coming though tunnel. 

2. If enabled WireGuard tunnel `description` will be mapped to `Host Table Entry` as `hostname` and `username` field. Hence Captive Portal / Firewall won't work as mentioned in ticket [NGFW-14862](https://awakesecurity.atlassian.net/browse/NGFW-14862)



[NGFW-14862]: https://awakesecurity.atlassian.net/browse/NGFW-14862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ