### PR TITLE
ngfw-14892 added test cases for disk health checks before upgrade

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_upgrade.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_upgrade.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import subprocess
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+from tests.common import NGFWTestCase
+from tests.global_functions import uvmContext
+import runtests.test_registry as test_registry
+
+
+UPGRADE_SCRIPT = os.path.abspath("/usr/share/untangle/bin/ut-upgrade.py")
+
+
+@pytest.mark.upgrade
+class UpgradeTests(NGFWTestCase):
+
+    not_an_app = True
+
+    @staticmethod
+    def module_name():
+        return "upgrade"
+
+    @staticmethod
+    def vendorName():
+        return "Untangle"
+    
+    def test_010_disk_health_check_on_upgrade(self):
+        """ Check disk health check error, pass and fail result impact on upgrade """
+
+        # We don't want to upgrade VM from test, so skip test if upgrade available.
+        available = uvmContext.systemManager().upgradesAvailable()
+        if available:
+            raise unittest.SkipTest('Upgrade available, skipping test')   
+
+        # Error condition check. 
+        # By default VMWare Boxes don't support SMART so check_smart_health will return error result
+        # For disk health check any error will result in proceeding upgrade
+        result = subprocess.run( [sys.executable, UPGRADE_SCRIPT], capture_output=True, text=True )
+
+        assert (result.returncode == 0)
+        assert ("done" in result.stdout)
+
+        # pass condition check
+        env = {"MOCK_TEST_PASS": "1"}
+        env.update(os.environ)
+        result = subprocess.run( [sys.executable, UPGRADE_SCRIPT], capture_output=True, text=True, env=env )
+
+        assert (result.returncode == 0)
+        assert ("done" in result.stdout)
+
+        # fail condition check
+        env = {"MOCK_TEST_FAIL": "1"}
+        env.update(os.environ)
+        result = subprocess.run( [sys.executable, UPGRADE_SCRIPT], capture_output=True, text=True, env=env )
+
+        assert (result.returncode == 1)
+        assert ("Aborting Upgrade" in result.stdout)
+
+
+    def test_010_skip_disk_health_check_on_upgrade(self):
+        """ Check if disk check is skipped if user want's to force upgrade on disk check failure """
+
+        # We don't want to upgrade VM from test, so skip test if upgrade available.
+        available = uvmContext.systemManager().upgradesAvailable()
+        if available:
+            raise unittest.SkipTest('Upgrade available, skipping test')
+
+        # Set skipDiskCheck flag True
+        uvmContext.systemManager().setSkipDiskCheck(True)
+        result = subprocess.run( [sys.executable, UPGRADE_SCRIPT], capture_output=True, text=True )
+
+        assert (result.returncode == 0)
+        assert ("Skipping drive health checks" in result.stdout)
+
+        # Set skipDiskCheck flag False
+        uvmContext.systemManager().setSkipDiskCheck(False)
+        result = subprocess.run( [sys.executable, UPGRADE_SCRIPT], capture_output=True, text=True )
+
+        assert ("disk health status" in result.stdout)
+
+test_registry.register_module("upgrade", UpgradeTests)

--- a/uvm/hier/usr/lib/python3/dist-packages/uvm/disk_health.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/uvm/disk_health.py
@@ -2,6 +2,7 @@ from psutil import disk_partitions
 from subprocess import run, CalledProcessError
 import re
 from collections import defaultdict
+import os
 
 # Constants for Messages
 ROOT_NOT_FOUND = "Root partition not found."
@@ -47,6 +48,13 @@ def run_smart_check(disk):
 
 def check_smart_health():
     """Find and check the SMART health of the root disk."""
+    if os.getenv("MOCK_TEST_PASS"):
+        update_status("pass", f"{SMART_RESULT} {SMART_PASS_KEYWORD}")
+        return dict(status)
+    elif os.getenv("MOCK_TEST_FAIL"):
+        update_status("fail", f"{SMART_RESULT} {SMART_FAIL_KEYWORD}")
+        return dict(status)
+    
     root_disk = get_root_disk()
     if root_disk:
         run_smart_check(root_disk)


### PR DESCRIPTION
Added test cases to:

1. Check disk health check `error, pass and fail` result impact on upgrade.
2. Check disk check is skipped or not if user want's to force upgrade on disk check failure.