### PR TITLE
NGFW-14894 : Hiding ECH block enable disable button

### DIFF
--- a/web-filter/js/view/Advanced.js
+++ b/web-filter/js/view/Advanced.js
@@ -103,6 +103,7 @@ Ext.define('Ung.apps.webfilter.view.Advanced', {
             bind: '{settings.closeHttpsBlockEnabled}'
         }, {
             xtype: 'checkbox',
+            hidden: true,
             boxLabel: 'Block Encrypted Client Hello (ECH)'.t(),
             bind: '{settings.blockECH}'
         }]


### PR DESCRIPTION
Currently, there is no way to distinguish between ECH (Encrypted Client Hello) and non-ECH calls, as both types of Client Hello messages include the ECH extension in the packets. Therefore, we are temporarily hiding the UI changes related to this ticket until we receive ECH packets with properly encrypted records.


**Testsing:**
1. ECH enable disable button should not be visible in UI:
![Screenshot from 2024-11-14 14-43-44](https://github.com/user-attachments/assets/96c6c467-1c10-4c53-87ac-9a4e20606035)

2. Write any web-filter rule, such as block site amazon.com. Hit the site from client it should be blocked.
3. hit any other site such as goal.com. It should work as expected.