### PR TITLE
Ngfw 14888 hard disk checks before upgrade

### DIFF
--- a/uvm/api/com/untangle/uvm/SystemManager.java
+++ b/uvm/api/com/untangle/uvm/SystemManager.java
@@ -83,4 +83,6 @@ public interface SystemManager
     void activateRadiusCertificate();
 
     Long getLogDirectorySize();
+
+    void logDiskCheckFailure( String diskCheckErrors );
 }

--- a/uvm/api/com/untangle/uvm/util/Constants.java
+++ b/uvm/api/com/untangle/uvm/util/Constants.java
@@ -1,0 +1,34 @@
+/**
+ * $Id$
+ */
+
+package com.untangle.uvm.util;
+
+/**
+ * Constants
+ */
+public class Constants {
+
+    // Symbols
+    public static final String EQUALS_TO = "=";
+
+    // Boolean
+    public static final String FALSE = "False";
+    public static final String TRUE = "True";
+
+    // Condition Keys
+    public static final String CLASS = "class";
+    public static final String COMPONENT = "component";
+    public static final String ACTION = "action";
+    public static final String S_SERVER_PORT = "SServerPort";
+    public static final String BLOCKED = "blocked";
+    public static final String CATEGORY = "category";
+
+    // Class Regexex as condition matcher
+    public static final String CRITICAL_ALERT_EVENT_RGX = "*CriticalAlertEvent*";
+    public static final String SYSTEM_STAT_EVENT_RGX = "*SystemStatEvent*";
+    public static final String SESSION_EVENT_RGX = "*SessionEvent*";
+    public static final String WEB_FILTER_EVENT_RGX = "*WebFilterEvent*";
+    public static final String APP_CONTROL_LOG_EVENT_RGX = "*ApplicationControlLogEvent*";
+
+}

--- a/uvm/hier/usr/lib/python3/dist-packages/uvm/disk_health.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/uvm/disk_health.py
@@ -1,0 +1,63 @@
+import json
+from psutil import disk_partitions
+from subprocess import run, CalledProcessError
+import re
+import logging
+from collections import defaultdict
+
+# Constants for Messages
+ROOT_NOT_FOUND = "Root partition not found."
+SMART_UNSUPPORTED_KEYWORDS = ["Unavailable", "not supported", "lacks SMART capability"]
+SMART_UNSUPPORTED = "SMART support is: Unavailable - device lacks SMART capability"
+SMART_PASS_KEYWORD = "PASSED"
+SMART_FAIL_KEYWORD = "FAILED"
+SMART_RESULT = "SMART overall-health self-assessment test result:"
+SMART_ERROR = "Failed to run smartctl on"
+
+# Configure logging
+logging.basicConfig(filename="/var/log/diskcheck.log", level=logging.INFO, format="%(asctime)s - %(message)s")
+
+# Health status dictionary
+status = defaultdict(list)
+
+def update_status(level, msg):
+    """Update status dictionary and log the message."""
+    status[level].append(msg)
+    logging.info(f"{level.upper()}: {msg}")
+
+def get_root_disk():
+    """Identify the root disk by finding the '/' mount point."""
+    root_part = next((part for part in disk_partitions(all=False) if part.mountpoint == '/'), None)
+    if not root_part:
+        update_status("error", ROOT_NOT_FOUND)
+        return None
+    return re.sub(r'p?\d+$', '', root_part.device)
+
+def run_smart_check(disk):
+    """Perform a SMART health check on the specified disk."""
+    try:
+        result = run(["smartctl", "-H", disk], capture_output=True, text=True, check=True)
+        output = result.stdout
+    except CalledProcessError as e:
+        output = e.stdout or e.stderr
+        msg = SMART_UNSUPPORTED if any(keyword in output for keyword in SMART_UNSUPPORTED_KEYWORDS) else f"{SMART_ERROR} {disk}: {output}"
+        update_status("error", msg)
+        return
+
+    if SMART_PASS_KEYWORD in output:
+        update_status("pass", f"{SMART_RESULT} {SMART_PASS_KEYWORD}")
+    elif SMART_FAIL_KEYWORD in output:
+        update_status("fail", f"{SMART_RESULT} {SMART_FAIL_KEYWORD}")
+    else:
+        update_status("error", f"{SMART_RESULT} UNKNOWN")
+
+def check_smart_health():
+    """Find and check the SMART health of the root disk."""
+    root_disk = get_root_disk()
+    if root_disk:
+        run_smart_check(root_disk)
+    return dict(status)  # Convert defaultdict back to dict for compatibility
+
+def check_disk_health():
+    """Main function to check disk health."""
+    return check_smart_health()

--- a/uvm/hier/usr/lib/python3/dist-packages/uvm/disk_health.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/uvm/disk_health.py
@@ -1,8 +1,6 @@
-import json
 from psutil import disk_partitions
 from subprocess import run, CalledProcessError
 import re
-import logging
 from collections import defaultdict
 
 # Constants for Messages
@@ -14,16 +12,12 @@ SMART_FAIL_KEYWORD = "FAILED"
 SMART_RESULT = "SMART overall-health self-assessment test result:"
 SMART_ERROR = "Failed to run smartctl on"
 
-# Configure logging
-logging.basicConfig(filename="/var/log/diskcheck.log", level=logging.INFO, format="%(asctime)s - %(message)s")
-
 # Health status dictionary
 status = defaultdict(list)
 
 def update_status(level, msg):
-    """Update status dictionary and log the message."""
+    """Update status dictionary."""
     status[level].append(msg)
-    logging.info(f"{level.upper()}: {msg}")
 
 def get_root_disk():
     """Identify the root disk by finding the '/' mount point."""
@@ -58,6 +52,3 @@ def check_smart_health():
         run_smart_check(root_disk)
     return dict(status)  # Convert defaultdict back to dict for compatibility
 
-def check_disk_health():
-    """Main function to check disk health."""
-    return check_smart_health()

--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -12,6 +12,8 @@ import tempfile
 import time
 import logging
 import platform
+from uvm import Uvm
+from uvm import disk_health
 
 # set noninteractive mode for all apt-get calls
 os.environ['DEBIAN_FRONTEND'] = 'noninteractive'
@@ -140,9 +142,18 @@ def check_dpkg():
         cmd_to_log(dpkg_config)
         return
 
+def check_disk_health():
+    health_status = disk_health.check_smart_health()
+    log(f"disk health status: {health_status}")
+    if "fail" in health_status:
+        Uvm().getUvmContext().systemManager().logDiskCheckFailure(str(health_status))
+        log("Aborting Upgrade\n")
+        sys.exit()
 
 log_date( os.path.basename( sys.argv[0]) )
 
+log("")
+check_disk_health()
 log("")
 
 check_dpkg()

--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -149,7 +149,7 @@ def check_disk_health():
         if "fail" in health_status:
             Uvm().getUvmContext().systemManager().logDiskCheckFailure(str(health_status))
             log("Disk health check failed, Aborting Upgrade.\n")
-            sys.exit()
+            sys.exit(1)
     except Exception as e:
         log(f"Disk health check encountered an error {e}, proceeding with upgrade.")
 

--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -150,8 +150,8 @@ def check_disk_health():
             Uvm().getUvmContext().systemManager().logDiskCheckFailure(str(health_status))
             log("Disk health check failed, Aborting Upgrade.\n")
             sys.exit()
-    except:
-        log(f"Disk health check encountered an error, proceeding with upgrade.")
+    except Exception as e:
+        log(f"Disk health check encountered an error {e}, proceeding with upgrade.")
 
 log_date( os.path.basename( sys.argv[0]) )
 

--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -143,12 +143,15 @@ def check_dpkg():
         return
 
 def check_disk_health():
-    health_status = disk_health.check_smart_health()
-    log(f"disk health status: {health_status}")
-    if "fail" in health_status:
-        Uvm().getUvmContext().systemManager().logDiskCheckFailure(str(health_status))
-        log("Aborting Upgrade\n")
-        sys.exit()
+    try:
+        health_status = disk_health.check_smart_health()
+        log(f"disk health status: {health_status}")
+        if "fail" in health_status:
+            Uvm().getUvmContext().systemManager().logDiskCheckFailure(str(health_status))
+            log("Disk health check failed, Aborting Upgrade.\n")
+            sys.exit()
+    except:
+        log(f"Disk health check encountered an error, proceeding with upgrade.")
 
 log_date( os.path.basename( sys.argv[0]) )
 

--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -15,6 +15,7 @@ import com.untangle.uvm.event.SyslogRule;
 import com.untangle.uvm.event.SyslogServer;
 import com.untangle.uvm.event.TriggerRule;
 import com.untangle.uvm.logging.LogEvent;
+import com.untangle.uvm.util.Constants;
 import com.untangle.uvm.util.I18nUtil;
 import com.untangle.uvm.util.StringUtil;
 import org.apache.commons.io.IOUtils;
@@ -261,7 +262,7 @@ public class EventManagerImpl implements EventManager
         Boolean classFound = false;
         String fieldValue = null;
         for(EventRuleCondition condition: rule.getConditions()){
-            if(condition.getField().equals("class") || condition.getField().equals("javaClass")){
+            if(condition.getField().equals(Constants.CLASS) || condition.getField().equals("javaClass")){
                 fieldValue = condition.getFieldValue();
                 classFound = true;
                 if(!classes.contains(fieldValue)){
@@ -348,7 +349,7 @@ public class EventManagerImpl implements EventManager
 
             for(String variable : sortedKeys){
                 JSONObject jo = new JSONObject(EventManagerImpl.eventTemplateVariables.get(variable));
-                jo.remove("class");
+                jo.remove(Constants.CLASS);
                 result.put(index++, jo);
             }
         }catch(Exception e){
@@ -428,10 +429,10 @@ public class EventManagerImpl implements EventManager
             // search for the CriticalAlertEvent DISK_CHECK_FAILURE rule
             for (EventRule er : settings.getAlertRules()) {
                 for(EventRuleCondition c : er.getConditions()) {
-                    if(c.getField().equals("class") && c.getFieldValue().equals("*CriticalAlertEvent*")){
+                    if(c.getField().equals(Constants.CLASS) && c.getFieldValue().equals(Constants.CRITICAL_ALERT_EVENT_RGX)){
                         criticalFlag = true;
                     }
-                    if(c.getField().equals("component") && c.getFieldValue().equals("DISK_CHECK_FAILURE")){
+                    if(c.getField().equals(Constants.COMPONENT) && c.getFieldValue().equals("DISK_CHECK_FAILURE")){
                         diskCheckFailFlag = true;
                     }
                 }
@@ -445,9 +446,9 @@ public class EventManagerImpl implements EventManager
                 AlertRule eventRule;
 
                 conditions = new LinkedList<>();
-                condition1 = new EventRuleCondition( "class", "=", "*CriticalAlertEvent*" );
+                condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.CRITICAL_ALERT_EVENT_RGX );
                 conditions.add( condition1 );
-                condition2 = new EventRuleCondition( "component", "=", "DISK_CHECK_FAILURE" );
+                condition2 = new EventRuleCondition( Constants.COMPONENT, Constants.EQUALS_TO, "DISK_CHECK_FAILURE" );
                 conditions.add( condition2 );
                 eventRule = new AlertRule( true, conditions, true, true, "Disk health checks failed", false, 0 );
                 settings.getAlertRules().addFirst( eventRule );
@@ -500,31 +501,31 @@ public class EventManagerImpl implements EventManager
         AlertRule eventRule;
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*CriticalAlertEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.CRITICAL_ALERT_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "component", "=", "DISK_CHECK_FAILURE" );
+        condition2 = new EventRuleCondition( Constants.COMPONENT, Constants.EQUALS_TO, "DISK_CHECK_FAILURE" );
         conditions.add( condition2 );
         eventRule = new AlertRule( true, conditions, true, true, "Disk health checks failed", false, 0 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*CriticalAlertEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.CRITICAL_ALERT_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "component", "=", "REPORTS" );
+        condition2 = new EventRuleCondition( Constants.COMPONENT, Constants.EQUALS_TO, "REPORTS" );
         conditions.add( condition2 );
         eventRule = new AlertRule( true, conditions, true, true, "Reporting disabled due to low disk space", false, 0 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*WanFailoverEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, "*WanFailoverEvent*" );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "action", "=", "DISCONNECTED" );
+        condition2 = new EventRuleCondition( Constants.ACTION, Constants.EQUALS_TO, "DISCONNECTED" );
         conditions.add( condition2 );
         eventRule = new AlertRule( true, conditions, true, true, "WAN is offline", false, 0 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*SystemStatEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.SYSTEM_STAT_EVENT_RGX );
         conditions.add( condition1 );
         condition2 = new EventRuleCondition( "load1", ">", "20" );
         conditions.add( condition2 );
@@ -532,7 +533,7 @@ public class EventManagerImpl implements EventManager
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*SystemStatEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.SYSTEM_STAT_EVENT_RGX );
         conditions.add( condition1 );
         condition2 = new EventRuleCondition( "diskFreePercent", "<", ".2" );
         conditions.add( condition2 );
@@ -540,7 +541,7 @@ public class EventManagerImpl implements EventManager
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*SystemStatEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.SYSTEM_STAT_EVENT_RGX );
         conditions.add( condition1 );
         condition2 = new EventRuleCondition( "memFreePercent", "<", ".05" );
         conditions.add( condition2 );
@@ -548,7 +549,7 @@ public class EventManagerImpl implements EventManager
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*SystemStatEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.SYSTEM_STAT_EVENT_RGX );
         conditions.add( condition1 );
         condition2 = new EventRuleCondition( "swapUsedPercent", ">", ".25" );
         conditions.add( condition2 );
@@ -556,93 +557,93 @@ public class EventManagerImpl implements EventManager
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*SessionEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.SESSION_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "SServerPort", "=", "22" );
+        condition2 = new EventRuleCondition( Constants.S_SERVER_PORT, Constants.EQUALS_TO, "22" );
         conditions.add( condition2 );
         eventRule = new AlertRule( true, conditions, true, true, "Suspicious Activity: Client created many SSH sessions", true, 60, Boolean.TRUE, 20.0D, 60, "CClientAddr");
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*SessionEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.SESSION_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "SServerPort", "=", "3389" );
+        condition2 = new EventRuleCondition( Constants.S_SERVER_PORT, Constants.EQUALS_TO, "3389" );
         conditions.add( condition2 );
         eventRule = new AlertRule( true, conditions, true, true, "Suspicious Activity: Client created many RDP sessions", true, 60, Boolean.TRUE, 20.0D, 60, "CClientAddr");
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*SessionEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.SESSION_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "entitled", "=", "false" );
+        condition2 = new EventRuleCondition( "entitled", Constants.EQUALS_TO, Constants.FALSE );
         conditions.add( condition2 );
         eventRule = new AlertRule( true, conditions, true, true, "License limit exceeded. Session not entitled", true, 60*24 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*WebFilterEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.WEB_FILTER_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "blocked", "=", "False" );
+        condition2 = new EventRuleCondition( Constants.BLOCKED, Constants.EQUALS_TO, Constants.FALSE );
         conditions.add( condition2 );
-        condition3 = new EventRuleCondition( "category", "=", "Malware Sites" );
+        condition3 = new EventRuleCondition( Constants.CATEGORY, Constants.EQUALS_TO, "Malware Sites" );
         conditions.add( condition3 );
         eventRule = new AlertRule( true, conditions, true, true, "Malware Sites website visit detected", false, 10 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*WebFilterEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.WEB_FILTER_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "blocked", "=", "True" );
+        condition2 = new EventRuleCondition( Constants.BLOCKED, Constants.EQUALS_TO, Constants.TRUE );
         conditions.add( condition2 );
-        condition3 = new EventRuleCondition( "category", "=", "Malware Sites" );
+        condition3 = new EventRuleCondition( Constants.CATEGORY, Constants.EQUALS_TO, "Malware Sites" );
         conditions.add( condition3 );
         eventRule = new AlertRule( true, conditions, true, true, "Malware Sites website visit blocked", false, 10 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*WebFilterEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.WEB_FILTER_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "blocked", "=", "False" );
+        condition2 = new EventRuleCondition( Constants.BLOCKED, Constants.EQUALS_TO, Constants.FALSE );
         conditions.add( condition2 );
-        condition3 = new EventRuleCondition( "category", "=", "Bot Netst" );
+        condition3 = new EventRuleCondition( Constants.CATEGORY, Constants.EQUALS_TO, "Bot Netst" );
         conditions.add( condition3 );
         eventRule = new AlertRule( true, conditions, true, true, "Bot Nets website visit detected", false, 10 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*WebFilterEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.WEB_FILTER_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "blocked", "=", "True" );
+        condition2 = new EventRuleCondition( Constants.BLOCKED, Constants.EQUALS_TO, Constants.TRUE );
         conditions.add( condition2 );
-        condition3 = new EventRuleCondition( "category", "=", "Bot Nets" );
+        condition3 = new EventRuleCondition( Constants.CATEGORY, Constants.EQUALS_TO, "Bot Nets" );
         conditions.add( condition3 );
         eventRule = new AlertRule( true, conditions, true, true, "Bot Nets website visit blocked", false, 10 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*WebFilterEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.WEB_FILTER_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "blocked", "=", "False" );
+        condition2 = new EventRuleCondition( Constants.BLOCKED, Constants.EQUALS_TO, Constants.FALSE );
         conditions.add( condition2 );
-        condition3 = new EventRuleCondition( "category", "=", "Phishing and Other Frauds" );
+        condition3 = new EventRuleCondition( Constants.CATEGORY, Constants.EQUALS_TO, "Phishing and Other Frauds" );
         conditions.add( condition3 );
         eventRule = new AlertRule( true, conditions, true, true, "Phishing and Other Frauds website visit detected", false, 10 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*WebFilterEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.WEB_FILTER_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "blocked", "=", "True" );
+        condition2 = new EventRuleCondition( Constants.BLOCKED, Constants.EQUALS_TO, Constants.TRUE );
         conditions.add( condition2 );
-        condition3 = new EventRuleCondition( "category", "=", "Phishing and Other Frauds" );
+        condition3 = new EventRuleCondition( Constants.CATEGORY, Constants.EQUALS_TO, "Phishing and Other Frauds" );
         conditions.add( condition3 );
         eventRule = new AlertRule( true, conditions, true, true, "Phishing and Other Frauds website visit blocked", false, 10 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*DeviceTableEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, "*DeviceTableEvent*" );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "key", "=", "add" );
+        condition2 = new EventRuleCondition( "key", Constants.EQUALS_TO, "add" );
         conditions.add( condition2 );
         if ( "i386".equals(System.getProperty("os.arch", "unknown")) || "amd64".equals(System.getProperty("os.arch", "unknown"))) {
             eventRule = new AlertRule( false, conditions, true, true, "New device discovered", false, 0 );
@@ -652,23 +653,23 @@ public class EventManagerImpl implements EventManager
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*QuotaEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, "*QuotaEvent*" );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "action", "=", "2" );
+        condition2 = new EventRuleCondition( Constants.ACTION, Constants.EQUALS_TO, "2" );
         conditions.add( condition2 );
         eventRule = new AlertRule( false, conditions, true, true, "Host exceeded quota.", false, 0 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*ApplicationControlLogEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.APP_CONTROL_LOG_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "protochain", "=", "*BITTORRE*" );
+        condition2 = new EventRuleCondition( "protochain", Constants.EQUALS_TO, "*BITTORRE*" );
         conditions.add( condition2 );
         eventRule = new AlertRule( false, conditions, true, true, "Host is using Bittorrent", true, 60 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*HttpResponseEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, "*HttpResponseEvent*" );
         conditions.add( condition1 );
         condition2 = new EventRuleCondition( "contentLength", ">", "1000000000" );
         conditions.add( condition2 );
@@ -676,25 +677,25 @@ public class EventManagerImpl implements EventManager
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*CaptivePortalUserEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, "*CaptivePortalUserEvent*" );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "event", "=", "FAILED" );
+        condition2 = new EventRuleCondition( "event", Constants.EQUALS_TO, "FAILED" );
         conditions.add( condition2 );
         eventRule = new AlertRule( false, conditions, true, true, "Failed Captive Portal login", false, 0 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*VirusHttpEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, "*VirusHttpEvent*" );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "clean", "=", "False" );
+        condition2 = new EventRuleCondition( "clean", Constants.EQUALS_TO, Constants.FALSE );
         conditions.add( condition2 );
         eventRule = new AlertRule( false, conditions, true, true, "HTTP virus blocked", false, 0 );
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*ConfigurationBackupEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, "*ConfigurationBackupEvent*" );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "success", "=", "False" );
+        condition2 = new EventRuleCondition( "success", Constants.EQUALS_TO, Constants.FALSE );
         conditions.add( condition2 );
         eventRule = new AlertRule( true, conditions, true, true, "Configuration backup failed", false, 0 );
         rules.add( eventRule );
@@ -738,9 +739,9 @@ public class EventManagerImpl implements EventManager
         TriggerRule eventRule;
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*AlertEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, "*AlertEvent*" );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "description", "=", "*Suspicious Activity*" );
+        condition2 = new EventRuleCondition( "description", Constants.EQUALS_TO, "*Suspicious Activity*" );
         conditions.add( condition2 );
         eventRule = new TriggerRule( true, conditions, true, "Tag suspicious activity", false, 0 );
         eventRule.setAction( TriggerRule.TriggerAction.TAG_HOST );
@@ -750,9 +751,9 @@ public class EventManagerImpl implements EventManager
         rules.add( eventRule );
         
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*ApplicationControlLogEvent*");
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.APP_CONTROL_LOG_EVENT_RGX);
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "category", "=", "Proxy" );
+        condition2 = new EventRuleCondition( Constants.CATEGORY, Constants.EQUALS_TO, "Proxy" );
         conditions.add( condition2 );
         eventRule = new TriggerRule( false, conditions, true, "Tag proxy-using hosts", false, 0 );
         eventRule.setAction( TriggerRule.TriggerAction.TAG_HOST );
@@ -762,9 +763,9 @@ public class EventManagerImpl implements EventManager
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*ApplicationControlLogEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.APP_CONTROL_LOG_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "application", "=", "BITTORRE" );
+        condition2 = new EventRuleCondition( "application", Constants.EQUALS_TO, "BITTORRE" );
         conditions.add( condition2 );
         eventRule = new TriggerRule( false, conditions, true, "Tag bittorrent-using hosts", false, 0 );
         eventRule.setAction( TriggerRule.TriggerAction.TAG_HOST );
@@ -774,9 +775,9 @@ public class EventManagerImpl implements EventManager
         rules.add( eventRule );
 
         conditions = new LinkedList<>();
-        condition1 = new EventRuleCondition( "class", "=", "*ApplicationControlLogEvent*" );
+        condition1 = new EventRuleCondition( Constants.CLASS, Constants.EQUALS_TO, Constants.APP_CONTROL_LOG_EVENT_RGX );
         conditions.add( condition1 );
-        condition2 = new EventRuleCondition( "category", "=", "BITTORRE" );
+        condition2 = new EventRuleCondition( Constants.CATEGORY, Constants.EQUALS_TO, "BITTORRE" );
         conditions.add( condition2 );
         eventRule = new TriggerRule( false, conditions, true, "Tag bittorrent-using hosts", false, 0 );
         eventRule.setAction( TriggerRule.TriggerAction.TAG_HOST );
@@ -797,7 +798,7 @@ public class EventManagerImpl implements EventManager
         Map<String, String> emailSettings = new HashMap<>();
         emailSettings.put( "emailSubject", DefaultEmailSubject );
         emailSettings.put( "emailBody", DefaultEmailBody );
-        emailSettings.put( "emailConvert", "true");
+        emailSettings.put( "emailConvert", Constants.TRUE);
         return emailSettings;
     }
 
@@ -1337,7 +1338,7 @@ public class EventManagerImpl implements EventManager
         JSONObject jsonSendObject = event.toJSONObject();
         cleanupJsonObject( jsonSendObject );
         try{
-            jsonSendObject.put("class", event.getClass());
+            jsonSendObject.put(Constants.CLASS, event.getClass());
         }catch(Exception e){}
 
         for ( SyslogRule rule : rules ) {
@@ -1440,7 +1441,7 @@ public class EventManagerImpl implements EventManager
             if ( keys == null ) return null;
 
             for( String key : keys ) {
-                if ("class".equals(key))
+                if (Constants.CLASS.equals(key))
                     continue;
                 if (name.equalsIgnoreCase(key)) {
                     Object o = json.get(key);
@@ -1450,7 +1451,7 @@ public class EventManagerImpl implements EventManager
 
             for( String key : keys ) {
                 try {
-                    if ("class".equals(key))
+                    if (Constants.CLASS.equals(key))
                         continue;
                     Object o = json.get(key);
                     if ( o == null )
@@ -1555,7 +1556,7 @@ public class EventManagerImpl implements EventManager
         while ( keys.hasNext() ) {
             String key = keys.next();
 
-            if ("class".equals(key)) {
+            if (Constants.CLASS.equals(key)) {
                 keys.remove();
                 continue;
             }

--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -1510,7 +1510,7 @@ public class EventManagerImpl implements EventManager
          * Report users
          */
         App reportsApp = UvmContextFactory.context().appManager().app("reports");
-        if(reportsApp == null) {
+        if(reportsApp != null) {
             List<String> reportsEmailAddresses = ((Reporting) reportsApp).getAlertEmailAddresses();
             alertRecipients.addAll(reportsEmailAddresses);
         }

--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -1510,8 +1510,10 @@ public class EventManagerImpl implements EventManager
          * Report users
          */
         App reportsApp = UvmContextFactory.context().appManager().app("reports");
-        List<String> reportsEmailAddresses = ((Reporting) reportsApp).getAlertEmailAddresses();
-        alertRecipients.addAll(reportsEmailAddresses);
+        if(reportsApp == null) {
+            List<String> reportsEmailAddresses = ((Reporting) reportsApp).getAlertEmailAddresses();
+            alertRecipients.addAll(reportsEmailAddresses);
+        }
 
         for( String emailAddress : alertRecipients){
             try {

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -83,7 +83,7 @@ public class SystemManagerImpl implements SystemManager
     // must update file in mods-enabled since it is a symlink to our own version
     private final static String FREERADIUS_EAP_CONFIG = "/etc/freeradius/3.0/mods-enabled/eap";
 
-    private final java.util.logging.Logger logger = LogManager.getLogger(this.getClass());
+    private final Logger logger = LogManager.getLogger(this.getClass());
 
     private SystemSettings settings;
 

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -1532,7 +1532,7 @@ can look deeper. - mahotz
     public void logDiskCheckFailure( String diskCheckErrors )
     {
         logger.info("Logging CriticalAlertEvent for Disk Check Failure");
-        CriticalAlertEvent alert = new CriticalAlertEvent("DISK_CHECK_FAILURE", "Disk health checks failed", "Errors: " + diskCheckErrors);
+        CriticalAlertEvent alert = new CriticalAlertEvent("DISK_CHECK_FAILURE", "Disk health checks failed, Upgrade aborted", "Errors: " + diskCheckErrors);
         UvmContextFactory.context().logEvent(alert);
     }
 }

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -1531,7 +1531,7 @@ can look deeper. - mahotz
      */
     public void logDiskCheckFailure( String diskCheckErrors )
     {
-        logger.info("Logging CriticalAlertEvent for Disk Check Failure");
+        logger.warn("Logging CriticalAlertEvent for Disk Check Failure. Errors: {}", diskCheckErrors);
         CriticalAlertEvent alert = new CriticalAlertEvent("DISK_CHECK_FAILURE", "Disk health checks failed, Upgrade aborted", "Errors: " + diskCheckErrors);
         UvmContextFactory.context().logEvent(alert);
     }

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -44,6 +44,7 @@ import com.untangle.uvm.SystemSettings;
 import com.untangle.uvm.SnmpSettings;
 import com.untangle.uvm.ExecManagerResultReader;
 import com.untangle.uvm.app.DayOfWeekMatcher;
+import com.untangle.uvm.event.AdminLoginEvent;
 import com.untangle.uvm.servlet.DownloadHandler;
 import com.untangle.uvm.util.FileDirectoryMetadata;
 import com.untangle.uvm.util.IOUtil;
@@ -82,7 +83,7 @@ public class SystemManagerImpl implements SystemManager
     // must update file in mods-enabled since it is a symlink to our own version
     private final static String FREERADIUS_EAP_CONFIG = "/etc/freeradius/3.0/mods-enabled/eap";
 
-    private final Logger logger = LogManager.getLogger(this.getClass());
+    private final java.util.logging.Logger logger = LogManager.getLogger(this.getClass());
 
     private SystemSettings settings;
 
@@ -1520,5 +1521,18 @@ can look deeper. - mahotz
 
         fw.flush();
         fw.close();
+    }
+
+    /**
+     * Send Disk check failure event log.
+     * 
+     * @param diskCheckErrors
+     *        String diskCheckErrors
+     */
+    public void logDiskCheckFailure( String diskCheckErrors )
+    {
+        logger.info("Logging CriticalAlertEvent for Disk Check Failure");
+        CriticalAlertEvent alert = new CriticalAlertEvent("DISK_CHECK_FAILURE", "Disk health checks failed", "Errors: " + diskCheckErrors);
+        UvmContextFactory.context().logEvent(alert);
     }
 }


### PR DESCRIPTION
Performing hard disk health checks using `smartct's SMART` capability before upgrade process.

1. Before every upgrade, upgrade script will call `check_smart_health` method of `disk_health.py` script.
This script checks for the root directory and runs command `smartctl -h {drive_path}` command on it.
Output is categorised in three types - pass, fail, error. 

Upgrade will be aborted only if SMART status is FAILED. Before exiting we are logging a `CriticalAlertEvent` with `component=DISK_CHECK_FAILURE`
![Screenshot from 2024-11-12 12-20-56](https://github.com/user-attachments/assets/a0bd215b-19e7-4554-8d49-60bbd0c22093)


If SMART is unsupported or any unknown error occurs then those are logged as error in result object.
![Screenshot from 2024-11-12 12-26-28](https://github.com/user-attachments/assets/3953ee12-3132-4dc3-90ce-ca8b85f644dd)


If SMART status is passed upgrade will continue.
![Screenshot from 2024-11-12 12-25-14](https://github.com/user-attachments/assets/1c599943-a635-4dbe-bd4a-67a829594bcb)

2. Added a default `AlertRule` at top for `CriticalAlertEvent` with condition `component=DISK_CHECK_FAILURE` and logs and emails enabled. so that whenever disk check fails Alert will be logged and email will be sent to user.

![Screenshot from 2024-11-12 12-35-09](https://github.com/user-attachments/assets/78f82037-1917-40a2-a224-e879467ddef8)

![Screenshot from 2024-11-12 13-36-31](https://github.com/user-attachments/assets/0289ca68-b142-43b7-8176-757c079bf25d)

3. Added a null check for `reportsApp` object in `sendEmailForEvents` method. It was causing exception when Reports app was uninstalled.

