### PR TITLE
NGFW-14890 Reports events performance fix

### DIFF
--- a/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
+++ b/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
@@ -220,7 +220,7 @@ public class ReportsManagerImpl implements ReportsManager
             if ( ! app.isLicenseValid() ) {
                 continue;
             }
-            org.json.JSONObject json = new org.json.JSONObject();
+            JSONObject json = new JSONObject();
 
             try {
                 json.put("displayName", appProperties.getDisplayName());
@@ -246,7 +246,7 @@ public class ReportsManagerImpl implements ReportsManager
         ArrayList<JSONObject> currentApplications = new ArrayList<>();
 
         for ( AppProperties appProperties : this.appPropertiesList ) {
-            org.json.JSONObject json = new org.json.JSONObject();
+            JSONObject json = new JSONObject();
 
             try {
                 json.put("displayName", appProperties.getDisplayName());
@@ -654,9 +654,9 @@ public class ReportsManagerImpl implements ReportsManager
      * @return
      *  ArrayList containing JSONObject of event result.
      */
-    public ArrayList<org.json.JSONObject> getEvents(final ReportEntry entry, final SqlCondition[] extraConditions, final int limit)
+    public ArrayList<JSONObject> getEvents(final ReportEntry entry, final SqlCondition[] extraConditions, final int limit)
     {
-        ArrayList<org.json.JSONObject> results = null;
+        ArrayList<JSONObject> results = null;
         if (entry == null) {
             logger.warn("Invalid arguments");
             return results;
@@ -822,7 +822,7 @@ public class ReportsManagerImpl implements ReportsManager
         ArrayList<JSONObject> interfacesInfo = new ArrayList<>();
         for( InterfaceSettings interfaceSettings : UvmContextFactory.context().networkManager().getNetworkSettings().getInterfaces() ){
             try {
-                JSONObject json = new org.json.JSONObject();
+                JSONObject json = new JSONObject();
                 json.put("interfaceId", interfaceSettings.getInterfaceId());
                 json.put("name", interfaceSettings.getName() );
                 interfacesInfo.add(json);
@@ -832,7 +832,7 @@ public class ReportsManagerImpl implements ReportsManager
         }
         for( InterfaceSettings interfaceSettings : UvmContextFactory.context().networkManager().getNetworkSettings().getVirtualInterfaces() ){
             try {
-                JSONObject json = new org.json.JSONObject();
+                JSONObject json = new JSONObject();
                 json.put("interfaceId", interfaceSettings.getInterfaceId());
                 json.put("name", interfaceSettings.getName() );
                 interfacesInfo.add(json);
@@ -1111,11 +1111,7 @@ public class ReportsManagerImpl implements ReportsManager
      */
     private HashMap<String,String> getColumnMetaData( String tableName )
     {
-        Connection conn = app.getDbConnection();
-        if ( conn == null ) {
-            return null;
-        }
-
+        Connection conn = null;
         try {
             HashMap<String,String> results = cacheColumnsResults.get( tableName );
             if ( results != null ) {
@@ -1123,6 +1119,10 @@ public class ReportsManagerImpl implements ReportsManager
             }
             results = new HashMap<>();
 
+            conn = app.getDbConnection();
+            if ( conn == null ) {
+                return null;
+            }
             ResultSet rs;
             if (ReportsApp.dbDriver.equals("sqlite"))
                 rs = conn.getMetaData().getColumns( null, null, tableName, null );
@@ -1143,8 +1143,12 @@ public class ReportsManagerImpl implements ReportsManager
             logger.warn("Failed to fetch column meta data", e);
             return null;
         } finally {
-            try { conn.close(); } catch (Exception e) {
-                logger.warn("Close Exception",e);
+            if (conn != null) {
+                try {
+                    conn.close();
+                } catch (Exception e) {
+                    logger.warn("Close Exception", e);
+                }
             }
         }
     }

--- a/uvm/hier/etc/untangle/startup.d/30uvm
+++ b/uvm/hier/etc/untangle/startup.d/30uvm
@@ -68,6 +68,7 @@ else
     GC_MIN_CYCLE=10
     REPORTS_MAX_QUEUE_LEN=50000
 fi
+REPORTS_QUEUE_DRAIN_THRESHOLD=`echo $REPORTS_MAX_QUEUE_LEN | awk '{printf int($1 / 10)}'`
 
 if [ $ARCH = 'x86_64' ]; then
     SESSION_LIMIT=0
@@ -80,6 +81,7 @@ echo "    GC safety factor         -> ${GC_SAFETY_FACTOR}"
 echo "    GC minimum cycle         -> ${GC_MIN_CYCLE}"
 echo "    Session limit            -> ${SESSION_LIMIT}"
 echo "    Reports queue limit      -> ${REPORTS_MAX_QUEUE_LEN}"
+echo "    Reports queue drain threshold      -> ${REPORTS_QUEUE_DRAIN_THRESHOLD}"
 
 #
 # Apply the settings
@@ -92,5 +94,6 @@ gc_safety_factor="$GC_SAFETY_FACTOR"
 gc_min_cycle="$GC_MIN_CYCLE"
 session_limit="$SESSION_LIMIT"
 reports_max_queue_len="$REPORTS_MAX_QUEUE_LEN"
+reports_queue_drain_threshold="$REPORTS_QUEUE_DRAIN_THRESHOLD"
 EOF
 

--- a/uvm/hier/usr/share/untangle/conf/untangle-vm.conf
+++ b/uvm/hier/usr/share/untangle/conf/untangle-vm.conf
@@ -10,6 +10,7 @@ gc_safety_factor="90"
 gc_min_cycle="10"
 session_limit="10000"
 reports_max_queue_len="1000000"
+reports_queue_drain_threshold="100000"
 reports_cacheTableInterval="300000"
 num_netcap_threads="25"
 tcp_buffer_size="131072"
@@ -50,7 +51,11 @@ if int(num_netcap_threads) > 0:
 if int(session_limit) > 0:
    uvm_args += " -Dnetcap.sessionlimit=%s" % session_limit 
 
-uvm_args += " -Dreports.max_queue_len=%s" % reports_max_queue_len 
+uvm_args += " -Dreports.max_queue_len=%s" % reports_max_queue_len
+# Set reports_queue_drain_threshold to override value set by untangle-hw.conf
+uvm_args += " -Dreports.queue_drain_threshold=%s" % reports_queue_drain_threshold
+# Uncomment and modify below to override reports events per cycle value
+#uvm_args += " -Dreports.events_per_cycle=%s" % "50000"
 uvm_args += " -Dreports.cacheTableInterval=%s" % reports_cacheTableInterval
 uvm_args += " -Dtcp_buffer_size=%s" % tcp_buffer_size
 uvm_args += " -Dhost_cleaner_interval=%s" % host_cleaner_interval


### PR DESCRIPTION
- Added `reports.queue_drain_threshold` and `reports.events_per_cycle` configuration flags to tune reports processing.
- Updated `partitionTableExists()` method to get database connection only when it is needed, this was the actual performance change that fixed the issue.
- `persist()` method now skips one for loop that processes events (max 50,000) and does the same work in another loop.