### PR TITLE
ngfw-14689 crossbrowser safari issue resolved for interface edit option

### DIFF
--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -193,6 +193,11 @@ Ext.define('Ung.config.network.Interface', {
                 itemId: 'ipv4ConfigType',
                 layout: { type: 'hbox' },
                 defaults: { padding: '0 10' },
+                style:{
+                    "display": "flex",
+                    "justify-content": "space-around",
+                    "overflow": "visible !important"
+                },
                 simpleValue: true,
                 // hidden: true,
                 bind: {


### PR DESCRIPTION

![Screenshot from 2024-11-22 18-31-24](https://github.com/user-attachments/assets/e7966d70-0a81-4288-ad05-c622933fcdaa)

Ticket -14689 
In the Safari browser, while editing a WAN interface, Radio buttons are not visible for the first time or sometimes it will take another action to refect on ui.
Here we added some css styling only for that particular component which happening due to overflow between two components (tbar). 