### PR TITLE
NGFE-14480: Backend changes for ECH block

### DIFF
--- a/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalSSLEngine.java
+++ b/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalSSLEngine.java
@@ -164,7 +164,7 @@ public class CaptivePortalSSLEngine
 
         if (sniHostname == null){
             try{
-                sniHostname = HttpUtility.extractSniHostname(data.duplicate());
+                sniHostname = HttpUtility.extractSniHostname(data.duplicate(),false);
             }catch (Exception exn) {
                 // The client is almost certainly sending us a bad TLS packet.
                 session.release();

--- a/http-casing/src/com/untangle/app/http/HttpUtility.java
+++ b/http-casing/src/com/untangle/app/http/HttpUtility.java
@@ -12,6 +12,7 @@ import javax.net.ssl.SSLEngine;
 import org.apache.hc.core5.net.URIBuilder;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Utility class for Extract host name
@@ -23,6 +24,7 @@ public class HttpUtility {
     private static int CLIENT_HELLO = 0x01;
     private static int SERVER_NAME = 0x0000;
     private static int HOST_NAME = 0x00;
+    private static int ENCRYPTED_CLIENT_HELLO = 0xfe0d;
 
     private static final HttpUtility INSTANCE = new HttpUtility();
     
@@ -45,10 +47,11 @@ public class HttpUtility {
     /**
      * Function for extracting the SNI hostname from the client request.
      * @param data
+     * @param isEchBlocked
      * @return The SNI hostname extracted from the client request, or null
      * @throws Exception
      */
-    public static String extractSniHostname(ByteBuffer data) throws Exception{
+    public static String extractSniHostname(ByteBuffer data, boolean isEchBlocked) throws Exception{
         int counter = 0;
         int pos=0;
 
@@ -99,7 +102,7 @@ public class HttpUtility {
             logger.debug("No extensions found in TLS handshake message");
             return (null);
         }
-        return extractSniHostNameFromExtensions(data, counter);
+        return extractSniHostNameFromExtensions(data, counter, isEchBlocked);
     }
     
     /**
@@ -144,13 +147,18 @@ public class HttpUtility {
      * Process all extensions to find the SNI signature.
      * @param data
      * @param counter
+     * @param isEchBlocked
      * @return The extracted SNI hostname, or null if not found.
      */
-    public static String extractSniHostNameFromExtensions(ByteBuffer data, int counter){
+    public static String extractSniHostNameFromExtensions(ByteBuffer data, int counter, boolean isEchBlocked) {
 
         // get the total size of extension data block
         int extensionLength = Math.abs(data.getShort());
-
+        boolean encryptedClientHelloFound = false;
+        // if ECH check enbled check for ech extention 
+        if(isEchBlocked){
+            encryptedClientHelloFound = checkEchExtention(extensionLength, data.duplicate(),counter);
+        }
          // walk through all of the extensions looking for SNI signature
          while (counter < extensionLength) {
             if (data.remaining() < 2) throw new BufferUnderflowException();
@@ -185,10 +193,40 @@ public class HttpUtility {
             // found a valid host name so adjust the position to skip over
             // the list length and name type info we directly accessed above
             if (data.remaining() < 5) throw new BufferUnderflowException();
-
-            return extractedSNIHostname(data, nameLength);
+            String hostname = extractedSNIHostname(data, nameLength);
+            //check for ech extention and encrypted hostname, if found return encrypted_client_hello
+            if(encryptedClientHelloFound && StringUtils.isEmpty(hostname)){
+                return "encrypted_client_hello";
+            }
+            return hostname;
         }
         return null;
+    }
+
+    /**
+     * Check for ECH extention
+     * @param extensionLength
+     * @param data
+     * @param counter
+     * @return encryptedClientHelloFound
+     */
+    public static boolean checkEchExtention(int extensionLength, ByteBuffer data, int counter){
+        while (counter < extensionLength) {
+            if (data.remaining() < 2) throw new BufferUnderflowException();
+
+            int extType = data.getShort() & 0xFFFF;
+            int extSize = Math.abs(data.getShort());
+            // Check for "encrypted client hello" extension first
+            if (extType == ENCRYPTED_CLIENT_HELLO) {
+                return true;
+            }
+    
+            // If not "encrypted client hello", process other extensions
+            if (data.remaining() < extSize) throw new BufferUnderflowException();
+            data.position(data.position() + extSize);
+            counter += (extSize + 4);
+        }
+        return false;
     }
 
     /**

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
@@ -539,7 +539,7 @@ for more data when a full packet has not yet been received.
      */
     public String extractSNIhostname(ByteBuffer data) throws Exception
     {
-       return HttpUtility.extractSniHostname(data);
+       return HttpUtility.extractSniHostname(data, false);
     }
 
     /**

--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
@@ -153,7 +153,7 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
 
         // scan the buffer for the SNI hostname
         try {
-            domain = HttpUtility.extractSniHostname(buff.duplicate());
+            domain = HttpUtility.extractSniHostname(buff.duplicate(), false);
         }
 
         // on underflow exception we stuff the partial packet into a buffer

--- a/uvm/js/common/util/Renderer.js
+++ b/uvm/js/common/util/Renderer.js
@@ -574,6 +574,7 @@ Ext.define('Ung.util.Renderer', {
         B: 'in Temporary Unblocked list'.t(),
         F: 'in Rules list'.t(),
         K: 'Kid-friendly redirect'.t(),
+        X: 'ECH blocked'.t(),
         default: 'no rule applied'.t()
     },
     httpReason: function( value, metaData ) {

--- a/uvm/js/common/util/_Map.js
+++ b/uvm/js/common/util/_Map.js
@@ -1600,6 +1600,7 @@ Ext.define('Ung.util.Map', {
         B: 'in Temporary Unblocked list'.t(),
         F: 'in Rules list'.t(),
         K: 'Kid-friendly redirect'.t(),
+        X: 'ECH blocked'.t(),
         default: 'no rule applied'.t()
     },
 

--- a/web-filter-base/src/com/untangle/app/web_filter/DecisionEngine.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/DecisionEngine.java
@@ -162,6 +162,21 @@ public abstract class DecisionEngine
                 header.addField("X-GoogApps-Allowed-Domains", allowedDomains);
             }
         }
+        // If ECH request then directly block the request and raise event
+        if (host.equals("encrypted_client_hello")) {
+                WebFilterEvent hbe = new WebFilterEvent(requestLine.getRequestLine(), sess.sessionEvent(), Boolean.TRUE, Boolean.TRUE, Reason.BLOCK_ECH, bestCategory.getId(), 0, "ECH BLOCKED", app.getName());
+                if (logger.isDebugEnabled()) logger.debug("LOG: ECH block : " + requestLine.getRequestLine());
+                app.logEvent(hbe);
+                app.incrementFlagCount();
+
+                return (
+                    new HttpRedirect(
+                        app.generateBlockResponse(
+                            new WebFilterRedirectDetails( app.getSettings(), "", "", "ECH blocked", clientIp, app.getAppTitle(), Reason.BLOCK_ECH, "ECH REQUEST"), 
+                            sess, uri.toString(), header),
+                        HttpRedirect.RedirectType.BLOCK));
+            
+        }
 
         // check client IP pass list
         // If a client is on the pass list is is passed regardless of any other settings

--- a/web-filter-base/src/com/untangle/app/web_filter/Reason.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/Reason.java
@@ -21,7 +21,8 @@ public enum Reason
     PASS_UNBLOCK('B', "in Bypass list"),
     FILTER_RULE('F', "matched Rule list"),
     REDIRECT_KIDS('K', "redirected to kid-friendly search engine"),
-    DEFAULT('N', "no rule applied");
+    DEFAULT('N', "no rule applied"),
+    BLOCK_ECH('X',"ECH blocked");
 
 // THIS IS FOR ECLIPSE - @formatter:on
 

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
@@ -154,10 +154,10 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
 
         logger.debug("HANDLE_CHUNK = " + buff.toString());
         app.incrementScanCount();
-
+        boolean isEchBlock = app.getSettings().getBlockECH();
         // scan the buffer for the SNI hostname
         try {
-            domain = HttpUtility.extractSniHostname(buff.duplicate());
+            domain = HttpUtility.extractSniHostname(buff.duplicate(), isEchBlock);
         }
 
         // on underflow exception we stuff the partial packet into a buffer


### PR DESCRIPTION
**Summary Of Implementation:**
Due to the current behavior of browsers, we are not receiving any ECH (Encrypted Client Hello) packets that contain an encrypted SNI (Server Name Indication). As a result, this feature has not been fully tested in scenarios where the SNI is actually encrypted.
The current implementation is designed to handle cases where we receive an ECH record, but the hostname remains unencrypted. In these cases, the request is allowed to pass through, ensuring that the web filter and other filtering applications continue to function as expected.
However, if in the future no SNI is provided in an encrypted Client Hello packet, the request will be blocked according to the current implementation, and the client will see a web filter block page.
https://awakesecurity.atlassian.net/wiki/spaces/ngfw/pages/2704277528/Blocking+Support+for+ECH+in+Filter+Apps

**Current Testing Steps:**
Regression Testing:(Firefox and chrome)
        1. Create rule on webfilter to block any site.(example --- > goal.com)
        2.  On client hit the same site you will see the site is blocked.
Testing:(Firefox and chrome)
        1. Enable the ECH block by checking  webFilter-->Advance-->Block encrypted client hello
        2. Hit any site it should not block the request if getting unencrypted SNI name in client hello packets.
        3. Now hit the goal.com the blocked site, it should block the request.
        4. Somehow if you get the ECH packet with SNI encrypted. the call should be blocked by web-filter.