### PR TITLE
Ngfw 14893 Handle SMART Disk check false possitives

### DIFF
--- a/uvm/api/com/untangle/uvm/SystemManager.java
+++ b/uvm/api/com/untangle/uvm/SystemManager.java
@@ -49,6 +49,10 @@ public interface SystemManager
 
     void setDate(long timestamp);
 
+    boolean isSkipDiskCheck();
+
+    void setSkipDiskCheck(boolean skipDiskCheck);
+
     /**
      * returns the current Calendar
      * when the timezone is changed all calendars must be recreated.
@@ -63,6 +67,8 @@ public interface SystemManager
     void setTimeSource();
 
     boolean getIsUpgrading();
+
+    String checkDiskHealth();
 
     boolean downloadUpgrades();
 

--- a/uvm/api/com/untangle/uvm/util/Constants.java
+++ b/uvm/api/com/untangle/uvm/util/Constants.java
@@ -24,7 +24,7 @@ public class Constants {
     public static final String BLOCKED = "blocked";
     public static final String CATEGORY = "category";
 
-    // Class Regexex as condition matcher
+    // Class Regex as condition matcher
     public static final String CRITICAL_ALERT_EVENT_RGX = "*CriticalAlertEvent*";
     public static final String SYSTEM_STAT_EVENT_RGX = "*SystemStatEvent*";
     public static final String SESSION_EVENT_RGX = "*SessionEvent*";

--- a/uvm/hier/usr/lib/python3/dist-packages/uvm/disk_health.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/uvm/disk_health.py
@@ -52,3 +52,5 @@ def check_smart_health():
         run_smart_check(root_disk)
     return dict(status)  # Convert defaultdict back to dict for compatibility
 
+if __name__ == "__main__":
+    print(check_smart_health())

--- a/uvm/hier/usr/share/untangle/bin/ut-system-mgr-helpers.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-system-mgr-helpers.sh
@@ -13,5 +13,9 @@ upgradesAvailable()
     apt-get -s dist-upgrade | grep -q '^Inst'
 }
 
+diskHealthCheck()
+{
+    python3 /usr/lib/python3/dist-packages/uvm/disk_health.py
+}
 
 $1 "$@"

--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -150,7 +150,7 @@ def check_disk_health():
             return
         skip_health_check = system_manager.isSkipDiskCheck()
         if skip_health_check:
-            log("Skip drive health checks is enabled. Proceeding with upgrade.")
+            log("Skipping drive health checks. Proceeding with upgrade.")
             return
         
         health_status = disk_health.check_smart_health()
@@ -184,8 +184,6 @@ r = check_upgrade();
 if r != 0:
     log("apt-get -s dist-upgrade returned an error (%i). Abort." % r)
     sys.exit(1)
-
-sys.exit()
 
 upgrade()
 

--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -144,10 +144,19 @@ def check_dpkg():
 
 def check_disk_health():
     try:
+        system_manager = Uvm().getUvmContext().systemManager()
+        if not system_manager:
+            log("System Manager is not available. Proceeding with upgrade.")
+            return
+        skip_health_check = system_manager.isSkipDiskCheck()
+        if skip_health_check:
+            log("Skip drive health checks is enabled. Proceeding with upgrade.")
+            return
+        
         health_status = disk_health.check_smart_health()
         log(f"disk health status: {health_status}")
         if "fail" in health_status:
-            Uvm().getUvmContext().systemManager().logDiskCheckFailure(str(health_status))
+            system_manager.logDiskCheckFailure(str(health_status))
             log("Disk health check failed, Aborting Upgrade.\n")
             sys.exit(1)
     except Exception as e:
@@ -175,6 +184,8 @@ r = check_upgrade();
 if r != 0:
     log("apt-get -s dist-upgrade returned an error (%i). Abort." % r)
     sys.exit(1)
+
+sys.exit()
 
 upgrade()
 

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -600,9 +600,7 @@ can look deeper. - mahotz
      */
     public String checkDiskHealth()
     {
-        String result;
-        result = UvmContextFactory.context().execManager().execOutput(System.getProperty("uvm.bin.dir") + "/ut-system-mgr-helpers.sh diskHealthCheck");
-        return result;
+        return UvmContextFactory.context().execManager().execOutput(System.getProperty("uvm.bin.dir") + "/ut-system-mgr-helpers.sh diskHealthCheck");
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -97,6 +97,7 @@ public class SystemManagerImpl implements SystemManager
     private String SettingsFileName = "";
 
     private boolean isUpgrading = false;
+    private boolean skipDiskCheck = false;
 
     private List<FileDirectoryMetadata> logFiles;
 
@@ -410,6 +411,22 @@ can look deeper. - mahotz
     }
 
     /**
+     * Get skip disk health check flag
+     * @return skipDiskCheck flag
+     */
+    public boolean isSkipDiskCheck() { 
+        return skipDiskCheck; 
+    }
+
+    /**
+     * Set skip disk health check flag
+     * @param skipDiskCheck
+     */
+    public void setSkipDiskCheck(boolean skipDiskCheck) { 
+        this.skipDiskCheck = skipDiskCheck; 
+    }
+
+    /**
      * Get the calendar
      * 
      * @return The calendar
@@ -581,6 +598,18 @@ can look deeper. - mahotz
      * 
      * @return True for success, false for failure
      */
+    public String checkDiskHealth()
+    {
+        String result;
+        result = UvmContextFactory.context().execManager().execOutput(System.getProperty("uvm.bin.dir") + "/ut-system-mgr-helpers.sh diskHealthCheck");
+        return result;
+    }
+
+    /**
+     * Download upgrades
+     * 
+     * @return True for success, false for failure
+     */
     public boolean downloadUpgrades()
     {
         LinkedList<String> downloadUrls = new LinkedList<>();
@@ -697,6 +726,7 @@ can look deeper. - mahotz
         } catch (Exception e) {
             logger.warn("Upgrade exception:", e);
         }
+        this.setSkipDiskCheck(false);
         this.setIsUpgrading(false);
         /*
          * probably will never return as the upgrade usually kills the

--- a/uvm/servlets/admin/config/upgrade/MainController.js
+++ b/uvm/servlets/admin/config/upgrade/MainController.js
@@ -169,6 +169,32 @@ Ext.define('Ung.config.upgrade.MainController', {
         }, 100);
     },
 
+    onUpgradeNowClick: function() {
+        var me = this;
+
+        Rpc.asyncData('rpc.systemManager.checkDiskHealth')
+        .then(function(result) {
+            if(result.includes("'fail'")) {
+                Ext.Msg.show({
+                    title: 'Warning'.t(),
+                    message: 'Drive health check failed. Disk issues could cause upgrade failures or data loss.<br>Are you sure you want to proceed with upgrade ?'.t(),
+                    buttons: Ext.Msg.OKCANCEL,
+                    icon: Ext.Msg.QUESTION,
+                    fn: function (btn) {
+                        if (btn === 'ok') {
+                            me.setSkipDiskCheckFlag(true);
+                        } 
+                    }
+                });
+            }
+            me.downloadUpgrades();
+        });
+    },
+
+    setSkipDiskCheckFlag: function(skipDiskCheck){
+        Rpc.directData('rpc.systemManager.setSkipDiskCheck', skipDiskCheck);
+    },
+
     downloadUpgrades: function() {
         var me = this;
         Ext.MessageBox.progress("Downloading Upgrade...".t(), ".");
@@ -186,6 +212,7 @@ Ext.define('Ung.config.upgrade.MainController', {
                 me.upgrade();
             } else {
                 Ext.MessageBox.alert("Warning".t(), "Downloading upgrades failed.".t());
+                me.setSkipDiskCheckFlag(false);
             }
         });
         me.getDownloadStatus();

--- a/uvm/servlets/admin/config/upgrade/MainController.js
+++ b/uvm/servlets/admin/config/upgrade/MainController.js
@@ -183,11 +183,13 @@ Ext.define('Ung.config.upgrade.MainController', {
                     fn: function (btn) {
                         if (btn === 'ok') {
                             me.setSkipDiskCheckFlag(true);
+                            me.downloadUpgrades();
                         } 
                     }
                 });
+            } else {
+                me.downloadUpgrades();
             }
-            me.downloadUpgrades();
         });
     },
 

--- a/uvm/servlets/admin/config/upgrade/view/Upgrade.js
+++ b/uvm/servlets/admin/config/upgrade/view/Upgrade.js
@@ -44,7 +44,7 @@ Ext.define('Ung.config.upgrade.view.Upgrade', {
             hidden: true,
             text: "Upgrade Now".t(),
             iconCls: 'fa fa-play',
-            handler: 'downloadUpgrades'
+            handler: 'onUpgradeNowClick'
         }, {
             title: 'Automatic Upgrade'.t(),
             items: [{


### PR DESCRIPTION
There might be a possibility of SMART health check providing false positive result. 
In that case we can’t have unconditional block for upgrade. Hence, Providing user a way to force update from UI on disk check failure.

If the SMART Disk health check fails. Auto upgrades from cron will be aborted and Critical Event will be generated as per [NGFW-14888](https://awakesecurity.atlassian.net/browse/NGFW-14888)

On upgrade page if user clicks on `Upgrade Now` button then Disk helath check will be performed.
![Screenshot from 2024-11-19 11-55-18](https://github.com/user-attachments/assets/3376291c-05b1-4dc8-9dbb-3d5fb3ecba2e)

1. If SMART failed then Warning Box will be shown to user as given below.

![Screenshot from 2024-11-19 11-57-43](https://github.com/user-attachments/assets/857235bd-af55-4f3d-b337-cafe793264e2)

If user clicks on `cancel` button. Message box will close and upgrade will be cancelled.
If user clicks on `ok`  button. Upgrade will proceed skipping the Disk health check step in upgrade script.
![Screenshot from 2024-11-19 11-59-21](https://github.com/user-attachments/assets/a878e21a-1dff-4662-9001-ca1510ad5e8b)

2. For Disk check pass/error status Upgrade will proceed as it would previously.

![Screenshot from 2024-11-19 12-00-58](https://github.com/user-attachments/assets/bff18dcf-8527-46f7-843b-390fd7bba3ab)

![Screenshot from 2024-11-19 11-54-53](https://github.com/user-attachments/assets/0548dc29-a89b-4e89-ad55-1d57eedfe99a)






[NGFW-14888]: https://awakesecurity.atlassian.net/browse/NGFW-14888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ