### PR TITLE
NGFW-14872-Fixed multiple pppoe connection tracking

### DIFF
--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -56,7 +56,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.concurrent.ConcurrentHashMap;

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -62,6 +62,7 @@ import java.util.Comparator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.Iterator;
 
 /**
@@ -1737,14 +1738,16 @@ public class NetworkManagerImpl implements NetworkManager
         networkSettings.setHostName( networkSettings.getHostName().replaceAll("\\..*","") );
         
         List<InterfaceSettings> interfacesSettings =  networkSettings.getInterfaces();
-        Optional<InterfaceSettings> interfaceToMove = interfacesSettings.stream()
-                                                                        .filter(i-> i.getInterfaceId() == -1).findFirst();
+        List<InterfaceSettings> interfacesToMove = interfacesSettings.stream()
+                                                                        .filter(i-> i.getInterfaceId() == -1).collect(Collectors.toList());
         
-        // If an interface with id == -1 is found, move it to the end
-        if (interfaceToMove.isPresent()) {
-            interfacesSettings.remove(interfaceToMove.get());  // Remove the interface from its current position
-            interfacesSettings.add(interfaceToMove.get());  // Add it to the last position
-        }
+        // For each interface with id == -1, remove it and add it to the end
+        if(!interfacesToMove.isEmpty()){
+            for (InterfaceSettings interfaceToMove : interfacesToMove) {
+                interfacesSettings.remove(interfaceToMove);  // Remove the interface from its current position
+                interfacesSettings.add(interfaceToMove);  // Add it to the last position
+            }
+        }  
         
         /**
          * Handle VLAN interfaces


### PR DESCRIPTION
**Description:**
A customer has two PPPoE interfaces.  The first interface (ADSL) does not connect but the second (Fibtr_Vlan).  
As indicated from the naming, the first interface is on eth2 while the second is on eth1.2900 (vlan).  The symbolic dev for the first interface is ppp0 and for the second ppp1.
The problem is that the second interface is actually connecting on ppp0.  Because of the symbolic dev mapping, it appears that ADSL is up when it it really isn’t; Fibr_Vlan is.

**Summary of Implementation:**

When PPPoE Interfaces are created, it get added to the first place which causes the PPPoE server name changes.
Hence implememted in such a way that it should be added at the last and PPPoE Interfaces are correctly updated with correct PPPoE i.e. ppp0, ppp1, .....

![image](https://github.com/user-attachments/assets/a7f8e1d1-bbbe-4d2f-b864-6a40be5d2ace)
![image](https://github.com/user-attachments/assets/e2d4bcf8-f690-4fc2-abfb-0bf3b6ab770b)

![image](https://github.com/user-attachments/assets/195ba5cb-5dc5-4136-a786-5077e116a375)



