### PR TITLE
ngfw-14833 -added UI changes of ECH block

### DIFF
--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterSettings.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterSettings.java
@@ -44,6 +44,7 @@ public class WebFilterSettings implements Serializable, JSONString
     private Boolean passReferers = true;
     private Boolean restrictGoogleApps = false;
     private String restrictGoogleAppsDomain = "";
+    private Boolean blockECH = false;
 
     private Boolean customBlockPageEnabled = false;
     private String customBlockPageUrl = "";
@@ -153,6 +154,9 @@ public class WebFilterSettings implements Serializable, JSONString
     public Boolean getCloseHttpsBlockEnabled() { return closeHttpsBlockEnabled; }
     public void setCloseHttpsBlockEnabled( Boolean closeHttpsBlockEnabled ) { this.closeHttpsBlockEnabled = closeHttpsBlockEnabled; }
 
+    public Boolean getBlockECH() { return blockECH; }
+    public void setBlockECH( Boolean blockECH ) { this.blockECH = blockECH; }
+    
     public GenericRule getCategory(Integer id)
     {
         for (GenericRule cat : getCategories()) {

--- a/web-filter/js/view/Advanced.js
+++ b/web-filter/js/view/Advanced.js
@@ -101,6 +101,10 @@ Ext.define('Ung.apps.webfilter.view.Advanced', {
             xtype: 'checkbox',
             boxLabel: 'Close connection for blocked HTTPS sessions without redirecting to block page'.t(),
             bind: '{settings.closeHttpsBlockEnabled}'
+        }, {
+            xtype: 'checkbox',
+            boxLabel: 'Block Encrypted Client Hello (ECH)'.t(),
+            bind: '{settings.blockECH}'
         }]
     }, {
         xtype: 'fieldset',


### PR DESCRIPTION
Testing scenarios:

1. Initially, Block ECH is disable, and logged as false in web filter settings file

![image](https://github.com/user-attachments/assets/1f56994a-d566-49b7-b562-2f5f19a91040)
![image](https://github.com/user-attachments/assets/1ec119df-348c-41c0-b5ad-8efc809bf9f3)

2. When enables the Block ECH --> logged as true in web filter settings file

![image](https://github.com/user-attachments/assets/35c10267-1423-4a73-b182-ac399180b322)
![image](https://github.com/user-attachments/assets/7d9d1780-3c8c-4d35-bf86-125969907b0f)

3. When disables Block ECH --> logged as false in web filter settings file

![image](https://github.com/user-attachments/assets/9b61ef1f-8927-4a9a-be63-d0fad9a0c75e)
![image](https://github.com/user-attachments/assets/8c75d9c1-a9a9-4d1b-894d-f313afa4ac48)
