### PR TITLE
NGFW-14889 : updated log level from info to debug

### DIFF
--- a/policy-manager/src/com/untangle/app/policy_manager/PolicyManagerApp.java
+++ b/policy-manager/src/com/untangle/app/policy_manager/PolicyManagerApp.java
@@ -510,7 +510,7 @@ public class PolicyManagerApp extends AppBase implements com.untangle.uvm.app.Po
             } else if (newPolicyId.equals(oldPolicyId)) {
                 return false;
             } else {
-                logger.info("Resetting session for policy switch: " +
+                logger.debug("Resetting session for policy switch: " +
                             clientAddr.toString() + ":" + clientPort + " -> " +
                             serverAddr.toString() + ":" + serverPort +
                             " Old policy: " + oldPolicyId + " New policy: " + newPolicyId + " New rule ID: " + newPolicyRuleId);

--- a/policy-manager/src/com/untangle/app/policy_manager/PolicyManagerApp.java
+++ b/policy-manager/src/com/untangle/app/policy_manager/PolicyManagerApp.java
@@ -510,7 +510,7 @@ public class PolicyManagerApp extends AppBase implements com.untangle.uvm.app.Po
             } else if (newPolicyId.equals(oldPolicyId)) {
                 return false;
             } else {
-                logger.debug("Resetting session for policy switch: " +
+                logger.debug(" Resetting session for policy switch: " +
                             clientAddr.toString() + ":" + clientPort + " -> " +
                             serverAddr.toString() + ":" + serverPort +
                             " Old policy: " + oldPolicyId + " New policy: " + newPolicyId + " New rule ID: " + newPolicyRuleId);


### PR DESCRIPTION
**ISSUE :** 
When a policy switches based on time of day, each session generates an info event, in large environments such as schools, these fill the logs which cause high disk utilization and permofrmance issue.
**FIX:**
Change the log level from info to debug.
