### PR TITLE
ngfw-14886: Need to change key value from catid to cat (bctid upgrade  36.1)

### DIFF
--- a/webroot-base/src/com/untangle/app/webroot/WebrootQuery.java
+++ b/webroot-base/src/com/untangle/app/webroot/WebrootQuery.java
@@ -98,7 +98,7 @@ public class WebrootQuery
     public static final String BCTI_API_DAEMON_REQUEST_URLINFO_SUFFIX = "\"],\"a1cat\":1, \"reputation\":1}}\r\n";
 
     public static final String BCTI_API_DAEMON_RESPONSE_URLINFO_CATEGORY_LIST_KEY="cats";
-    public static final String BCTI_API_DAEMON_RESPONSE_URLINFO_CATEGORY_ID_KEY="catid";
+    public static final String BCTI_API_DAEMON_RESPONSE_URLINFO_CATEGORY_ID_KEY="cat";
     public static final String BCTI_API_DAEMON_RESPONSE_URLINFO_A1CAT_KEY="a1cat";
 
     public static final String BCTI_API_DAEMON_RESPONSE_URLINFO_URL_KEY="url";


### PR DESCRIPTION
Tested the changes locally with build for ngfw and mfw openwrt. Upgraded Bctid daemon with webfilter is working as expected.
However there are dependant tickets for NGFW and MFW for following

Handling libcjson dependency and Need to change key value from catid to cat.

https://awakesecurity.atlassian.net/browse/NGFW-14884
https://awakesecurity.atlassian.net/browse/MFW-5803
These all changes should go in simultaneously.

Tested webfilter test cases all things are working fine
![web-filter](https://github.com/user-attachments/assets/d39ba7c6-acf9-4a04-96d9-ff14855a0ea1)

