### PR TITLE
Ngfw 14874 test 081 any remote tunnel ping fix

### DIFF
--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -834,7 +834,7 @@ class IPsecTests(NGFWTestCase):
         time.sleep(10)
 
         # Add pingAddress in local NGFW tunnel
-        ipsec_settings["tunnels"]["list"][0]["pingAddress"] = "192.168.57.100"
+        ipsec_settings["tunnels"]["list"][0]["pingAddress"] = IPSEC_HOST_LAN_IP
         self._app.setSettings(ipsec_settings)
         time.sleep(40)
 

--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -52,8 +52,8 @@ tunnelUp = False
 ipsecTestLAN = ""
 orig_netsettings = None
 
-tunnel_local_ip = None
-tunnel_local_lan_ip = None
+local_host_ip = None
+local_host_lan_ip = None
 
 Remote_ngfw = overrides.get("Remote_ngfw", default={
         "serverAddress": IPSEC_HOST,
@@ -65,7 +65,7 @@ def build_ipsec_tunnel(remote_ip=IPSEC_HOST, remote_lan=IPSEC_HOST_LAN, local_ip
     Create an ipsec tunnel settings entry.
     If the Local values are not defined, use the WAN address to search for them from IPSEC_CONFIGURED_HOST_IPS.
     """
-    global tunnel_local_ip, tunnel_local_lan_ip
+    global local_host_ip, local_host_lan_ip
     if ( local_ip is None or
          local_lan_ip is None or
          local_lan_range is None ):
@@ -79,8 +79,8 @@ def build_ipsec_tunnel(remote_ip=IPSEC_HOST, remote_lan=IPSEC_HOST_LAN, local_ip
                     local_lan_ip = host_config[1]
                 if local_lan_range is None:
                     local_lan_range = host_config[2]
-                tunnel_local_ip = local_ip
-                tunnel_local_lan_ip = local_lan_ip
+                local_host_ip = local_ip
+                local_host_lan_ip = local_lan_ip
                 break
 
         if ( local_ip is None or
@@ -829,7 +829,7 @@ class IPsecTests(NGFWTestCase):
 
         
         remote_ipsec_settings = remote_app.getSettings()
-        remote_ipsec_settings["tunnels"]["list"] = [build_ipsec_tunnel(remote_ip=tunnel_local_ip, remote_lan=tunnel_local_lan_ip)]
+        remote_ipsec_settings["tunnels"]["list"] = [build_ipsec_tunnel(remote_ip=local_host_ip, remote_lan=local_host_lan_ip)]
         remote_app.setSettings(remote_ipsec_settings)
         time.sleep(10)
 

--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -73,7 +73,7 @@ def build_ipsec_tunnel(remote_ip=IPSEC_HOST, remote_lan=IPSEC_HOST_LAN, local_ip
         wan_ip = global_functions.uvmContext.networkManager().getFirstWanAddress()
         for host_config in IPSEC_CONFIGURED_HOST_IPS:
             if (wan_ip == host_config[0]):
-                local_ip, local_lan_ip, local_lan_range = getLocalIpConfiguration(wan_ip, host_config)
+                local_ip, local_lan_ip, local_lan_range = getLocalIpConfiguration(host_config)
                 tunnel_local_ip = local_ip
                 tunnel_local_lan_ip = local_lan_ip
                 break
@@ -114,14 +114,13 @@ def build_ipsec_tunnel(remote_ip=IPSEC_HOST, remote_lan=IPSEC_HOST_LAN, local_ip
         "ikeVersion": 2
     }    
     
-def getLocalIpConfiguration(wan_ip, host_config, local_ip=None, local_lan_ip=None, local_lan_range=None):
-    if (wan_ip == host_config[0]):
-            if local_ip is None:
-                local_ip = host_config[0]
-            if local_lan_ip is None:
-                local_lan_ip = host_config[1]
-            if local_lan_range is None:
-                local_lan_range = host_config[2]
+def getLocalIpConfiguration(host_config, local_ip=None, local_lan_ip=None, local_lan_range=None):
+    if local_ip is None:
+        local_ip = host_config[0]
+    if local_lan_ip is None:
+        local_lan_ip = host_config[1]
+    if local_lan_range is None:
+        local_lan_range = host_config[2]
     return local_ip, local_lan_ip, local_lan_range
 
 def nukeIPSecTunnels(app):

--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -73,7 +73,12 @@ def build_ipsec_tunnel(remote_ip=IPSEC_HOST, remote_lan=IPSEC_HOST_LAN, local_ip
         wan_ip = global_functions.uvmContext.networkManager().getFirstWanAddress()
         for host_config in IPSEC_CONFIGURED_HOST_IPS:
             if (wan_ip == host_config[0]):
-                local_ip, local_lan_ip, local_lan_range = getLocalIpConfiguration(host_config)
+                if local_ip is None:
+                    local_ip = host_config[0]
+                if local_lan_ip is None:
+                    local_lan_ip = host_config[1]
+                if local_lan_range is None:
+                    local_lan_range = host_config[2]
                 tunnel_local_ip = local_ip
                 tunnel_local_lan_ip = local_lan_ip
                 break
@@ -114,15 +119,6 @@ def build_ipsec_tunnel(remote_ip=IPSEC_HOST, remote_lan=IPSEC_HOST_LAN, local_ip
         "ikeVersion": 2
     }    
     
-def getLocalIpConfiguration(host_config, local_ip=None, local_lan_ip=None, local_lan_range=None):
-    if local_ip is None:
-        local_ip = host_config[0]
-    if local_lan_ip is None:
-        local_lan_ip = host_config[1]
-    if local_lan_range is None:
-        local_lan_range = host_config[2]
-    return local_ip, local_lan_ip, local_lan_range
-
 def nukeIPSecTunnels(app):
     ipsecSettings = app.getSettings()
     ipsecSettings["tunnels"]["list"] = []


### PR DESCRIPTION
Description:
ATS IPsec test test_081_any_remote_tunnel_ping removed hard coded IP addresses.  This test will pass on generic ATS testbeds since the IP addresses must be retrieved from the environment.  

Test scenario:
Execute the test case test_081_any_remote_tunnel_ping and ensure that it passes
Test case - **test_081_any_remote_tunnel_ping** result as passed 
![image](https://github.com/user-attachments/assets/bb1e0077-db64-41cb-b64d-3b8a464c5e5d)
