### PR TITLE
ngfw-14875: ATS: global_functions.get_broadcast_address is not return…

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -2718,7 +2718,14 @@ server=dynupdate.no-ip.com
         unreachable_entry = {}
         unreachable_entry['usernameDirectoryConnector'] = 'unrechable_host'
         
-        unreachable_entry['address'] = global_functions.get_broadcast_address(interface_name)
+        ip_address = global_functions.get_broadcast_address(interface_name)
+        #Cover the PPPOE case where broadcast address is recieved as x.x.x.x/xx instead of x.x.x.x
+        if "/" in ip_address and ip_address.split("/")[1].isdigit():
+        #Broadcast address of pppoe interface is reachable,  modifying last ip segment to 255
+            unreachable_entry['address'] = ".".join(ip_address.split("/")[0].split(".")[:-1] + ["255"])
+        else:
+            unreachable_entry['address'] = ip_address
+
         global_functions.uvmContext.hostTable().setHostTableEntry( unreachable_entry['address'], unreachable_entry )
 
         client_entry = {}


### PR DESCRIPTION
Summary of test case:
1. test case adds a host entry which is not part of the network
2. Modifies host cleaner run interval
3. Result should be entry should be removed once hostcleaner runs

For unreachable entry broadcast address is used. Reasons for test case not working for pppoe server
   -  pppoe broadcast address is received as 172.17.18.1/32  (in non pppoe server it is just the ip)
![Screenshot from 2024-11-12 16-23-26](https://github.com/user-attachments/assets/6abc6a55-844e-4b54-9791-ee7e543441da)

   -  After modifying the code to use only ip, on pppoe 172.17.18.1 is reachable , hence hosttable cleaner is unable  to remove the entry
   
Fix: 
   - Modified code to support pppoe broadcast address format
   - made the ip unreachable by modifying last segment to 255 instead of 1 (172.17.18.255)
   
   
Tested both the pppoe and nonpppoe scenarios. Both are passing
![Screenshot from 2024-11-12 16-52-47](https://github.com/user-attachments/assets/3f191357-8637-4648-8599-655515716221)

