### PR TITLE
NGFW-14795 : password encryption feature

### DIFF
--- a/directory-connector/js/view/ActiveDirectory.js
+++ b/directory-connector/js/view/ActiveDirectory.js
@@ -48,6 +48,9 @@ Ext.define('Ung.apps.directoryconnector.view.ActiveDirectory', {
                 listProperty: 'settings.activeDirectorySettings.servers.list',
                 ruleJavaClass: 'com.untangle.app.directory_connector.ActiveDirectoryServer',
 
+                importValidationJavaClass: true,
+                importValidatorParams: { "superuserPass": "encrSupUserPass" },
+
                 emptyRow: {
                     LDAPHost: '',
                     LDAPPort: 636,
@@ -242,7 +245,25 @@ Ext.define('Ung.apps.directoryconnector.view.ActiveDirectory', {
                     inputType: 'password',
                     fieldLabel: 'Authentication Password'.t(),
                     bind: '{record.superuserPass}',
-                    allowBlank: false
+                    validator: function (value, encPass) {
+                        // Either superuserPass or encrSupUserPass should not be blank
+                        if(value) return true;
+                        var emptyText = "[Leave empty to keep the current password unchanged]".t();
+                        // encPass is recieved from import validation call
+                        if(encPass) {
+                            this.emptyText = emptyText;
+                            return true;
+                        }
+                        if(this.lookupViewModel) {
+                            var record = this.lookupViewModel().get('record');
+                            if(record && record.data.encrSupUserPass) {
+                                this.emptyText = emptyText;
+                                return true;
+                            } 
+                        }
+                        this.emptyText = "[no authentication password]".t();
+                        return "This field is required".t();
+                    }
                 },{
                     xtype: 'container',
                     layout: 'column',

--- a/directory-connector/src/com/untangle/app/directory_connector/ActiveDirectoryServer.java
+++ b/directory-connector/src/com/untangle/app/directory_connector/ActiveDirectoryServer.java
@@ -3,8 +3,12 @@
  */
 package com.untangle.app.directory_connector;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.json.JSONString;
+
+import com.untangle.uvm.PasswordUtil;
+
 import java.util.List;
 import java.util.LinkedList;
 
@@ -19,6 +23,7 @@ public class ActiveDirectoryServer implements java.io.Serializable, JSONString
 {
     private String superuser;
     private String superuserPass;
+    private String encrSupUserPass;
     private String domain;
     private String ldapHost;
     private boolean ldapSecure;
@@ -62,6 +67,7 @@ public class ActiveDirectoryServer implements java.io.Serializable, JSONString
         this.ldapSecure = ldapSecure;
         this.ouFilters = new LinkedList<>();
         this.azure = azure;
+        this.encryptSuperUserPass();
     }
 
     /**
@@ -125,6 +131,36 @@ public class ActiveDirectoryServer implements java.io.Serializable, JSONString
      *      superuser password
      */
     public void setSuperuserPass(String pass) { this.superuserPass = pass; }
+
+    /**
+     * Returns encrypted superuser password.
+     *
+     * @return
+     *      encrypted superuser password.
+     */
+    public String getEncrSupUserPass() {
+        return encrSupUserPass; 
+    }
+    /**
+     * Sets encrypted superuser password.
+     *
+     * @param encrSupUserPass
+     *      encrypted superuser password
+     */
+    public void setEncrSupUserPass(String encrSupUserPass) { 
+        this.encrSupUserPass = encrSupUserPass;
+    }
+
+    /**
+     * Gets encrypted password using superuserPass sets it to encrSupUserPass
+     * Sets superuserPass to null
+     */
+    public void encryptSuperUserPass() { 
+        if(StringUtils.isNotBlank(this.superuserPass)) {
+            this.encrSupUserPass = PasswordUtil.getEncryptPassword(superuserPass);
+            this.superuserPass = null;
+        }
+    }
 
     /**
      * Returns domain name

--- a/directory-connector/src/com/untangle/app/directory_connector/DirectoryConnectorApp.java
+++ b/directory-connector/src/com/untangle/app/directory_connector/DirectoryConnectorApp.java
@@ -17,6 +17,7 @@ import java.util.LinkedList;
 import java.io.FileWriter;
 import java.io.IOException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
@@ -168,6 +169,12 @@ public class DirectoryConnectorApp extends AppBase implements com.untangle.uvm.a
                 writeFlag = true;
             }
 
+            // setSettings will set encrypted password and remove original password
+            if ( readSettings.getVersion() < 4 ) {
+                readSettings.setVersion(4);
+                writeFlag = true;
+            }
+
             if (writeFlag == true) {
                 // if any changes were made we need to write the updated settings
                 this.setSettings( readSettings );
@@ -223,6 +230,7 @@ public class DirectoryConnectorApp extends AppBase implements com.untangle.uvm.a
             throw new IllegalArgumentException("Must provide settings for Google");
         }
 
+        setEncryptedPassword(newSettings);
         /**
          * Save the settings
          */
@@ -242,6 +250,20 @@ public class DirectoryConnectorApp extends AppBase implements com.untangle.uvm.a
         try { logger.debug("New Settings: \n" + new org.json.JSONObject(this.settings).toString(2)); } catch (Exception e) {}
 
         this.reconfigure();
+    }
+
+     /**
+     * Encrypt the password for AD Servers
+     *
+     * @param settings
+     *      Settings to convert.
+     */
+    private void setEncryptedPassword( DirectoryConnectorSettings settings ) {
+        ActiveDirectorySettings adSettings = settings.getActiveDirectorySettings();
+        for(ActiveDirectoryServer server : adSettings.getServers()) {
+            if(StringUtils.isNotBlank(server.getSuperuserPass()))
+                server.encryptSuperUserPass();
+        }
     }
 
     /**

--- a/directory-connector/src/com/untangle/app/directory_connector/DirectoryConnectorSettings.java
+++ b/directory-connector/src/com/untangle/app/directory_connector/DirectoryConnectorSettings.java
@@ -12,7 +12,7 @@ import org.json.JSONString;
 @SuppressWarnings("serial")
 public class DirectoryConnectorSettings implements java.io.Serializable, JSONString
 {
-    private int version = 3;
+    private int version = 4;
 
     private boolean apiEnabled = false;
     private String apiSecretKey = null;

--- a/directory-connector/src/com/untangle/app/directory_connector/LdapAdapter.java
+++ b/directory-connector/src/com/untangle/app/directory_connector/LdapAdapter.java
@@ -62,6 +62,7 @@ import javax.net.ssl.SSLContext;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.untangle.uvm.PasswordUtil;
 import com.untangle.uvm.util.Pair;
 
 /**
@@ -457,21 +458,21 @@ abstract class LdapAdapter
             return createSuperuserContext();
         }
         catch(AuthenticationException ex) {
-            logger.warn("Unable to create superuser context with settings: " +
-                        "Host: \"" + settings.getLDAPHost() + "\", " +
-                        "Port: \"" + settings.getLDAPPort() + "\", " +
-                        "Superuser DN: \"" + getSuperuserDN() + "\", " +
-                        "Pass: " + (settings.getSuperuserPass()==null?"<null>":"<not null>") +
-                        " ; Error is: " + ex);
+            logger.warn("Unable to create superuser context with settings: Host: {} Port: {} Superuser DN: {} Encrypted Pass: {} ; Error is: ", 
+                                        settings.getLDAPHost(), 
+                                        settings.getLDAPPort(), 
+                                        getSuperuserDN(), 
+                                        (settings.getSuperuserPass()==null && settings.getEncrSupUserPass()==null)?"<null>":"<not null>",
+                                        ex);
             throw ex;
         }
         catch(CommunicationException ex) {
-            logger.warn("Unable to create superuser context with settings: " +
-                        "Host: \"" + settings.getLDAPHost() + "\", " +
-                        "Port: \"" + settings.getLDAPPort() + "\", " +
-                        "Superuser DN: \"" + getSuperuserDN() + "\", " +
-                        "Pass: " + (settings.getSuperuserPass()==null?"<null>":"<not null>") +
-                        " ; Error is: " + ex.toString());
+            logger.warn("Unable to create superuser context with settings: Host: {} Port: {} Superuser DN: {} Encrypted Pass: {} ; Error is: {}", 
+                                        settings.getLDAPHost(), 
+                                        settings.getLDAPPort(), 
+                                        getSuperuserDN(), 
+                                        (settings.getSuperuserPass()==null && settings.getEncrSupUserPass()==null)?"<null>":"<not null>", 
+                                        ex.toString());
 
             Throwable cause = null; 
             Throwable result = ex;
@@ -483,12 +484,12 @@ abstract class LdapAdapter
             throw new CommunicationException( result.getMessage() + ": " + ex.getMessage() );
         }
         catch(Exception ex) {
-            logger.error("Unable to create superuser context with settings: " +
-                         "Host: \"" + settings.getLDAPHost() + "\", " +
-                         "Port: \"" + settings.getLDAPPort() + "\", " +
-                         "Superuser DN: \"" + getSuperuserDN() + "\", " +
-                         "Pass: " + (settings.getSuperuserPass()==null?"<null>":"<not null>") +
-                         " ; Error is: " + ex);
+            logger.warn("Unable to create superuser context with settings: Host: {} Port: {} Superuser DN: {} Encrypted Pass: {} ; Error is: ", 
+                                        settings.getLDAPHost(), 
+                                        settings.getLDAPPort(), 
+                                        getSuperuserDN(), 
+                                        (settings.getSuperuserPass()==null && settings.getEncrSupUserPass()==null)?"<null>":"<not null>",
+                                        ex);
             throw ex;
         }
     }
@@ -731,11 +732,12 @@ abstract class LdapAdapter
         throws CommunicationException, AuthenticationException, NamingException
     {
         ActiveDirectoryServer settings = getSettings();
+        String password = settings.getSuperuserPass() != null ? settings.getSuperuserPass() : PasswordUtil.getDecryptPassword(settings.getEncrSupUserPass());
         return createContext(settings.getLDAPHost(),
                              settings.getLDAPPort(),
                              settings.getLDAPSecure(),
                              getSuperuserDN(),
-                             settings.getSuperuserPass());
+                             password);
     }
 
     /**

--- a/openvpn/js/MainController.js
+++ b/openvpn/js/MainController.js
@@ -73,6 +73,7 @@ Ext.define('Ung.apps.openvpn.MainController', {
             }
 
             vm.set('settings', result);
+            me.getOrignalPasswd();
 
             vm.set('panel.saveDisabled', false);
             v.setLoading(false);
@@ -96,6 +97,19 @@ Ext.define('Ung.apps.openvpn.MainController', {
                 });
             }
         });
+    },
+
+    getOrignalPasswd: function() {
+        var vm = this.getViewModel();
+        servers = vm.get('settings.remoteServers.list');
+        if(servers){
+            servers.forEach(function(server){
+                encryptedPassword = server.remoteServerEncryptedPassword;
+                if(encryptedPassword != null && encryptedPassword != ""){
+                    server.authPassword = Util.getDecryptedPassword(server.remoteServerEncryptedPassword);
+                }
+            });
+        }
     },
 
     setSettings: function () {

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
@@ -25,6 +25,7 @@ import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.SettingsManager;
 import com.untangle.uvm.NetspaceManager;
 import com.untangle.uvm.NetspaceManager.NetworkSpace;
+import com.untangle.uvm.PasswordUtil;
 import com.untangle.uvm.NetspaceManager.IPVersion;
 import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.HookCallback;
@@ -50,7 +51,7 @@ import com.untangle.uvm.vnet.PipelineConnector;
 public class OpenVpnAppImpl extends AppBase
 {
 
-    private static final Integer SETTINGS_CURRENT_VERSION = 1;
+    private static final Integer SETTINGS_CURRENT_VERSION = 2;
 
     private final Logger logger = LogManager.getLogger(getClass());
 
@@ -291,6 +292,11 @@ public class OpenVpnAppImpl extends AppBase
         sanitizeSettings(newSettings);
 
         /**
+         * encrypt the password of remote server stroed in new Settings
+         */
+        setEncryptedPassword(newSettings);
+
+        /**
          * Save the settings
          */
         SettingsManager settingsManager = UvmContextFactory.context().settingsManager();
@@ -348,6 +354,22 @@ public class OpenVpnAppImpl extends AppBase
             cleanServerSettings();
         } catch (Exception exn) {
             logger.warn("Exception during client/server cleanup", exn);
+        }
+    }
+
+    /**
+     * Encrypt the password for Remote Servers
+     *
+     * @param settings
+     *      Settings to convert.
+     */
+    private void setEncryptedPassword( OpenVpnSettings settings ) {
+        List<OpenVpnRemoteServer> remoteServers = settings.getRemoteServers();
+        for(OpenVpnRemoteServer server : remoteServers) {
+            if(server.getAuthPassword() != null){
+                server.setRemoteServerEncryptedPassword(PasswordUtil.getEncryptPassword(server.getAuthPassword()));
+                server.setAuthPassword(null);
+            }
         }
     }
 

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.LogManager;
 
 import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.ExecManagerResult;
+import com.untangle.uvm.PasswordUtil;
 import com.untangle.uvm.app.IPMaskedAddress;
 import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.network.InterfaceSettings;
@@ -747,7 +748,7 @@ public class OpenVpnManager
         BufferedWriter authWriter;
         for (OpenVpnRemoteServer server : remoteServers) {
             if (!server.getEnabled()) continue;
-
+            String serverPassword;
             String name = server.getName();
             logger.info("Writing server configuration file for [" + name + "]");
 
@@ -795,10 +796,17 @@ public class OpenVpnManager
 
                 // if user+pass auth is enabled create the auth file
                 if (server.getAuthUserPass()) {
+
+                    serverPassword = PasswordUtil.getDecryptPassword(server.getRemoteServerEncryptedPassword());
+                    if(serverPassword == null){
+                        logger.warn("Error occured while decrypting the encrypted passowrd for server : { }", name);
+                        continue;
+                    }
+                    
                     File authFile = new File("/etc/openvpn/" + name + ".auth");
                     authWriter = new BufferedWriter(new FileWriter(authFile));
                     authWriter.write(server.getAuthUsername() + LINE_BREAK);
-                    authWriter.write(server.getAuthPassword() + LINE_BREAK);
+                    authWriter.write(serverPassword + LINE_BREAK);
                 }
 
                 count += 1;

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnRemoteServer.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnRemoteServer.java
@@ -18,6 +18,7 @@ public class OpenVpnRemoteServer implements java.io.Serializable, org.json.JSONS
     private boolean authUserPass = false;
     private String authUsername;
     private String authPassword;
+    private String remoteServerEncryptedPassword;
 
     public OpenVpnRemoteServer()
     {
@@ -39,6 +40,9 @@ public class OpenVpnRemoteServer implements java.io.Serializable, org.json.JSONS
 
     public String getAuthPassword() { return this.authPassword; }
     public void setAuthPassword( String newValue ) { this.authPassword = newValue; }
+
+    public String getRemoteServerEncryptedPassword() { return this.remoteServerEncryptedPassword; }
+    public void setRemoteServerEncryptedPassword( String newValue ) { this.remoteServerEncryptedPassword = newValue; }
 
 // THIS IS FOR ECLIPSE - @formatter:on
 

--- a/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
+++ b/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
@@ -46,7 +46,7 @@ def create_tunnel_rule(vpn_enabled=True,vpn_ipv6=True,rule_id=50,vpn_tunnel_id=T
             "tunnelId": vpn_tunnel_id
     }
 
-def create_tunnel_profile(username=None,vpn_enabled=True,provider="tunnel-Arista",password= None,name="tunnel-Arista",vpn_tunnel_id=TUNNEL_ID):
+def create_tunnel_profile(username=None,vpn_enabled=True,provider="tunnel-Arista",password=None,name="tunnel-Arista",vpn_tunnel_id=TUNNEL_ID):
     if (password):
         return {
             "allTraffic": False,
@@ -75,11 +75,6 @@ def create_tunnel_profile(username=None,vpn_enabled=True,provider="tunnel-Arista
             },
             "tunnelId": vpn_tunnel_id
         }
-
-def remove_tunnel_profile():
-    return {'javaClass': 'java.util.LinkedList',
-        'list': []
-    }
 
 def create_trigger_rule(action, tag_target, tag_name, tag_lifetime_sec, description, field, operator, value, field2, operator2, value2):
     return {
@@ -301,12 +296,12 @@ class TunnelVpnTests(NGFWTestCase):
         assert(connected)
         assert(connectStatus == "CONNECTED")
     
-    def test_041_password_encryption_setting_process_for_Tunnel_VPN(self):
+    def test_50_password_encryption_setting_process_for_Tunnel_VPN(self):
         """
         Verify tunnel vpn password encryption setting process
         """
         appData = self._app.getSettings()
-        appData['tunnels']['list'].append(create_tunnel_profile(name="Tunnel1",password="testing",vpn_tunnel_id="200",username="test"))
+        appData['tunnels']['list'].append(create_tunnel_profile(name="Tunnel1",password="testing",vpn_tunnel_id="202",username="test"))
         appData['tunnels']['list'].append(create_tunnel_profile(name="Tunnel2",vpn_tunnel_id="201"))
         self._app.setSettings(appData)
 
@@ -320,10 +315,10 @@ class TunnelVpnTests(NGFWTestCase):
         assert tunnel_with_no_password.get('encryptedTunnelVpnPassword') is None, "encryptedTunnelVpnPassword is not none"
         assert tunnel_with_no_password.get('password') is None, "Password is not None"
 
-        tunnelId200 = appData['tunnels']['list'][0]["tunnelId"]
+        tunnelId202 = appData['tunnels']['list'][0]["tunnelId"]
         tunnelId201 = appData['tunnels']['list'][1]["tunnelId"]
 
-        filename1 = f"@PREFIX@/usr/share/untangle/settings/tunnel-vpn/tunnel-{tunnelId200}/auth.txt"
+        filename1 = f"@PREFIX@/usr/share/untangle/settings/tunnel-vpn/tunnel-{tunnelId202}/auth.txt"
         filename2 = f"@PREFIX@/usr/share/untangle/settings/tunnel-vpn/tunnel-{tunnelId201}/auth.txt"
 
         second_line = None
@@ -346,6 +341,7 @@ class TunnelVpnTests(NGFWTestCase):
         assert second_line == "password", f"Expected 'testing' but got '{second_line}'"
         
         # clear the created tunnel
-        appData['tunnels']['list'].append(remove_tunnel_profile())
+        appData['tunnels']['list'][:] = []
+        self._app.setSettings(appData)
 
 test_registry.register_module("tunnel-vpn", TunnelVpnTests)

--- a/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
+++ b/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
@@ -46,29 +46,14 @@ def create_tunnel_rule(vpn_enabled=True,vpn_ipv6=True,rule_id=50,vpn_tunnel_id=T
             "tunnelId": vpn_tunnel_id
     }
 
-def create_tunnel_profile(vpn_enabled=True,provider="tunnel-Arista",name="tunnel-Arista",vpn_tunnel_id=TUNNEL_ID):
-    return {
-            "allTraffic": False,
-            "enabled": vpn_enabled,
-            "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
-            "name": name,
-            "provider": "Arista",
-            "tags": {
-                "javaClass": "java.util.LinkedList",
-                "list": []
-            },
-            "tunnelId": vpn_tunnel_id
-    }
-
-def create_tunnel_profile_for_password_encrypt(vpn_enabled=True,provider="tunnel-Arista",password=None,name="tunnel-Arista",vpn_tunnel_id=TUNNEL_ID):
-    encoded_password = global_functions.uvmContext.systemManager().getEncryptedPassword(password)
-    if  (password):
+def create_tunnel_profile(vpn_enabled=True,provider="tunnel-Arista",password= None,name="tunnel-Arista",vpn_tunnel_id=TUNNEL_ID):
+    if (password):
         return {
             "allTraffic": False,
             "enabled": vpn_enabled,
             "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
             "name": name,
-            "encryptedTunnelVpnPassword": encoded_password, 
+            "password": password, 
             "provider": "Arista",
             "tags": {
                 "javaClass": "java.util.LinkedList",
@@ -88,7 +73,7 @@ def create_tunnel_profile_for_password_encrypt(vpn_enabled=True,provider="tunnel
                 "list": []
             },
             "tunnelId": vpn_tunnel_id
-    }
+        }
 
 def remove_tunnel_profile():
     return {'javaClass': 'java.util.LinkedList',
@@ -320,11 +305,11 @@ class TunnelVpnTests(NGFWTestCase):
         Verify tunnel vpn password encryption setting process
         """
         appData = self._app.getSettings()
-        appData['tunnels']['list'].append(create_tunnel_profile_for_password_encrypt(name="Tunnel1",password="test"))
+        appData['tunnels']['list'].append(create_tunnel_profile(name="Tunnel1",password="test"))
         self._app.setSettings(appData)
         tunnel_with_password = appData['tunnels']['list'][0]
 
-        appData['tunnels']['list'].append(create_tunnel_profile_for_password_encrypt(name="Tunnel2"))
+        appData['tunnels']['list'].append(create_tunnel_profile(name="Tunnel2"))
         self._app.setSettings(appData)
         tunnel_with_no_password = appData['tunnels']['list'][1]
 

--- a/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
+++ b/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
@@ -326,28 +326,27 @@ class TunnelVpnTests(NGFWTestCase):
         filename1 = f"@PREFIX@/usr/share/untangle/settings/tunnel-vpn/tunnel-{tunnelId200}/auth.txt"
         filename2 = f"@PREFIX@/usr/share/untangle/settings/tunnel-vpn/tunnel-{tunnelId201}/auth.txt"
 
-        # If password is encrypted, it should be decrypted and saved in auth.txt file.
-        # If there is no password, then also auth.txt file get created with default password.
-        with open(filename1, 'r') as file:
-        # Read the entire content of the file into a variable
-            lines = file.readlines()
-            for line in lines:
-                line = line.strip()  # Remove newline or extra spaces
-                if len(lines) >= 2:
-                     # Store the second line into a variable
-                    second_line = lines[1].strip()  # Remove newline or extra spaces
-                    assert True is second_line, appData['tunnels']['list'][0]["password"]
+        second_line = None
+        with open(filename1, 'r') as file:        
+            file.seek(0)  # Reset the file pointer to the beginning of the file
+            lines = file.readlines()  # Now read the lines again
+            if len(lines) > 1:
+                second_line = lines[1].strip()  # Removing trailing newline
+            else:
+                print("The file doesn't contain a second line.")
+        assert second_line == "testing", f"Expected 'testing' but got '{second_line}'"
 
-        with open(filename2, 'r') as file:
-        # Read the entire content of the file into a variable
-            lines = file.readlines()
-            for line in lines:
-                if len(lines) >= 2:
-                    # Store the second line into a variable
-                    second_line = lines[1].strip()  # Remove newline or extra spaces
-                    assert True is second_line, "password"
-
+        with open(filename2, 'r') as file:        
+            file.seek(0)  # Reset the file pointer to the beginning of the file
+            lines = file.readlines()  # Now read the lines again
+            if len(lines) > 1:
+                second_line = lines[1].strip()  # Removing trailing newline
+            else:
+                print("The file doesn't contain a second line.")
+        assert second_line == "password", f"Expected 'testing' but got '{second_line}'"
+        
         # clear the created tunnel
         appData['tunnels']['list'].append(remove_tunnel_profile())
+        self._app.setSettings(appData)
 
 test_registry.register_module("tunnel-vpn", TunnelVpnTests)

--- a/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
+++ b/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
@@ -60,6 +60,11 @@ def create_tunnel_profile(vpn_enabled=True,provider="tunnel-Arista",name="tunnel
             "tunnelId": vpn_tunnel_id
     }
 
+def remove_tunnel_profile():
+    return {'javaClass': 'java.util.LinkedList',
+        'list': []
+    }
+
 def create_trigger_rule(action, tag_target, tag_name, tag_lifetime_sec, description, field, operator, value, field2, operator2, value2):
     return {
         "description": description,
@@ -279,5 +284,20 @@ class TunnelVpnTests(NGFWTestCase):
         # If VPN tunnel has failed to connect, fail the test,
         assert(connected)
         assert(connectStatus == "CONNECTED")
+    
+    def test_041_password_encryption_setting_process_for_Tunnel_VPN(self):
+        """
+        Verify tunnel vpn password encryption setting process
+        """
+        appData = self._app.getSettings()
+        appData['tunnels']['list'].append(create_tunnel_profile())
+        self._app.setSettings(appData)
+
+        tunnel = appData['list'][0]
+        
+        assert tunnel.get('password') is None, "Password is not None"
+
+        # clear the created tunner
+        appData['tunnels']['list'].appned(remove_tunnel_profile())
 
 test_registry.register_module("tunnel-vpn", TunnelVpnTests)

--- a/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
+++ b/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
@@ -347,6 +347,5 @@ class TunnelVpnTests(NGFWTestCase):
         
         # clear the created tunnel
         appData['tunnels']['list'].append(remove_tunnel_profile())
-        self._app.setSettings(appData)
 
 test_registry.register_module("tunnel-vpn", TunnelVpnTests)

--- a/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
+++ b/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
@@ -306,11 +306,11 @@ class TunnelVpnTests(NGFWTestCase):
         """
         appData = self._app.getSettings()
         appData['tunnels']['list'].append(create_tunnel_profile(name="Tunnel1",password="test"))
-        self._app.setSettings(appData)
-        tunnel_with_password = appData['tunnels']['list'][0]
-
         appData['tunnels']['list'].append(create_tunnel_profile(name="Tunnel2"))
         self._app.setSettings(appData)
+
+        appData = self._app.getSettings()
+        tunnel_with_password = appData['tunnels']['list'][0]
         tunnel_with_no_password = appData['tunnels']['list'][1]
 
         assert tunnel_with_password.get('encryptedTunnelVpnPassword') is not None, "encryptedTunnelVpnPassword is missing"

--- a/tunnel-vpn/hier/usr/share/untangle/bin/tunnel-vpn-sync-settings.py
+++ b/tunnel-vpn/hier/usr/share/untangle/bin/tunnel-vpn-sync-settings.py
@@ -279,15 +279,16 @@ for tunnel in settings.get('tunnels').get('list'):
             if not system_manager:
                 log("System Manager is not available...")
                 continue
-            log(f"Before decryption {tunnel.get('encryptedTunnelVpnPassword')}")
-            print("Before decryption" % tunnel.get('encryptedTunnelVpnPassword'))
+            encryptedpassword = tunnel.get('encryptedTunnelVpnPassword')
+            log(f"Before decryption {encryptedpassword}")
+            print("Before decryption: %s" % encryptedpassword)
             start_time = time.time()
             password = system_manager.getDecryptedPassword(tunnel.get('encryptedTunnelVpnPassword'))
 
             end_time = time.time()
             time_taken = end_time - start_time
-            log("After decryption: %s" % password)
-            print("After decryption: " % password)
+            log(f"After decryption: {password}")
+            print("After decryption: %s" % password)
             log(f"Time taken to decrypt the password: {time_taken:.2f} seconds")
             print("Time taken to decrypt the password: %s seconds" % time_taken)
         except Exception as e:
@@ -296,7 +297,7 @@ for tunnel in settings.get('tunnels').get('list'):
 
 
     print("Decrypted password: %s" % password)
-    log("Decrypted password: %s" % password)
+    log(f"Decrypted password: {password}")
 
     filename = parser.prefix + "@PREFIX@/usr/share/untangle/settings/tunnel-vpn/tunnel-%i/auth.txt" % tunnel.get('tunnelId')
     try: os.makedirs(os.path.dirname(filename))

--- a/tunnel-vpn/js/view/Tunnels.js
+++ b/tunnel-vpn/js/view/Tunnels.js
@@ -191,11 +191,8 @@ Ext.define('Ung.apps.tunnel-vpn.view.Tunnels', {
                 var me = this,
                 vm = me.up('window').getViewModel(),
                 record = vm.get('record');
-
-                if(record){
-                    if (!record.get('password') && record.get('encryptedTunnelVpnPassword')){
-                        me.setValue(Util.getDecryptedPassword(record.get('encryptedTunnelVpnPassword')));
-                    }
+                if(record && !record.get('password') && record.get('encryptedTunnelVpnPassword')){
+                    me.setValue(Util.getDecryptedPassword(record.get('encryptedTunnelVpnPassword')));
                 }
             }
         },

--- a/tunnel-vpn/js/view/Tunnels.js
+++ b/tunnel-vpn/js/view/Tunnels.js
@@ -186,6 +186,19 @@ Ext.define('Ung.apps.tunnel-vpn.view.Tunnels', {
             disabled: '{tunnelUsernameHidden == true}',
             hidden: '{tunnelProviderSelected == false}'
         },
+        listeners: {
+            afterrender: function() {
+                var me = this,
+                vm = me.up('window').getViewModel(),
+                record = vm.get('record');
+
+                if(record){
+                    if (!record.get('password') && record.get('encryptedTunnelVpnPassword')){
+                        me.setValue(Util.getDecryptedPassword(record.get('encryptedTunnelVpnPassword')));
+                    }
+                }
+            }
+        },
     }, {
         xtype: 'fieldset',
         margin: '0 10 0 190',

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
@@ -301,6 +301,10 @@ public class TunnelVpnApp extends AppBase
         } else {
             logger.info("Loading Settings...");
 
+            // setSettings will set encrypted password and remove original password
+            if ( readSettings.getVersion() < 2 ) {
+                readSettings.setVersion(2);
+            }
             /**
              * If the settings file date is newer than the system files, re-sync
              * them

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
@@ -24,6 +24,7 @@ import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.SettingsManager;
 import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.HookCallback;
+import com.untangle.uvm.PasswordUtil;
 import com.untangle.uvm.app.AppSettings;
 import com.untangle.uvm.app.AppProperties;
 import com.untangle.uvm.app.AppBase;
@@ -99,6 +100,13 @@ public class TunnelVpnApp extends AppBase
          * Save the settings
          */
         String appID = this.getAppSettings().getId().toString();
+        for(TunnelVpnTunnelSettings tunnelSettings : newSettings.getTunnels()) {
+            if(tunnelSettings.getPassword() != null){
+                // encrypt the plaintext password of password to encryptedTunnelVpnPassword
+                tunnelSettings.setEncryptedTunnelVpnPassword(PasswordUtil.getEncryptPassword(tunnelSettings.getPassword()));
+                tunnelSettings.setPassword(null);// remove cleartext
+            }
+        }
         try {
             UvmContextFactory.context().settingsManager().save( System.getProperty("uvm.settings.dir") + "/" + "tunnel-vpn/" + "settings_"  + appID + ".js", newSettings );
         } catch (SettingsManager.SettingsException e) {

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
@@ -304,6 +304,7 @@ public class TunnelVpnApp extends AppBase
             // setSettings will set encrypted password and remove original password
             if ( readSettings.getVersion() < 2 ) {
                 readSettings.setVersion(2);
+                this.setSettings(readSettings);
             }
             /**
              * If the settings file date is newer than the system files, re-sync

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnSettings.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnSettings.java
@@ -17,7 +17,7 @@ import org.json.JSONString;
 @SuppressWarnings("serial")
 public class TunnelVpnSettings implements Serializable, JSONString
 {
-    private Integer version = Integer.valueOf(1);
+    private Integer version = Integer.valueOf(2);
 
     private List<TunnelVpnTunnelSettings> servers = new LinkedList<>();
 

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnTunnelSettings.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnTunnelSettings.java
@@ -25,6 +25,7 @@ public class TunnelVpnTunnelSettings implements JSONString, Serializable
     private String provider = null;
     private String username = null;
     private String password = null;
+    private String encryptedTunnelVpnPassword = null; /* encrypted password of password*/
 
     private Integer boundInterfaceId = null; /* 0 and null mean any interface */
     
@@ -49,6 +50,9 @@ public class TunnelVpnTunnelSettings implements JSONString, Serializable
 
     public String getPassword() { return password; }
     public void setPassword(String newValue) { this.password = newValue; }
+
+    public String getEncryptedTunnelVpnPassword() { return encryptedTunnelVpnPassword; }
+    public void setEncryptedTunnelVpnPassword(String newValue) { this.encryptedTunnelVpnPassword = newValue; }
 
     public boolean getNat() { return nat; }
     public void setNat(boolean newValue) { this.nat = newValue; }

--- a/uvm/api/com/untangle/uvm/ExecManager.java
+++ b/uvm/api/com/untangle/uvm/ExecManager.java
@@ -14,6 +14,11 @@ public interface ExecManager
     ExecManagerResult exec( String cmd );
 
     /**
+    * Execute the specified command and return the result
+    */
+    ExecManagerResult exec(String cmd, boolean rateLimit, boolean safe, boolean logEnabled);
+
+    /**
      * Execute the specified command and return the stdout
      */
     ExecManagerResult exec( String cmd, boolean rateLimit );

--- a/uvm/api/com/untangle/uvm/ExecManager.java
+++ b/uvm/api/com/untangle/uvm/ExecManager.java
@@ -38,6 +38,11 @@ public interface ExecManager
     /**
      * Execute the specified command and return the stdout
      */
+    String execOutput( boolean logEnabled, String cmd );
+
+    /**
+     * Execute the specified command and return the stdout
+     */
     String execOutput( String cmd, boolean rateLimit );
 
     /**

--- a/uvm/api/com/untangle/uvm/LocalDirectoryUser.java
+++ b/uvm/api/com/untangle/uvm/LocalDirectoryUser.java
@@ -22,6 +22,7 @@ public final class LocalDirectoryUser implements Serializable, Comparable<LocalD
     private String passwordShaHash;
     private String passwordMd5Hash;
     private String passwordBase64Hash;
+    private String encryptedPassword;
     private Boolean mfaEnabled;
     private String twofactorSecretKey;
 
@@ -79,6 +80,24 @@ public final class LocalDirectoryUser implements Serializable, Comparable<LocalD
     }
 
     /**
+     * Get the encryptedPassword 
+     * 
+     * @return the encryptedPassword
+     */
+    public String getEncryptedPassword() {
+        return this.encryptedPassword;
+    }
+
+    /**
+     * Set the encryptedPassword
+     * 
+     * @param password The original password
+     */
+    public void setEncryptedPassword(String password) {
+        this.encryptedPassword = makeNotNull(password);
+    }
+
+    /**
      * Get the passwordShaHash to used in account creation
      * 
      * @return the passwordShaHash
@@ -129,7 +148,7 @@ public final class LocalDirectoryUser implements Serializable, Comparable<LocalD
      * @param passwordBase64Hash The hash
      */
     public void setPasswordBase64Hash(String passwordBase64Hash) {
-        this.passwordBase64Hash = makeNotNull(passwordBase64Hash);
+        this.passwordBase64Hash = passwordBase64Hash;
     }
 
     /**

--- a/uvm/api/com/untangle/uvm/PasswordUtil.java
+++ b/uvm/api/com/untangle/uvm/PasswordUtil.java
@@ -21,6 +21,12 @@ public class PasswordUtil
     // We pass no seed here, so we'll get different random numbers each time.
     private static SecureRandom srng = new SecureRandom();
 
+
+    /**  ************************* NOTE *************************
+     *  Currently binary is generating warn related to TPM including the password in second line
+     *  so handled the code accordingly in getEncryptPassword() and getDecryptPassword()
+     *  Also while executing the command password is shown in logger in future will handle this by overriding rhe exec method
+    */
     /**
      * Encrypt the provided password by invoking an password manager
      * command to retrieve the encrypted value.

--- a/uvm/api/com/untangle/uvm/PasswordUtil.java
+++ b/uvm/api/com/untangle/uvm/PasswordUtil.java
@@ -49,13 +49,18 @@ public class PasswordUtil
     */
     public static String getEncryptPassword(String password){
         try {
-            if (StringUtils.isBlank(password)) {
-                throw new IllegalArgumentException("password can not be null or empty.");
+            if (password == null) {
+                throw new IllegalArgumentException("password can not be null.");
+            }
+            //paasword encryption should work for empty string too as we allow empty passwords
+            if(password.isEmpty() || password.isBlank()){
+                //set empty string as " " so command can execute for empty and blank password too
+                password = Constants.EMPTY_STRING;
             }
             String command = passwordEncryptionCmd + password;
             return execCmd(command);
         } catch (IllegalArgumentException | IllegalStateException e) {
-            logger.error("Password can not be null or empty, or encryption output is invalid.", e);
+            logger.error("Password can not be null or encryption output is invalid.", e);
         } 
         catch (Exception e) {
             logger.error("Exception occured while encrypting the password", e);
@@ -165,5 +170,31 @@ public class PasswordUtil
             if (testRawPW[i] != rawPW[i])
                 return false;
         return true;
+    }
+
+    /**
+     * Password  exception
+     */
+    @SuppressWarnings("serial")
+    public static class CryptoProcessException extends Exception
+    {
+        /**
+         * Initialize instance of CryptoProcessException.
+         * @param  message String of message.
+         * @return         Instance of CryptoProcessException.
+         */
+        public CryptoProcessException(String message) {
+            super(message);
+        }
+
+        /**
+         * Initialize instance of CryptoProcessException.
+         * @param  message String of message.
+         * @param  cause Trowable of cause.
+         * @return         Instance of CryptoProcessException.
+         */
+        public CryptoProcessException(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 }

--- a/uvm/api/com/untangle/uvm/PasswordUtil.java
+++ b/uvm/api/com/untangle/uvm/PasswordUtil.java
@@ -15,8 +15,6 @@ import java.security.SecureRandom;
 public class PasswordUtil
 {
     public static final String PASSWORD_HASH_ALGORITHM = "MD5";
-    public static final String ENCRYPTED_PASSWORD = "";
-    public static final String DECRYPTED_PASSWORD = "";
 
     public static final int SALT_LENGTH = 8;
 
@@ -43,7 +41,7 @@ public class PasswordUtil
         if (encryptPassword.length <= 1) {
             throw new IllegalStateException("Decryption output is invalid.");
         }
-        ENCRYPTED_PASSWORD = encryotPassword[1];
+        final String ENCRYPTED_PASSWORD = encryptPassword[1];
         return ENCRYPTED_PASSWORD;
     }
     /**
@@ -62,7 +60,7 @@ public class PasswordUtil
         if (decryptPassword.length <= 1) {
             throw new IllegalStateException("Decryption output is invalid.");
         }
-        DECRYPTED_PASSWORD = decryptPassword[1];
+        final String DECRYPTED_PASSWORD = decryptPassword[1];
         return DECRYPTED_PASSWORD;
     }
     

--- a/uvm/api/com/untangle/uvm/PasswordUtil.java
+++ b/uvm/api/com/untangle/uvm/PasswordUtil.java
@@ -5,6 +5,8 @@ package com.untangle.uvm;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import com.untangle.uvm.UvmContextFactory;
+import org.apache.commons.lang3.StringUtils;
 import java.security.SecureRandom;
 
 /**
@@ -19,6 +21,41 @@ public class PasswordUtil
     // We pass no seed here, so we'll get different random numbers each time.
     private static SecureRandom srng = new SecureRandom();
 
+    /**
+     * Encrypt the provided password by invoking an password manager
+     * command to retrieve the encrypted value.
+     * 
+     * @param password a <code>String</code> containing the password to be encrypt
+     * @return a <code>String</code> containing the encrypt password
+    */
+    public static String getEncryptPassword(String password){
+        String command = new StringBuilder("/usr/bin/password-manager -e ").append(password).toString();
+        String cmdOutput =  UvmContextFactory.context().execManager().execOutput(command);
+        String[] encryptPassword = cmdOutput.split("\n");
+        if (encryptPassword.length <= 1) {
+            throw new IllegalStateException("Decryption output is invalid.");
+        }
+        return encryotPassword[1];
+    }
+    /**
+     * Decrypts the provided encrypted password by invoking an external password manager
+     * command to retrieve the decrypted value.
+     * @param encryptedPassword a <code>String</code> containing the encrypted password to be decrypted
+     * @return a <code>String</code> containing the decrypted password
+        */
+    public static String getDecryptPassword(String encryptedPassword) {
+        if (StringUtils.isBlank(encryptedPassword)) {
+            throw new IllegalArgumentException("Encrypted password must not be null or empty.");
+        }
+        String command = "/usr/bin/password-manager -d " + encryptedPassword;
+        String cmdOutput = UvmContextFactory.context().execManager().execOutput(command);
+        String[] decryptPassword = cmdOutput.split("\n");
+        if (decryptPassword.length <= 1) {
+            throw new IllegalStateException("Decryption output is invalid.");
+        }
+        return decryptPassword[1];
+    }
+    
     /**
      * Use <code>encrypt</code> to encrypt a password (using a one-way hash
      * function) before storing into the User prefs app. We automatically

--- a/uvm/api/com/untangle/uvm/PasswordUtil.java
+++ b/uvm/api/com/untangle/uvm/PasswordUtil.java
@@ -15,6 +15,8 @@ import java.security.SecureRandom;
 public class PasswordUtil
 {
     public static final String PASSWORD_HASH_ALGORITHM = "MD5";
+    public static final String ENCRYPTED_PASSWORD = "";
+    public static final String DECRYPTED_PASSWORD = "";
 
     public static final int SALT_LENGTH = 8;
 
@@ -41,7 +43,8 @@ public class PasswordUtil
         if (encryptPassword.length <= 1) {
             throw new IllegalStateException("Decryption output is invalid.");
         }
-        return encryotPassword[1];
+        ENCRYPTED_PASSWORD = encryotPassword[1];
+        return ENCRYPTED_PASSWORD;
     }
     /**
      * Decrypts the provided encrypted password by invoking an external password manager
@@ -59,7 +62,8 @@ public class PasswordUtil
         if (decryptPassword.length <= 1) {
             throw new IllegalStateException("Decryption output is invalid.");
         }
-        return decryptPassword[1];
+        DECRYPTED_PASSWORD = decryptPassword[1];
+        return DECRYPTED_PASSWORD;
     }
     
     /**

--- a/uvm/api/com/untangle/uvm/PasswordUtil.java
+++ b/uvm/api/com/untangle/uvm/PasswordUtil.java
@@ -6,6 +6,8 @@ package com.untangle.uvm;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import com.untangle.uvm.UvmContextFactory;
+import com.untangle.uvm.util.Constants;
+
 import org.apache.commons.lang3.StringUtils;
 import java.security.SecureRandom;
 import org.apache.logging.log4j.Logger;
@@ -28,65 +30,75 @@ public class PasswordUtil
     private final static String passwordDecryptionCmd = "/usr/bin/password-manager -d ";
     
     
-        /**  ************************* NOTE *************************
-         *  Currently binary is generating warn related to TPM including the password in second line
-         *  so handled the code accordingly in getEncryptPassword() and getDecryptPassword()
-         *  Also while executing the command password is shown in log, I  handled this by overriding rhe execOutput() 
-         *  and sending the value as false so you will not see any cmd log for password encryption and decryption
-         * 
-         * To get it in log for debug purpose you can set the value as true
-         * 
-        */
-        /**
-         * Encrypt the provided password by invoking an password manager
-         * command to retrieve the encrypted value.
-         * 
-         * @param password a <code>String</code> containing the password to be encrypt
-         * @return a <code>String</code> containing the encrypt password
-        */
-        public static String getEncryptPassword(String password){
-            try {
-                String command = passwordEncryptionCmd + password;
-                String cmdOutput =  UvmContextFactory.context().execManager().execOutput(false, command);
-                String[] encryptPassword = cmdOutput.split("\n");
-                if (encryptPassword.length <= 1) {
-                    throw new IllegalStateException("Encryption output is invalid.");
-                }
-                return encryptPassword[1];               
-            } catch (IllegalStateException e) {
-                logger.info("Encryption output is invalid."+ e);
-            } 
-            catch (Exception e) {
-                logger.info("Exception occured while encrypting the password"+ e);
+    /**  ************************* NOTE *************************
+     *  Currently binary is generating warn related to TPM including the password in second line
+     *  so handled the code accordingly in getEncryptPassword() and getDecryptPassword()
+     *  Also while executing the command password is shown in log, I  handled this by overriding rhe execOutput() 
+     *  and sending the value as false so you will not see any cmd log for password encryption and decryption
+     * 
+     * To get it in log for debug purpose you can set the value as true
+     * 
+    */
+    /**
+     * Encrypt the provided password by invoking an password manager
+     * command to retrieve the encrypted value.
+     * @param password a <code>String</code> containing the password to be encrypt
+     * @return a <code>String</code> containing the encrypt password or null if an error occurs during encryption so caller need to handle this.
+     * @throw IllegalArgumentException if the encrypted password is null or empty.
+     * @throw IllegalStateException if the decryption output is invalid (e.g., the command output cannot be parsed correctly).
+    */
+    public static String getEncryptPassword(String password){
+        try {
+            if (StringUtils.isBlank(password)) {
+                throw new IllegalArgumentException("password can not be null or empty.");
             }
-            return null;
+            String command = passwordEncryptionCmd + password;
+            return execCmd(command);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            logger.error("Password can not be null or empty, or encryption output is invalid.", e);
+        } 
+        catch (Exception e) {
+            logger.error("Exception occured while encrypting the password", e);
         }
-        /**
-         * Decrypts the provided encrypted password by invoking an external password manager
-         * command to retrieve the decrypted value.
-         * @param encryptedPassword a <code>String</code> containing the encrypted password to be decrypted
-         * @return a <code>String</code> containing the decrypted password
-            */
-        public static String getDecryptPassword(String encryptedPassword) {
-            try {
-                if (StringUtils.isBlank(encryptedPassword)) {
-                    throw new IllegalArgumentException("Encrypted password must not be null or empty.");
-                }
-                String command = passwordDecryptionCmd + encryptedPassword;
-                String cmdOutput = UvmContextFactory.context().execManager().execOutput(false, command);
-                String[] decryptPassword = cmdOutput.split("\n");
-                if (decryptPassword.length <= 1) {
-                    throw new IllegalStateException("Decryption output is invalid.");
-                }
-                return decryptPassword[1];                
-            } catch (IllegalArgumentException | IllegalStateException e) {
-                logger.info("Encrypted password must not be null or empty, or decryption output is invalid. "+ e);
-            } catch (Exception e) {
-                logger.info("Exception occured while decrypting the password "+ e);
+        return null;
+    }
+    /**
+     * Decrypts the provided encrypted password by invoking password manager
+     * command to retrieve the decrypted value.
+     * @param encryptedPassword The encrypted password string to be decrypted.
+     * @return a <code>String</code> containing decrypted password, or null if an error occurs during decryption so caller need to handle this.
+     * @throw IllegalArgumentException if the encrypted password is null or empty.
+     * @throw IllegalStateException if the decryption output is invalid (e.g., the command output cannot be parsed correctly).
+     */
+    public static String getDecryptPassword(String encryptedPassword) {
+        try {
+            if (StringUtils.isBlank(encryptedPassword)) {
+                throw new IllegalArgumentException("Encrypted password can not be null or empty.");
+            }
+            String command = passwordDecryptionCmd + encryptedPassword;
+            return execCmd(command);                
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            logger.error("Encrypted password can not be null or empty, or decryption output is invalid. ", e);
+        } catch (Exception e) {
+            logger.error("Exception occured while decrypting the password ", e);
         }
         return null;       
     }
-    
+    /**
+     * Executes the provided command to encrypt/decrypt the password and processes the output.
+     * 
+     * @param command The command to execute for password encryption/decryption.
+     * @return The encrypted/decrypted password string extracted from the command output.
+     * @throw IllegalStateException if the command output is invalid (does not contain expected output result).
+     */
+    public static String execCmd(String command){
+        String cmdOutput = UvmContextFactory.context().execManager().execOutput(false, command);
+        String[] encryptOrDecryptPassword = cmdOutput.split(Constants.NEW_LINE);
+        if (encryptOrDecryptPassword.length <= 1) {
+            throw new IllegalStateException("Decryption output is invalid.");
+        }
+        return encryptOrDecryptPassword[1];  
+    }
     /**
      * Use <code>encrypt</code> to encrypt a password (using a one-way hash
      * function) before storing into the User prefs app. We automatically

--- a/uvm/api/com/untangle/uvm/PasswordUtil.java
+++ b/uvm/api/com/untangle/uvm/PasswordUtil.java
@@ -40,12 +40,12 @@ public class PasswordUtil
      * 
     */
     /**
-     * Encrypt the provided password by invoking an password manager
+     * Encrypt the provided password by invoking password manager
      * command to retrieve the encrypted value.
      * @param password a <code>String</code> containing the password to be encrypt
      * @return a <code>String</code> containing the encrypt password or null if an error occurs during encryption so caller need to handle this.
      * @throw IllegalArgumentException if the encrypted password is null or empty.
-     * @throw IllegalStateException if the decryption output is invalid (e.g., the command output cannot be parsed correctly).
+     * @throw IllegalStateException if the encryption output is invalid (e.g., the command output cannot be parsed correctly).
     */
     public static String getEncryptPassword(String password){
         try {
@@ -65,7 +65,7 @@ public class PasswordUtil
     /**
      * Decrypts the provided encrypted password by invoking password manager
      * command to retrieve the decrypted value.
-     * @param encryptedPassword The encrypted password string to be decrypted.
+     * @param encryptedPassword a <code>String</code>  containing encrypted password string to be decrypted.
      * @return a <code>String</code> containing decrypted password, or null if an error occurs during decryption so caller need to handle this.
      * @throw IllegalArgumentException if the encrypted password is null or empty.
      * @throw IllegalStateException if the decryption output is invalid (e.g., the command output cannot be parsed correctly).
@@ -95,7 +95,7 @@ public class PasswordUtil
         String cmdOutput = UvmContextFactory.context().execManager().execOutput(false, command);
         String[] encryptOrDecryptPassword = cmdOutput.split(Constants.NEW_LINE);
         if (encryptOrDecryptPassword.length <= 1) {
-            throw new IllegalStateException("Decryption output is invalid.");
+            throw new IllegalStateException("Output is invalid.");
         }
         return encryptOrDecryptPassword[1];  
     }

--- a/uvm/api/com/untangle/uvm/SystemManager.java
+++ b/uvm/api/com/untangle/uvm/SystemManager.java
@@ -76,6 +76,10 @@ public interface SystemManager
 
     int getUsedDiskSpacePercentage();
 
+    String getDecryptedPassword(String encryptedPassword);
+
+    String getEncryptedPassword(String Password);
+
     org.json.JSONObject getDownloadStatus();
 
     boolean upgradesAvailable();

--- a/uvm/api/com/untangle/uvm/SystemSettings.java
+++ b/uvm/api/com/untangle/uvm/SystemSettings.java
@@ -10,6 +10,7 @@ import org.json.JSONString;
 
 import com.untangle.uvm.app.DayOfWeekMatcher;
 
+import org.apache.commons.lang3.StringUtils;
 /**
  * System settings.
  */
@@ -56,11 +57,13 @@ public class SystemSettings implements Serializable, JSONString
      * These are used for RADIUS proxy support
      */
     private boolean radiusProxyEnabled = false;
-    private String radiusProxyServer = "";
-    private String radiusProxyWorkgroup = "";
-    private String radiusProxyRealm = "";
-    private String radiusProxyUsername = "";
-    private String radiusProxyPassword = "";
+    private String radiusProxyServer = StringUtils.EMPTY;
+    private String radiusProxyWorkgroup = StringUtils.EMPTY;
+    private String radiusProxyRealm = StringUtils.EMPTY;
+    private String radiusProxyUsername = StringUtils.EMPTY;
+    private String radiusProxyPassword = StringUtils.EMPTY;
+    private String radiusProxyEncryptedPassword = StringUtils.EMPTY;
+
 
     private String installType = "";
 
@@ -187,6 +190,8 @@ public class SystemSettings implements Serializable, JSONString
     public void setRadiusProxyUsername(String newValue) { this.radiusProxyUsername = newValue; }
     public String getRadiusProxyPassword() { return radiusProxyPassword; }
     public void setRadiusProxyPassword(String newValue) { this.radiusProxyPassword = newValue; }
+    public String getRadiusProxyEncryptedPassword() { return radiusProxyEncryptedPassword; }
+    public void setRadiusProxyEncryptedPassword(String newValue) { this.radiusProxyEncryptedPassword = newValue; }
 
     /* DEPRECATED in 12.2 - moved to network settings */
     /* DEPRECATED in 12.1 - moved to network settings */

--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -78,6 +78,7 @@ public class InterfaceSettings implements Serializable, JSONString
     private Boolean     v4PPPoEUsePeerDns; /* If the DNS should be determined via PPP */
     private InetAddress v4PPPoEDns1; /* the dns1  of this interface if configured static */
     private InetAddress v4PPPoEDns2; /* the dns2  of this interface if configured static */
+    private String      v4PPPoEPasswordEncrypted; /* Encrypted PPPoE Password */
 
     private Boolean     v4NatEgressTraffic;
     private Boolean     v4NatIngressTraffic;
@@ -230,6 +231,9 @@ public class InterfaceSettings implements Serializable, JSONString
 
     public String getV4PPPoEPassword( ) { return this.v4PPPoEPassword; }
     public void setV4PPPoEPassword( String newValue ) { this.v4PPPoEPassword = newValue; }
+
+    public String getV4PPPoEPasswordEncrypted( ) { return this.v4PPPoEPasswordEncrypted; }
+    public void setV4PPPoEPasswordEncrypted( String newValue ) { this.v4PPPoEPasswordEncrypted = newValue; }
 
     public Boolean getV4PPPoEUsePeerDns( ) { return this.v4PPPoEUsePeerDns; }
     public void setV4PPPoEUsePeerDns( Boolean newValue ) { this.v4PPPoEUsePeerDns = newValue; }

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -24,7 +24,7 @@ public class NetworkSettings implements Serializable, JSONString
     public static final String PUBLIC_URL_HOSTNAME = "hostname";
     public static final String PUBLIC_URL_ADDRESS_AND_PORT = "address_and_port";
 
-    private Integer version;
+    private Integer version = Integer.valueOf(11);
 
     private List<InterfaceSettings> interfaces = null;
     private List<InterfaceSettings> virtualInterfaces = null;

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -24,7 +24,7 @@ public class NetworkSettings implements Serializable, JSONString
     public static final String PUBLIC_URL_HOSTNAME = "hostname";
     public static final String PUBLIC_URL_ADDRESS_AND_PORT = "address_and_port";
 
-    private Integer version = Integer.valueOf(11);
+    private Integer version;
 
     private List<InterfaceSettings> interfaces = null;
     private List<InterfaceSettings> virtualInterfaces = null;

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -24,7 +24,7 @@ public class NetworkSettings implements Serializable, JSONString
     public static final String PUBLIC_URL_HOSTNAME = "hostname";
     public static final String PUBLIC_URL_ADDRESS_AND_PORT = "address_and_port";
 
-    private Integer version = Integer.valueOf(11);;
+    private Integer version;
 
     private List<InterfaceSettings> interfaces = null;
     private List<InterfaceSettings> virtualInterfaces = null;

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -24,7 +24,7 @@ public class NetworkSettings implements Serializable, JSONString
     public static final String PUBLIC_URL_HOSTNAME = "hostname";
     public static final String PUBLIC_URL_ADDRESS_AND_PORT = "address_and_port";
 
-    private Integer version;
+    private Integer version = Integer.valueOf(11);;
 
     private List<InterfaceSettings> interfaces = null;
     private List<InterfaceSettings> virtualInterfaces = null;

--- a/uvm/api/com/untangle/uvm/util/Constants.java
+++ b/uvm/api/com/untangle/uvm/util/Constants.java
@@ -31,4 +31,6 @@ public class Constants {
     public static final String WEB_FILTER_EVENT_RGX = "*WebFilterEvent*";
     public static final String APP_CONTROL_LOG_EVENT_RGX = "*ApplicationControlLogEvent*";
 
+    // Escape sequence
+    public static final String NEW_LINE = "\n";
 }

--- a/uvm/api/com/untangle/uvm/util/Constants.java
+++ b/uvm/api/com/untangle/uvm/util/Constants.java
@@ -33,4 +33,7 @@ public class Constants {
 
     // Escape sequence
     public static final String NEW_LINE = "\n";
+
+    //Empty string
+    public static final String EMPTY_STRING = "\" \"";
 }

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -1323,4 +1323,47 @@ class UvmTests(NGFWTestCase):
         assert int(upgrade) > 0, "{int(upgrade)} upgrade log files found"
         assert int(wrapper) > 0, "{int(wrapper)} wrapper log files found"
 
+    '''
+    def create_tunnel_vpn_tunnel(provider, username, password):
+        encoded_password = global_functions.uvmContext.systemManager().getEncryptedPassword(password)
+        encoded_password = global_functions.uvmContext.systemManager().getEncryptedPassword(password)
+        if (provider == 'NGFirewall'):
+            return {'javaClass': 'java.util.LinkedList',
+            'list': [{
+                "boundInterfaceId": 0,
+                "enabled": true,
+                "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
+                "name": "tunnel-NGFirewall",
+                "nat": true,
+                "provider": "NGFirewall",
+                "tunnelId": 200
+            }]
+            }
+        elif (provider == 'CustomZip'):
+            return {'javaClass': 'java.util.LinkedList',
+            'list': [{
+                "boundInterfaceId": 0,
+                "enabled": true,
+                "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
+                "name": "tunnel-CustomZip",
+                "nat": true,
+                "provider": "CustomZip",
+                "tunnelId": 201
+            }]
+            }
+        elif (provider == 'CustomZipPass'):
+            return {'javaClass': 'java.util.LinkedList',
+            'list': [{
+                "boundInterfaceId": 0,
+                "enabled": true,
+                "encryptedTunnelVpnPassword": encoded_password,
+                "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
+                "name": "tunnel-CustomZipPass",
+                "nat": true,
+                "provider": "CustomZipPass",
+                "tunnelId": 202,
+                "username": username
+            }]
+            }
+        '''
 test_registry.register_module("uvm", UvmTests)

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -1036,6 +1036,34 @@ class UvmTests(NGFWTestCase):
 
         assert(result == 0)
 
+    def test_165_password_encryption_decryption_process(self):
+        """
+        Verify password encryption decryption process
+        """
+        password = 'passwd'
+        # Test 1: Valid password - it should pass if encrypted and decrypted correctly
+        encrypted_password = global_functions.uvmContext.systemManager().getEncryptedPassword(password)
+        decrypted_password = global_functions.uvmContext.systemManager().getDecryptedPassword(encrypted_password)
+
+        # Compare original password with decrypted password
+        self.assertEqual(password, decrypted_password, "Password encryption/decryption failed.")
+
+        # Test 2: Empty password - it should pass if encrypted and decrypted correctly
+        password = " "
+        encrypted_password = global_functions.uvmContext.systemManager().getEncryptedPassword(password)
+        decrypted_password = global_functions.uvmContext.systemManager().getDecryptedPassword(encrypted_password)
+
+        # Password should match after encryption and decryption
+        self.assertEqual(password, decrypted_password, "Empty password encryption/decryption failed.")
+
+        # Test 3: None (null) password - should return None or raise an exception
+        password = None
+        encrypted_password = global_functions.uvmContext.systemManager().getEncryptedPassword(password)
+
+        # Check if encryption of None returns None or raises an exception
+        self.assertIsNone(encrypted_password, "Encrypted password should be None when input is None.")
+
+
     def test_170_log_retention(self):
         """
         Verify log retention policy

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -29,14 +29,9 @@ app = None
 appFW = None
 
 default_policy_id = 1
-TUNNEL_ID = 200
 origMailsettings = None
 test_untangle_com_ip = socket.gethostbyname("test.untangle.com")
 DEFAULT_RULE_DESCRIPTION = "Route all traffic over any available Tunnel."
-DEFAULT_CONDITION = {
-            "javaClass": "java.util.LinkedList",
-            "list": []
-        }
 
 Login_username = overrides.get("Login_username", default="admin")
 Login_password = overrides.get("Login_password", default="passwd")
@@ -100,27 +95,6 @@ def create_local_directory_user(directory_user='test',expire_time=0):
 def remove_local_directory_user():
     return {'javaClass': 'java.util.LinkedList',
         'list': []
-    }
-
-def create_tunnel_profile(vpn_enabled=True,provider="tunnel-Arista",name="tunnel-Arista",vpn_tunnel_id=TUNNEL_ID):
-    encoded_password = global_functions.uvmContext.systemManager().getEncryptedPassword("test")
-    return {
-        "allTraffic": False,
-        "enabled": vpn_enabled,
-        "encryptedTunnelVpnPassword":encoded_password,
-        "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
-        "name": name,
-        "provider": "Arista",
-        "tags": {
-            "javaClass": "java.util.LinkedList",
-            "list": []
-        },
-        "tunnelId": vpn_tunnel_id
-    }
-
-def remove_tunnelvpn_connection():
-    return {'javaClass': 'java.util.LinkedList',
-    'list': []
     }
 
 def check_javascript_exceptions(errors):
@@ -1349,36 +1323,5 @@ class UvmTests(NGFWTestCase):
         assert int(reports) > 0, "{int(reports)} reports log files found"
         assert int(upgrade) > 0, "{int(upgrade)} upgrade log files found"
         assert int(wrapper) > 0, "{int(wrapper)} wrapper log files found"
-
-    '''
-    def create_tunnel_rule(vpn_enabled=True,vpn_ipv6=True,rule_id=50,vpn_tunnel_id=TUNNEL_ID, description=DEFAULT_RULE_DESCRIPTION, conditions=DEFAULT_CONDITION):
-        return {
-            "conditions": conditions,
-            "description": description,
-            "enabled": vpn_enabled,
-            "ipv6Enabled": vpn_ipv6,
-            "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnRule",
-            "ruleId": rule_id,
-            "tunnelId": vpn_tunnel_id
-        }
-    '''
-
-    def test_311_password_encryption_tunnelVPN_setting_process(self):
-        """
-        Verify tunnel vpn password encryption setting process
-        """
-        global tunnelApp   
-        appData = self._app.getSettings()
-        appData['tunnels']['list'].append(create_tunnel_profile())
-        self._app.setSettings(appData)
-
-        listOfConnections = self._app.getTunnelStatusList()
-        assert appData['tunnels']['encryptedTunnelVpnPassword'], "encryptedTunnelVpnPassword not found"
-        assert not appData['tunnels']['password'], "password not encrypted"
-
-        # remove the added tunnel
-        appData['tunnels']['list'][:] = []
-        self._app.setSettings(appData)
-        appData['tunnels']['list'].append(remove_tunnelvpn_connection())
 
 test_registry.register_module("uvm", UvmTests)

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -29,8 +29,14 @@ app = None
 appFW = None
 
 default_policy_id = 1
+TUNNEL_ID = 200
 origMailsettings = None
 test_untangle_com_ip = socket.gethostbyname("test.untangle.com")
+DEFAULT_RULE_DESCRIPTION = "Route all traffic over any available Tunnel."
+DEFAULT_CONDITION = {
+            "javaClass": "java.util.LinkedList",
+            "list": []
+        }
 
 Login_username = overrides.get("Login_username", default="admin")
 Login_password = overrides.get("Login_password", default="passwd")
@@ -94,6 +100,27 @@ def create_local_directory_user(directory_user='test',expire_time=0):
 def remove_local_directory_user():
     return {'javaClass': 'java.util.LinkedList',
         'list': []
+    }
+
+def create_tunnel_profile(vpn_enabled=True,provider="tunnel-Arista",name="tunnel-Arista",vpn_tunnel_id=TUNNEL_ID):
+    encoded_password = global_functions.uvmContext.systemManager().getEncryptedPassword("test")
+    return {
+        "allTraffic": False,
+        "enabled": vpn_enabled,
+        "encryptedTunnelVpnPassword":encoded_password,
+        "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
+        "name": name,
+        "provider": "Arista",
+        "tags": {
+            "javaClass": "java.util.LinkedList",
+            "list": []
+        },
+        "tunnelId": vpn_tunnel_id
+    }
+
+def remove_tunnelvpn_connection():
+    return {'javaClass': 'java.util.LinkedList',
+    'list': []
     }
 
 def check_javascript_exceptions(errors):
@@ -1324,46 +1351,34 @@ class UvmTests(NGFWTestCase):
         assert int(wrapper) > 0, "{int(wrapper)} wrapper log files found"
 
     '''
-    def create_tunnel_vpn_tunnel(provider, username, password):
-        encoded_password = global_functions.uvmContext.systemManager().getEncryptedPassword(password)
-        encoded_password = global_functions.uvmContext.systemManager().getEncryptedPassword(password)
-        if (provider == 'NGFirewall'):
-            return {'javaClass': 'java.util.LinkedList',
-            'list': [{
-                "boundInterfaceId": 0,
-                "enabled": true,
-                "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
-                "name": "tunnel-NGFirewall",
-                "nat": true,
-                "provider": "NGFirewall",
-                "tunnelId": 200
-            }]
-            }
-        elif (provider == 'CustomZip'):
-            return {'javaClass': 'java.util.LinkedList',
-            'list': [{
-                "boundInterfaceId": 0,
-                "enabled": true,
-                "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
-                "name": "tunnel-CustomZip",
-                "nat": true,
-                "provider": "CustomZip",
-                "tunnelId": 201
-            }]
-            }
-        elif (provider == 'CustomZipPass'):
-            return {'javaClass': 'java.util.LinkedList',
-            'list': [{
-                "boundInterfaceId": 0,
-                "enabled": true,
-                "encryptedTunnelVpnPassword": encoded_password,
-                "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnTunnelSettings",
-                "name": "tunnel-CustomZipPass",
-                "nat": true,
-                "provider": "CustomZipPass",
-                "tunnelId": 202,
-                "username": username
-            }]
-            }
-        '''
+    def create_tunnel_rule(vpn_enabled=True,vpn_ipv6=True,rule_id=50,vpn_tunnel_id=TUNNEL_ID, description=DEFAULT_RULE_DESCRIPTION, conditions=DEFAULT_CONDITION):
+        return {
+            "conditions": conditions,
+            "description": description,
+            "enabled": vpn_enabled,
+            "ipv6Enabled": vpn_ipv6,
+            "javaClass": "com.untangle.app.tunnel_vpn.TunnelVpnRule",
+            "ruleId": rule_id,
+            "tunnelId": vpn_tunnel_id
+        }
+    '''
+
+    def test_311_password_encryption_tunnelVPN_setting_process(self):
+        """
+        Verify tunnel vpn password encryption setting process
+        """
+        global tunnelApp   
+        appData = self._app.getSettings()
+        appData['tunnels']['list'].append(create_tunnel_profile())
+        self._app.setSettings(appData)
+
+        listOfConnections = self._app.getTunnelStatusList()
+        assert appData['tunnels']['encryptedTunnelVpnPassword'], "encryptedTunnelVpnPassword not found"
+        assert not appData['tunnels']['password'], "password not encrypted"
+
+        # remove the added tunnel
+        appData['tunnels']['list'][:] = []
+        self._app.setSettings(appData)
+        appData['tunnels']['list'].append(remove_tunnelvpn_connection())
+
 test_registry.register_module("uvm", UvmTests)

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -17,6 +17,7 @@ import urllib.request, urllib.error, urllib.parse
 import urllib
 import urllib3
 import fnmatch
+import base64
 
 from tests.common import NGFWTestCase
 import tests.global_functions as global_functions
@@ -72,6 +73,27 @@ def create_trigger_rule(action, tag_target, tag_name, tag_lifetime_sec, descript
             }]
         },
         "ruleId": 1
+    }
+
+def create_local_directory_user(directory_user='test',expire_time=0):
+    user_email = directory_user + "@test.untangle.com"
+    passwd_encoded = base64.b64encode("passwd".encode("utf-8"))
+    return {'javaClass': 'java.util.LinkedList',
+        'list': [{
+            'username': directory_user,
+            'firstName': '[firstName]',
+            'lastName': '[lastName]',
+            'javaClass': 'com.untangle.uvm.LocalDirectoryUser',
+            'expirationTime': expire_time,
+            'passwordBase64Hash': passwd_encoded.decode("utf-8"),
+            'email': user_email
+            },]
+    }
+
+
+def remove_local_directory_user():
+    return {'javaClass': 'java.util.LinkedList',
+        'list': []
     }
 
 def check_javascript_exceptions(errors):
@@ -1063,6 +1085,26 @@ class UvmTests(NGFWTestCase):
         # Check if encryption of None returns None or raises an exception
         self.assertIsNone(encrypted_password, "Encrypted password should be None when input is None.")
 
+
+    def test_168_password_encryption_setting_process(self):
+        """
+        Verify password encryption setting process
+        """
+        # Create local directory user 'test'
+        global_functions.uvmContext.localDirectory().setUsers(create_local_directory_user())
+
+        # Get local directory users 
+        users = global_functions.uvmContext.localDirectory().getUsers()
+
+        # Extract the user object
+        user = users['list'][0]
+
+        # Assert that encryptedPassword is present and password is None
+        assert user.get('encryptedPassword') is not None, "encryptedPassword is missing"
+        assert user.get('password') is None, "password is not None"
+        #Clear the created user
+        global_functions.uvmContext.localDirectory().setUsers(remove_local_directory_user())
+        
 
     def test_170_log_retention(self):
         """

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -31,7 +31,6 @@ appFW = None
 default_policy_id = 1
 origMailsettings = None
 test_untangle_com_ip = socket.gethostbyname("test.untangle.com")
-DEFAULT_RULE_DESCRIPTION = "Route all traffic over any available Tunnel."
 
 Login_username = overrides.get("Login_username", default="admin")
 Login_password = overrides.get("Login_password", default="passwd")

--- a/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
@@ -127,7 +127,7 @@ public class ExecManagerImpl implements ExecManager
      */
     public synchronized ExecManagerResult exec(String cmd)
     {
-        return exec(cmd, false, false);
+        return exec(cmd, false, false, true);
     }
 
     /**
@@ -141,7 +141,7 @@ public class ExecManagerImpl implements ExecManager
      */
     public synchronized ExecManagerResult exec(String cmd, boolean rateLimit)
     {
-        return exec(cmd, rateLimit, false);
+        return exec(cmd, rateLimit, false, true);
     }
 
     /**
@@ -153,7 +153,7 @@ public class ExecManagerImpl implements ExecManager
      */
     public synchronized ExecManagerResult execSafe(String cmd)
     {
-        return exec(cmd, false, true);
+        return exec(cmd, false, true, true);
     }
 
     /**
@@ -165,9 +165,11 @@ public class ExecManagerImpl implements ExecManager
      *        A boolean controlling if the output should be rate controlled or not
      * @param safe
      *        If true, prevent call if suspicious characters found. Otherwise, if found just note.
+     * @param logEnabled
+     *        In case of password encryption we don't log command
      * @return The execution result object
      */
-    public synchronized ExecManagerResult exec(String cmd, boolean rateLimit, boolean safe)
+    public synchronized ExecManagerResult exec(String cmd, boolean rateLimit, boolean safe, boolean logEnabled)
     {
 
         if (in == null | out == null || proc == null) {
@@ -194,7 +196,8 @@ public class ExecManagerImpl implements ExecManager
             }
             boolean showStatus = status.showStatus(rateLimit);
             if(showStatus){
-                logger.log(this.level, "ExecManager.exec(" + cmd + ")");
+                if(logEnabled)
+                    logger.log(this.level, "ExecManager.exec(" + cmd + ")");
             }
             // write the command to the launcher daemon
             out.write(cmd + "\n", 0, cmd.length() + 1);
@@ -214,9 +217,11 @@ public class ExecManagerImpl implements ExecManager
             status.update(t0, t1);
             if(showStatus){
                 if(status.calls == 1){
-                    logger.log(this.level, "ExecManager.exec(" + cmd + ") = " + result.getResult() + " took " + (t1 - t0) + " ms.");
+                    if(logEnabled)
+                        logger.log(this.level, "ExecManager.exec(" + cmd + ") = " + result.getResult() + " took " + (t1 - t0) + " ms.");
                 }else{
-                    logger.log(this.level, "ExecManager.exec(" + cmd + ") = " + result.getResult() + " (most recent) avg " + (status.interval/status.calls) + " ms in " + status.calls + " calls.");
+                    if(logEnabled)
+                        logger.log(this.level, "ExecManager.exec(" + cmd + ") = " + result.getResult() + " (most recent) avg " + (status.interval/status.calls) + " ms in " + status.calls + " calls.");
                 }
                 status.clear();
             }
@@ -254,7 +259,21 @@ public class ExecManagerImpl implements ExecManager
      */
     public String execOutput(String cmd)
     {
-        return exec(cmd, false, false).getOutput();
+        return exec(cmd, false, false, true).getOutput();
+    }
+
+     /**
+     * Execute a command and return the command output
+     * 
+     * @param logEnabled
+     *        The String command to execute and optionally the rateLimit flag
+     * @param cmd
+     *        
+     * @return The output from the command
+     */
+    public String execOutput(boolean logEnabled, String cmd)
+    {
+        return exec(cmd, false, false, logEnabled).getOutput();
     }
 
 
@@ -270,7 +289,7 @@ public class ExecManagerImpl implements ExecManager
     public String execOutput(String cmd, boolean rateLimit)
     {
 
-           return exec(cmd, rateLimit, false).getOutput();
+           return exec(cmd, rateLimit, false,true).getOutput();
     }
 
     /**
@@ -282,7 +301,7 @@ public class ExecManagerImpl implements ExecManager
      */
     public String execOutputSafe(String cmd)
     {
-        return exec(cmd, false, true).getOutput();
+        return exec(cmd, false, true, true).getOutput();
     }
 
 
@@ -298,7 +317,7 @@ public class ExecManagerImpl implements ExecManager
     public String execOutputSafe(String cmd, boolean rateLimit)
     {
 
-           return exec(cmd, rateLimit, true).getOutput();
+           return exec(cmd, rateLimit, true, true).getOutput();
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -174,6 +174,11 @@ public class NetworkManagerImpl implements NetworkManager
             updateNetworkReservations(readSettings);
             configureInterfaceSettingsArray();
 
+            // setSettings will set encrypted password and remove original password
+            if ( this.networkSettings.getVersion() < currentVersion ) {
+                this.networkSettings.setVersion(11);
+            }
+
             if ( this.networkSettings.getVersion() < currentVersion ) {
                 convertSettings();
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1790,11 +1790,9 @@ public class NetworkManagerImpl implements NetworkManager
                 intf.setSystemDev("ppp" + pppCount);
                 intf.setSymbolicDev("ppp" + pppCount);
                 //Encrypt the password for v4PPPoEPassword and save it in v4PPPoEPasswordEncrypted
-                if(StringUtils.isNotBlank(intf.getV4PPPoEPassword())){
+                if(intf.getV4PPPoEPassword() != null){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
-                }
-                if(StringUtils.isNotBlank(intf.getV4PPPoEPasswordEncrypted())){
-                    intf.setV4PPPoEPassword(StringUtils.EMPTY);
+                    intf.setV4PPPoEPassword(null);
                 }
                 pppCount++;
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -174,7 +174,6 @@ public class NetworkManagerImpl implements NetworkManager
             updateNetworkReservations(readSettings);
             configureInterfaceSettingsArray();
 
-
             if ( this.networkSettings.getVersion() < currentVersion ) {
                 convertSettings();
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -143,7 +143,7 @@ public class NetworkManagerImpl implements NetworkManager
                 
                 if (readSettings != null)
                     settingsManager.save( this.settingsFilename, readSettings );
-                
+                    
             } catch ( SettingsManager.SettingsException e ) {
                 logger.warn( "Failed to load settings:", e );
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -97,7 +97,7 @@ public class NetworkManagerImpl implements NetworkManager
      * The current network settings
      */
     private NetworkSettings networkSettings;
-    private Integer currentVersion = 10;
+    private Integer currentVersion = 11;
 
     /**
      * This array holds the current interface Settings indexed by the interface ID.
@@ -174,10 +174,6 @@ public class NetworkManagerImpl implements NetworkManager
             updateNetworkReservations(readSettings);
             configureInterfaceSettingsArray();
 
-            // setSettings will set encrypted password and remove original password
-            if ( this.networkSettings.getVersion() < 11 ) {
-                this.networkSettings.setVersion(11);
-            }
 
             if ( this.networkSettings.getVersion() < currentVersion ) {
                 convertSettings();

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -173,6 +173,11 @@ public class NetworkManagerImpl implements NetworkManager
             this.networkSettings = readSettings;
             updateNetworkReservations(readSettings);
             configureInterfaceSettingsArray();
+            
+            // setSettings will set encrypted password and remove original password
+            if(this.networkSettings.getVersion() < 11){
+                this.networkSettings.setVersion(11);
+            }
 
             if ( this.networkSettings.getVersion() < currentVersion ) {
                 convertSettings();

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -141,24 +141,7 @@ public class NetworkManagerImpl implements NetworkManager
                 logger.info("Reading Network Settings from " + this.settingsFilenameBackup + " = " + readSettings);
                 
                 if (readSettings != null){
-                    this.networkSettings = readSettings;
-                    List<InterfaceSettings> interfacesSettings =  networkSettings.getInterfaces();
-                    for ( InterfaceSettings intf : interfacesSettings ) {
-                        if (!InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType() ) &&
-                            InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType() ) ) { 
-
-                            if(intf.getV4PPPoEPassword() != null && !intf.getV4PPPoEPassword().isEmpty()){
-                                intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
-                                intf.setV4PPPoEPassword("");
-                            }
-                            if(intf.getV4PPPoEPasswordEncrypted() != null && !intf.getV4PPPoEPasswordEncrypted().isEmpty()){
-                                intf.setV4PPPoEPassword("");
-                            }
-                            logger.info("********Inside pppoe block********** " + this.settingsFilenameBackup + " = " + intf.getV4PPPoEPasswordEncrypted());
-                        }
-                        networkSettings.setInterfaces(interfacesSettings);  
-                        settingsManager.save( this.settingsFilename, readSettings );
-                    }  
+                    settingsManager.save( this.settingsFilename, readSettings ); 
                 } 
             } catch ( SettingsManager.SettingsException e ) {
                 logger.warn( "Failed to load settings:", e );
@@ -1808,11 +1791,11 @@ public class NetworkManagerImpl implements NetworkManager
                 //Encrypt the password for v4PPPoEPassword and save it in v4PPPoEPasswordEncrypted
                 if(intf.getV4PPPoEPassword() != null && !intf.getV4PPPoEPassword().isEmpty()){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
-                    intf.setV4PPPoEPassword("");
                 }
                 if(intf.getV4PPPoEPasswordEncrypted() != null && !intf.getV4PPPoEPasswordEncrypted().isEmpty()){
                     intf.setV4PPPoEPassword("");
                 }
+                logger.info("********Inside Sanitize pppoe block********** " + intf.getV4PPPoEPasswordEncrypted() + " = " + intf.getV4PPPoEPassword());
                 pppCount++;
             }
         }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1794,7 +1794,7 @@ public class NetworkManagerImpl implements NetworkManager
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
                 }
                 if(StringUtils.isNotBlank(intf.getV4PPPoEPasswordEncrypted())){
-                    intf.setV4PPPoEPassword("");
+                    intf.setV4PPPoEPassword(StringUtils.EMPTY);
                 }
                 pppCount++;
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -140,9 +140,9 @@ public class NetworkManagerImpl implements NetworkManager
                 readSettings = settingsManager.load( NetworkSettings.class, this.settingsFilenameBackup );
                 logger.info("Reading Network Settings from " + this.settingsFilenameBackup + " = " + readSettings);
                 
-                if (readSettings != null){
+                if (readSettings != null)
                     settingsManager.save( this.settingsFilename, readSettings ); 
-                } 
+                 
             } catch ( SettingsManager.SettingsException e ) {
                 logger.warn( "Failed to load settings:", e );
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -43,6 +43,7 @@ import org.jabsorb.serializer.UnmarshallException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -141,8 +142,8 @@ public class NetworkManagerImpl implements NetworkManager
                 logger.info("Reading Network Settings from " + this.settingsFilenameBackup + " = " + readSettings);
                 
                 if (readSettings != null)
-                    settingsManager.save( this.settingsFilename, readSettings ); 
-                 
+                    settingsManager.save( this.settingsFilename, readSettings );
+                
             } catch ( SettingsManager.SettingsException e ) {
                 logger.warn( "Failed to load settings:", e );
             }
@@ -1789,13 +1790,12 @@ public class NetworkManagerImpl implements NetworkManager
                 intf.setSystemDev("ppp" + pppCount);
                 intf.setSymbolicDev("ppp" + pppCount);
                 //Encrypt the password for v4PPPoEPassword and save it in v4PPPoEPasswordEncrypted
-                if(intf.getV4PPPoEPassword() != null && !intf.getV4PPPoEPassword().isEmpty()){
+                if(StringUtils.isNotBlank(intf.getV4PPPoEPassword())){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
                 }
-                if(intf.getV4PPPoEPasswordEncrypted() != null && !intf.getV4PPPoEPasswordEncrypted().isEmpty()){
+                if(StringUtils.isNotBlank(intf.getV4PPPoEPasswordEncrypted())){
                     intf.setV4PPPoEPassword("");
                 }
-                logger.info("********Inside Sanitize pppoe block********** " + intf.getV4PPPoEPasswordEncrypted() + " = " + intf.getV4PPPoEPassword());
                 pppCount++;
             }
         }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1783,18 +1783,18 @@ public class NetworkManagerImpl implements NetworkManager
          */
         int pppCount = 0;
         for ( InterfaceSettings intf : interfacesSettings ) {
-            if ( !InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType() ) &&
-                 InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType() ) ) {
-                // save the old system dev (usuallyy physdev or sometimse vlan dev as root dev)
-                intf.setV4PPPoERootDev(intf.getSystemDev());
-                intf.setSystemDev("ppp" + pppCount);
-                intf.setSymbolicDev("ppp" + pppCount);
-                //Encrypt the password for v4PPPoEPassword and save it in v4PPPoEPasswordEncrypted
+            if (!InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType())){
+                if(InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType())){
+                    // save the old system dev (usuallyy physdev or sometimse vlan dev as root dev)
+                    intf.setV4PPPoERootDev(intf.getSystemDev());
+                    intf.setSystemDev("ppp" + pppCount);
+                    intf.setSymbolicDev("ppp" + pppCount);
+                    pppCount++;
+                }
                 if(intf.getV4PPPoEPassword() != null){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
                     intf.setV4PPPoEPassword(null);
                 }
-                pppCount++;
             }
         }
 

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1783,18 +1783,16 @@ public class NetworkManagerImpl implements NetworkManager
          */
         int pppCount = 0;
         for ( InterfaceSettings intf : interfacesSettings ) {
-            if (!InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType())){
-                if(InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType())){
-                    // save the old system dev (usuallyy physdev or sometimse vlan dev as root dev)
-                    intf.setV4PPPoERootDev(intf.getSystemDev());
-                    intf.setSystemDev("ppp" + pppCount);
-                    intf.setSymbolicDev("ppp" + pppCount);
-                    pppCount++;
-                }
+            if (!InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType()) && InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType())){
+                // save the old system dev (usuallyy physdev or sometimse vlan dev as root dev)
+                intf.setV4PPPoERootDev(intf.getSystemDev());
+                intf.setSystemDev("ppp" + pppCount);
+                intf.setSymbolicDev("ppp" + pppCount);
                 if(intf.getV4PPPoEPassword() != null){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
                     intf.setV4PPPoEPassword(null);
                 }
+                pppCount++;
             }
         }
 

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -175,7 +175,7 @@ public class NetworkManagerImpl implements NetworkManager
             configureInterfaceSettingsArray();
 
             // setSettings will set encrypted password and remove original password
-            if ( this.networkSettings.getVersion() < currentVersion ) {
+            if ( this.networkSettings.getVersion() < 11 ) {
                 this.networkSettings.setVersion(11);
             }
 

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -173,11 +173,6 @@ public class NetworkManagerImpl implements NetworkManager
             this.networkSettings = readSettings;
             updateNetworkReservations(readSettings);
             configureInterfaceSettingsArray();
-            
-            // setSettings will set encrypted password and remove original password
-            if(this.networkSettings.getVersion() < 11){
-                this.networkSettings.setVersion(11);
-            }
 
             if ( this.networkSettings.getVersion() < currentVersion ) {
                 convertSettings();

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -242,6 +242,26 @@ public class SystemManagerImpl implements SystemManager
     }
 
     /**
+    * Get decrypted passowrd from encrypted password
+    *
+    * @param encryptedPassword
+    * @return password
+    */
+    public String getDecryptedPassword(String encryptedPassword){
+        return PasswordUtil.getDecryptPassword(encryptedPassword);
+    }
+
+    /**
+    * Get encrypted password from password
+    *
+    * @param password
+    * @return encrypted password
+    */
+    public String getEncryptedPassword(String password){
+        return PasswordUtil.getEncryptPassword(password);
+    }
+
+    /**
      * Set the settings
      * 
      * @param newSettings

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -242,6 +242,17 @@ public class SystemManagerImpl implements SystemManager
     }
 
     /**
+    * Set settings without regards to the dirtyRadiusFields
+    *
+    * @param password
+    *        The new settings
+    * @return password
+    */
+    public String getDecryptedPassword(String password){
+        return PasswordUtil.getDecryptPassword(password);
+    }
+    
+    /**
      * Set the settings
      * 
      * @param newSettings

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -33,6 +33,7 @@ import java.util.zip.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -55,7 +56,7 @@ import com.untangle.uvm.util.StringUtil;
  */
 public class SystemManagerImpl implements SystemManager
 {
-    private static final int SETTINGS_VERSION = 4;
+    private static final int SETTINGS_VERSION = 5;
     private static final String ZIP_FILE = "system_logs.zip";
     private static final String EOL = "\n";
     private static final String BLANK_LINE = EOL + EOL;
@@ -89,12 +90,12 @@ public class SystemManagerImpl implements SystemManager
 
     private int downloadTotalFileCount;
     private int downloadCurrentFileCount;
-    private String downloadCurrentFileProgress = "";
-    private String downloadCurrentFileRate = "";
+    private String downloadCurrentFileProgress = StringUtils.EMPTY;
+    private String downloadCurrentFileRate = StringUtils.EMPTY;
 
     private Calendar currentCalendar = Calendar.getInstance();
 
-    private String SettingsFileName = "";
+    private String SettingsFileName = StringUtils.EMPTY;
 
     private boolean isUpgrading = false;
     private boolean skipDiskCheck = false;
@@ -124,6 +125,10 @@ public class SystemManagerImpl implements SystemManager
             logger.warn("No settings found - Initializing new settings.");
             this.setSettings(defaultSettings(), false);
         } else {
+            if(readSettings.getRadiusProxyPassword() != null){
+                readSettings.setRadiusProxyEncryptedPassword(PasswordUtil.getEncryptPassword(readSettings.getRadiusProxyPassword()));
+                readSettings.setRadiusProxyPassword(null);
+            }
             this.settings = readSettings;
 
             if (this.settings.getVersion() < SETTINGS_VERSION) {
@@ -278,6 +283,10 @@ public class SystemManagerImpl implements SystemManager
         /**
          * Save the settings
          */
+        if(dirtyRadiusFields){
+            newSettings.setRadiusProxyEncryptedPassword(PasswordUtil.getEncryptPassword(newSettings.getRadiusProxyPassword()));
+            newSettings.setRadiusProxyPassword(null);
+        }
         SettingsManager settingsManager = UvmContextFactory.context().settingsManager();
         try {
             settingsManager.save(this.SettingsFileName, newSettings);

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -242,17 +242,6 @@ public class SystemManagerImpl implements SystemManager
     }
 
     /**
-    * Set settings without regards to the dirtyRadiusFields
-    *
-    * @param password
-    *        The new settings
-    * @return password
-    */
-    public String getDecryptedPassword(String password){
-        return PasswordUtil.getDecryptPassword(password);
-    }
-    
-    /**
      * Set the settings
      * 
      * @param newSettings

--- a/uvm/js/common/ungrid/GridController.js
+++ b/uvm/js/common/ungrid/GridController.js
@@ -757,12 +757,12 @@ Ext.define('Ung.cmp.GridController', {
                     }
                     
                     var types = ["textfield", "numberfield"];
-                    if((!fieldConfig.hasOwnProperty("allowBlank") || fieldConfig.allowBlank) && (fieldValue === null || fieldValue === undefined) && types.includes(fieldConfig.xtype)){
+                    if((fieldConfig.allowBlank) && (fieldValue === null || fieldValue === undefined) && types.includes(fieldConfig.xtype)){
                         continue;
                     }
 
                     var fieldTypes = ["textfield", "textarea"];
-                    if((!fieldConfig.hasOwnProperty("allowBlank") || fieldConfig.allowBlank) && ((typeof fieldConfig === 'object' && fieldConfig.hidden && fieldConfig.disabled && fieldTypes.includes(fieldConfig.xtype)) || fieldValue === "")){
+                    if((fieldConfig.allowBlank) && ((typeof fieldConfig === 'object' && fieldConfig.hidden && fieldConfig.disabled && fieldTypes.includes(fieldConfig.xtype)) || fieldValue === "")){
                         continue;
                     }
 

--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -63,6 +63,10 @@ Ext.define('Ung.util.Util', {
         return Ext.Date.subtract(clientDate, Ext.Date.MINUTE, new Date().getTimezoneOffset() + rpc.timeZoneOffset / 60000);
     },
 
+    getDecryptedPassword: function(encryptedPassword){ 
+        return rpc.systemManager.getDecryptedPassword(encryptedPassword);
+    },
+
     // returns milliseconds depending of the servlet ADMIN or REPORTS
     getMilliseconds: function () {
         // UvmContext

--- a/uvm/servlets/admin/config/local-directory/MainController.js
+++ b/uvm/servlets/admin/config/local-directory/MainController.js
@@ -38,6 +38,7 @@ Ext.define('Ung.config.local-directory.MainController', {
 
             vm.set('usersData', users);
             vm.set('systemSettings', result[1]);
+            me.getOrignalPasswd();
             v.setLoading(false);
             vm.set('panel.saveDisabled', false);
         }, function(ex) {
@@ -46,6 +47,16 @@ Ext.define('Ung.config.local-directory.MainController', {
                 v.setLoading(false);
             }
         });
+    },
+
+    getOrignalPasswd: function() { 
+        var vm = this.getViewModel();
+        encryptedPassword = vm.get('systemSettings.radiusProxyEncryptedPassword');
+        if(encryptedPassword != null && encryptedPassword != "")
+        {
+            password  = Util.getDecryptedPassword(encryptedPassword);
+            vm.set('systemSettings.radiusProxyPassword', password);
+        }
     },
 
     saveSettings: function () {

--- a/uvm/servlets/admin/config/local-directory/view/Users.js
+++ b/uvm/servlets/admin/config/local-directory/view/Users.js
@@ -26,8 +26,7 @@ Ext.define('Ung.config.local-directory.view.Users', {
             firstName: '',
             lastName: '',
             email: '',
-            password: '',
-            passwordBase64Hash: '',
+            encryptPassword: '',
             twofactorSecretKey: '',
             localExpires: Util.serverToClientDate(new Date()),
             localForever: true,
@@ -82,8 +81,8 @@ Ext.define('Ung.config.local-directory.view.Users', {
             width: Renderer.messageWidth,
             dataIndex: 'password',
             renderer: Ext.bind(function (value, metadata, record) {
-                if (record.get("passwordBase64Hash") == null) return ('');
-                if (Ext.isEmpty(value) && record.get("passwordBase64Hash").length > 0) return ('*** ' + 'Unchanged'.t() + ' ***');
+                if (record.get("encryptedPassword") == null) return ('');
+                if (Ext.isEmpty(value) && record.get("encryptedPassword").length > 0) return ('*** ' + 'Unchanged'.t() + ' ***');
                 var result = "";
                 for (var i = 0; value != null && i < value.length; i++) result = result + '*';
                 return result;

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -523,7 +523,7 @@ Ext.define('Ung.config.network.Interface', {
                                 var intf = window.getViewModel().get('intf');
                                 var isPppoeConfigEnabled = intf.get('getConfigType') !== 'DISABLED' && intf.get('v4ConfigType') === 'PPPOE';
                                 if(isPppoeConfigEnabled && intf.get('v4PPPoEPasswordEncrypted')){
-                                    me.setValue(Util.decrypt(intf.get('v4PPPoEPasswordEncrypted')));
+                                    me.setValue(Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                 }
                             }
                         }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -223,7 +223,7 @@ Ext.define('Ung.config.network.Interface', {
                                         intf.set('v4PPPoEPassword', Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                     }
                                     intf.set('transientv4PPPoEPassword', null);
-                                } else if (newValue !== "PPPOE") {
+                                } else {
                                     intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
                                     intf.set('v4PPPoEPassword', null);
                                 }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -218,19 +218,13 @@ Ext.define('Ung.config.network.Interface', {
                             if (window) {
                                 var intf = window.getViewModel().get('intf');
                                 if (newValue !== "PPPOE") {
-                                    // Persist plaintext password in a temporary field (which we don't want to be sent to backend)
-                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
                                     // clear the plaintext
                                     intf.set('v4PPPoEPassword', null);
                                 } else {
-                                    // repopulate plaintext value from the temporary field
-                                    intf.set('v4PPPoEPassword', intf.get('transientv4PPPoEPassword'));
-                                    // If plaintext is still unavailable and we have encrypted password then get the corresponding plaintext from backend
-                                    if (!intf.get('v4PPPoEPassword') && intf.get('v4PPPoEPasswordEncrypted')) {
+                                    // If we have encrypted password then get the corresponding plaintext from backend
+                                    if (intf.get('v4PPPoEPasswordEncrypted') && !intf.get('v4PPPoEPassword')) {
                                         intf.set('v4PPPoEPassword', Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                     }
-                                    // clear the temporary field
-                                    intf.set('transientv4PPPoEPassword', null);
                                 }
 
                             }
@@ -546,19 +540,6 @@ Ext.define('Ung.config.network.Interface', {
                     inputType: 'password',
                     bind: {
                         value: '{intf.v4PPPoEPassword}',
-                    },
-                    listeners: {
-                        afterrender: function() {
-                            var me = this,
-                            window = me.up('window[itemId=interface]');
-                            if (window){
-                                var intf = window.getViewModel().get('intf'),
-                                    isPppoeConfigEnabled = intf.get('getConfigType') !== 'DISABLED' && intf.get('v4ConfigType') === 'PPPOE';
-                                if (isPppoeConfigEnabled && intf.get('v4PPPoEPasswordEncrypted')){
-                                    me.setValue(Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
-                                }
-                            }
-                        }
                     },
                     fieldLabel: 'Password'.t()
                 }, {

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -217,15 +217,20 @@ Ext.define('Ung.config.network.Interface', {
                                 window = me.up('window[itemId=interface]');
                             if (window) {
                                 var intf = window.getViewModel().get('intf');
-                                if (newValue === "PPPOE") {
+                                if (newValue !== "PPPOE") {
+                                    // Persist plaintext password in a temporary field (which we don't want to be sent to backend)
+                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
+                                    // clear the plaintext
+                                    intf.set('v4PPPoEPassword', null);
+                                } else {
+                                    // repopulate plaintext value from the temporary field
                                     intf.set('v4PPPoEPassword', intf.get('transientv4PPPoEPassword'));
+                                    // If plaintext is still unavailable and we have encrypted password then get the corresponding plaintext from backend
                                     if (!intf.get('v4PPPoEPassword') && intf.get('v4PPPoEPasswordEncrypted')) {
                                         intf.set('v4PPPoEPassword', Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                     }
+                                    // clear the temporary field
                                     intf.set('transientv4PPPoEPassword', null);
-                                } else {
-                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
-                                    intf.set('v4PPPoEPassword', null);
                                 }
 
                             }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -217,15 +217,15 @@ Ext.define('Ung.config.network.Interface', {
                                 window = me.up('window[itemId=interface]');
                             if (window) {
                                 var intf = window.getViewModel().get('intf');
-                                if (newValue !== "PPPOE") {
-                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
-                                    intf.set('v4PPPoEPassword', null);
-                                } else if (newValue === "PPPOE") {
+                                if (newValue === "PPPOE") {
                                     intf.set('v4PPPoEPassword', intf.get('transientv4PPPoEPassword'));
                                     if (!intf.get('v4PPPoEPassword') && intf.get('v4PPPoEPasswordEncrypted')) {
                                         intf.set('v4PPPoEPassword', Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                     }
                                     intf.set('transientv4PPPoEPassword', null);
+                                } else if (newValue !== "PPPOE") {
+                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
+                                    intf.set('v4PPPoEPassword', null);
                                 }
 
                             }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -526,8 +526,7 @@ Ext.define('Ung.config.network.Interface', {
                             var window = me.up('window[itemId=interface]');
                             if(window){
                                 var intf = window.getViewModel().get('intf');
-                                var isPppoeConfigEnabled = intf.get('getConfigType') !== 'DISABLED' && intf.get('v4ConfigType') === 'PPPOE';
-                                if(isPppoeConfigEnabled && intf.get('v4PPPoEPasswordEncrypted')){
+                                if((intf.get('getConfigType') !== 'DISABLED') && intf.get('v4PPPoEPasswordEncrypted')){
                                     me.setValue(Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                 }
                             }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -8,6 +8,7 @@ Ext.define('Ung.config.network.Interface', {
     layout: 'border',
     modal: true,
     withValidation: true,
+    itemId: 'interface',
 
     items: [{
         region: 'north',
@@ -513,6 +514,19 @@ Ext.define('Ung.config.network.Interface', {
                     inputType: 'password',
                     bind: {
                         value: '{intf.v4PPPoEPassword}',
+                    },
+                    listeners: {
+                        afterrender: function() {
+                            var me = this;
+                            var window = me.up('window[itemId=interface]');
+                            if(window){
+                                var intf = window.getViewModel().get('intf');
+                                var isPppoeConfigEnabled = intf.get('getConfigType') !== 'DISABLED' && intf.get('v4ConfigType') === 'PPPOE';
+                                if(isPppoeConfigEnabled && intf.get('v4PPPoEPasswordEncrypted')){
+                                    me.setValue(Util.decrypt(intf.get('v4PPPoEPasswordEncrypted')));
+                                }
+                            }
+                        }
                     },
                     fieldLabel: 'Password'.t()
                 }, {


### PR DESCRIPTION
Added Utility method to encrypt and decrypt password using binary.

 *************************** NOTE ***************************
         *  Currently binary is generating warn related to TPM including the password in second line
         *  so handled the code accordingly in getEncryptPassword() and getDecryptPassword()
         *  Also while executing the command password is shown in log, I  handled this by overriding rhe execOutput() 
         *  and sending the value as false so you will not see any cmd log for password encryption and decryption
         * To get it in log for debug purpose you can set the value as true

**ISSUE:** Currently, the NGFW is storing passwords in plain text or base64 format for various features like LocalDirectory, Directory Connector, IPSec, TunnelVPN, OpenVPN, Captive Portal, and PPPoE.

**REQUIREMENT:** Passwords should not be stored in plain text in the settings.js file for any service.

**IMPLEMENTATION:** A utility method has been added in the PasswordUtil class to encrypt and decrypt passwords.

**Encryption**: We are using a binary file to encrypt the password and created a new variable to store the encrypted password. After encrypting the password, the original password is set to null to ensure it is not stored in plain text.
**Decryption**: The encrypted password is decrypted using the same binary file whenever the original password is required for authentication.
Additionally, the change includes log-level adjustments to hide the original password from logs.

> **Note**: This implementation only handles password fields. Shared secret keys are stored exactly as provided by the user. 

**Previous structure of json file for local directory:**
![Screenshot from 2024-11-27 13-10-57](https://github.com/user-attachments/assets/4105698b-c778-43bf-a515-baabc61ec064)
**Current structure of json file for local directory:**
![Screenshot from 2024-11-27 18-44-19](https://github.com/user-attachments/assets/406ee9e2-109d-4b90-b66b-da11e8dcc4e4)


ADDED unit test to verify the encryption/decryption functionality:
![Screenshot from 2024-12-02 20-43-29](https://github.com/user-attachments/assets/8d364f96-6e89-4b4e-9e7b-f2b5a0b6e405)




