### PR TITLE
Ngfw 14841 password encryption pppoe

### DIFF
--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -78,6 +78,7 @@ public class InterfaceSettings implements Serializable, JSONString
     private Boolean     v4PPPoEUsePeerDns; /* If the DNS should be determined via PPP */
     private InetAddress v4PPPoEDns1; /* the dns1  of this interface if configured static */
     private InetAddress v4PPPoEDns2; /* the dns2  of this interface if configured static */
+    private String      v4PPPoEPasswordEncrypted; /* Encrypted PPPoE Password */
 
     private Boolean     v4NatEgressTraffic;
     private Boolean     v4NatIngressTraffic;
@@ -230,6 +231,9 @@ public class InterfaceSettings implements Serializable, JSONString
 
     public String getV4PPPoEPassword( ) { return this.v4PPPoEPassword; }
     public void setV4PPPoEPassword( String newValue ) { this.v4PPPoEPassword = newValue; }
+
+    public String getV4PPPoEPasswordEncrypted( ) { return this.v4PPPoEPasswordEncrypted; }
+    public void setV4PPPoEPasswordEncrypted( String newValue ) { this.v4PPPoEPasswordEncrypted = newValue; }
 
     public Boolean getV4PPPoEUsePeerDns( ) { return this.v4PPPoEUsePeerDns; }
     public void setV4PPPoEUsePeerDns( Boolean newValue ) { this.v4PPPoEUsePeerDns = newValue; }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1790,11 +1790,9 @@ public class NetworkManagerImpl implements NetworkManager
                 intf.setSystemDev("ppp" + pppCount);
                 intf.setSymbolicDev("ppp" + pppCount);
                 //Encrypt the password for v4PPPoEPassword and save it in v4PPPoEPasswordEncrypted
-                if(StringUtils.isNotBlank(intf.getV4PPPoEPassword())){
+                if(intf.getV4PPPoEPassword() != null){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
-                }
-                if(StringUtils.isNotBlank(intf.getV4PPPoEPasswordEncrypted())){
-                    intf.setV4PPPoEPassword(StringUtils.EMPTY);
+                    intf.setV4PPPoEPassword(null);
                 }
                 pppCount++;
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -143,7 +143,7 @@ public class NetworkManagerImpl implements NetworkManager
                 
                 if (readSettings != null)
                     settingsManager.save( this.settingsFilename, readSettings );
-                
+                    
             } catch ( SettingsManager.SettingsException e ) {
                 logger.warn( "Failed to load settings:", e );
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -141,24 +141,7 @@ public class NetworkManagerImpl implements NetworkManager
                 logger.info("Reading Network Settings from " + this.settingsFilenameBackup + " = " + readSettings);
                 
                 if (readSettings != null){
-                    this.networkSettings = readSettings;
-                    List<InterfaceSettings> interfacesSettings =  networkSettings.getInterfaces();
-                    for ( InterfaceSettings intf : interfacesSettings ) {
-                        if (!InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType() ) &&
-                            InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType() ) ) { 
-
-                            if(intf.getV4PPPoEPassword() != null && !intf.getV4PPPoEPassword().isEmpty()){
-                                intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
-                                intf.setV4PPPoEPassword("");
-                            }
-                            if(intf.getV4PPPoEPasswordEncrypted() != null && !intf.getV4PPPoEPasswordEncrypted().isEmpty()){
-                                intf.setV4PPPoEPassword("");
-                            }
-                            logger.info("********Inside pppoe block********** " + this.settingsFilenameBackup + " = " + intf.getV4PPPoEPasswordEncrypted());
-                        }
-                        networkSettings.setInterfaces(interfacesSettings);  
-                        settingsManager.save( this.settingsFilename, readSettings );
-                    }  
+                    settingsManager.save( this.settingsFilename, readSettings ); 
                 } 
             } catch ( SettingsManager.SettingsException e ) {
                 logger.warn( "Failed to load settings:", e );
@@ -1808,11 +1791,11 @@ public class NetworkManagerImpl implements NetworkManager
                 //Encrypt the password for v4PPPoEPassword and save it in v4PPPoEPasswordEncrypted
                 if(intf.getV4PPPoEPassword() != null && !intf.getV4PPPoEPassword().isEmpty()){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
-                    intf.setV4PPPoEPassword("");
                 }
                 if(intf.getV4PPPoEPasswordEncrypted() != null && !intf.getV4PPPoEPasswordEncrypted().isEmpty()){
                     intf.setV4PPPoEPassword("");
                 }
+                logger.info("********Inside Sanitize pppoe block********** " + intf.getV4PPPoEPasswordEncrypted() + " = " + intf.getV4PPPoEPassword());
                 pppCount++;
             }
         }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1794,7 +1794,7 @@ public class NetworkManagerImpl implements NetworkManager
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
                 }
                 if(StringUtils.isNotBlank(intf.getV4PPPoEPasswordEncrypted())){
-                    intf.setV4PPPoEPassword("");
+                    intf.setV4PPPoEPassword(StringUtils.EMPTY);
                 }
                 pppCount++;
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -140,9 +140,9 @@ public class NetworkManagerImpl implements NetworkManager
                 readSettings = settingsManager.load( NetworkSettings.class, this.settingsFilenameBackup );
                 logger.info("Reading Network Settings from " + this.settingsFilenameBackup + " = " + readSettings);
                 
-                if (readSettings != null){
+                if (readSettings != null)
                     settingsManager.save( this.settingsFilename, readSettings ); 
-                } 
+                 
             } catch ( SettingsManager.SettingsException e ) {
                 logger.warn( "Failed to load settings:", e );
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -43,6 +43,7 @@ import org.jabsorb.serializer.UnmarshallException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -141,8 +142,8 @@ public class NetworkManagerImpl implements NetworkManager
                 logger.info("Reading Network Settings from " + this.settingsFilenameBackup + " = " + readSettings);
                 
                 if (readSettings != null)
-                    settingsManager.save( this.settingsFilename, readSettings ); 
-                 
+                    settingsManager.save( this.settingsFilename, readSettings );
+                
             } catch ( SettingsManager.SettingsException e ) {
                 logger.warn( "Failed to load settings:", e );
             }
@@ -1789,13 +1790,12 @@ public class NetworkManagerImpl implements NetworkManager
                 intf.setSystemDev("ppp" + pppCount);
                 intf.setSymbolicDev("ppp" + pppCount);
                 //Encrypt the password for v4PPPoEPassword and save it in v4PPPoEPasswordEncrypted
-                if(intf.getV4PPPoEPassword() != null && !intf.getV4PPPoEPassword().isEmpty()){
+                if(StringUtils.isNotBlank(intf.getV4PPPoEPassword())){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
                 }
-                if(intf.getV4PPPoEPasswordEncrypted() != null && !intf.getV4PPPoEPasswordEncrypted().isEmpty()){
+                if(StringUtils.isNotBlank(intf.getV4PPPoEPasswordEncrypted())){
                     intf.setV4PPPoEPassword("");
                 }
-                logger.info("********Inside Sanitize pppoe block********** " + intf.getV4PPPoEPasswordEncrypted() + " = " + intf.getV4PPPoEPassword());
                 pppCount++;
             }
         }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1783,18 +1783,18 @@ public class NetworkManagerImpl implements NetworkManager
          */
         int pppCount = 0;
         for ( InterfaceSettings intf : interfacesSettings ) {
-            if ( !InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType() ) &&
-                 InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType() ) ) {
-                // save the old system dev (usuallyy physdev or sometimse vlan dev as root dev)
-                intf.setV4PPPoERootDev(intf.getSystemDev());
-                intf.setSystemDev("ppp" + pppCount);
-                intf.setSymbolicDev("ppp" + pppCount);
-                //Encrypt the password for v4PPPoEPassword and save it in v4PPPoEPasswordEncrypted
+            if (!InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType())){
+                if(InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType())){
+                    // save the old system dev (usuallyy physdev or sometimse vlan dev as root dev)
+                    intf.setV4PPPoERootDev(intf.getSystemDev());
+                    intf.setSystemDev("ppp" + pppCount);
+                    intf.setSymbolicDev("ppp" + pppCount);
+                    pppCount++;
+                }
                 if(intf.getV4PPPoEPassword() != null){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
                     intf.setV4PPPoEPassword(null);
                 }
-                pppCount++;
             }
         }
 

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1783,18 +1783,16 @@ public class NetworkManagerImpl implements NetworkManager
          */
         int pppCount = 0;
         for ( InterfaceSettings intf : interfacesSettings ) {
-            if (!InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType())){
-                if(InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType())){
-                    // save the old system dev (usuallyy physdev or sometimse vlan dev as root dev)
-                    intf.setV4PPPoERootDev(intf.getSystemDev());
-                    intf.setSystemDev("ppp" + pppCount);
-                    intf.setSymbolicDev("ppp" + pppCount);
-                    pppCount++;
-                }
+            if (!InterfaceSettings.ConfigType.DISABLED.equals( intf.getConfigType()) && InterfaceSettings.V4ConfigType.PPPOE.equals( intf.getV4ConfigType())){
+                // save the old system dev (usuallyy physdev or sometimse vlan dev as root dev)
+                intf.setV4PPPoERootDev(intf.getSystemDev());
+                intf.setSystemDev("ppp" + pppCount);
+                intf.setSymbolicDev("ppp" + pppCount);
                 if(intf.getV4PPPoEPassword() != null){
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
                     intf.setV4PPPoEPassword(null);
                 }
+                pppCount++;
             }
         }
 

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -242,6 +242,17 @@ public class SystemManagerImpl implements SystemManager
     }
 
     /**
+    * Set settings without regards to the dirtyRadiusFields
+    *
+    * @param password
+    *        The new settings
+    * @return password
+    */
+    public String getDecryptedPassword(String password){
+        return PasswordUtil.getDecryptPassword(password);
+    }
+    
+    /**
      * Set the settings
      * 
      * @param newSettings

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -242,17 +242,6 @@ public class SystemManagerImpl implements SystemManager
     }
 
     /**
-    * Set settings without regards to the dirtyRadiusFields
-    *
-    * @param password
-    *        The new settings
-    * @return password
-    */
-    public String getDecryptedPassword(String password){
-        return PasswordUtil.getDecryptPassword(password);
-    }
-    
-    /**
      * Set the settings
      * 
      * @param newSettings

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -523,7 +523,7 @@ Ext.define('Ung.config.network.Interface', {
                                 var intf = window.getViewModel().get('intf');
                                 var isPppoeConfigEnabled = intf.get('getConfigType') !== 'DISABLED' && intf.get('v4ConfigType') === 'PPPOE';
                                 if(isPppoeConfigEnabled && intf.get('v4PPPoEPasswordEncrypted')){
-                                    me.setValue(Util.decrypt(intf.get('v4PPPoEPasswordEncrypted')));
+                                    me.setValue(Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                 }
                             }
                         }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -223,7 +223,7 @@ Ext.define('Ung.config.network.Interface', {
                                         intf.set('v4PPPoEPassword', Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                     }
                                     intf.set('transientv4PPPoEPassword', null);
-                                } else if (newValue !== "PPPOE") {
+                                } else {
                                     intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
                                     intf.set('v4PPPoEPassword', null);
                                 }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -218,19 +218,13 @@ Ext.define('Ung.config.network.Interface', {
                             if (window) {
                                 var intf = window.getViewModel().get('intf');
                                 if (newValue !== "PPPOE") {
-                                    // Persist plaintext password in a temporary field (which we don't want to be sent to backend)
-                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
                                     // clear the plaintext
                                     intf.set('v4PPPoEPassword', null);
                                 } else {
-                                    // repopulate plaintext value from the temporary field
-                                    intf.set('v4PPPoEPassword', intf.get('transientv4PPPoEPassword'));
-                                    // If plaintext is still unavailable and we have encrypted password then get the corresponding plaintext from backend
-                                    if (!intf.get('v4PPPoEPassword') && intf.get('v4PPPoEPasswordEncrypted')) {
+                                    // If we have encrypted password then get the corresponding plaintext from backend
+                                    if (intf.get('v4PPPoEPasswordEncrypted') && !intf.get('v4PPPoEPassword')) {
                                         intf.set('v4PPPoEPassword', Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                     }
-                                    // clear the temporary field
-                                    intf.set('transientv4PPPoEPassword', null);
                                 }
 
                             }
@@ -546,19 +540,6 @@ Ext.define('Ung.config.network.Interface', {
                     inputType: 'password',
                     bind: {
                         value: '{intf.v4PPPoEPassword}',
-                    },
-                    listeners: {
-                        afterrender: function() {
-                            var me = this,
-                            window = me.up('window[itemId=interface]');
-                            if (window){
-                                var intf = window.getViewModel().get('intf'),
-                                    isPppoeConfigEnabled = intf.get('getConfigType') !== 'DISABLED' && intf.get('v4ConfigType') === 'PPPOE';
-                                if (isPppoeConfigEnabled && intf.get('v4PPPoEPasswordEncrypted')){
-                                    me.setValue(Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
-                                }
-                            }
-                        }
                     },
                     fieldLabel: 'Password'.t()
                 }, {

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -217,15 +217,20 @@ Ext.define('Ung.config.network.Interface', {
                                 window = me.up('window[itemId=interface]');
                             if (window) {
                                 var intf = window.getViewModel().get('intf');
-                                if (newValue === "PPPOE") {
+                                if (newValue !== "PPPOE") {
+                                    // Persist plaintext password in a temporary field (which we don't want to be sent to backend)
+                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
+                                    // clear the plaintext
+                                    intf.set('v4PPPoEPassword', null);
+                                } else {
+                                    // repopulate plaintext value from the temporary field
                                     intf.set('v4PPPoEPassword', intf.get('transientv4PPPoEPassword'));
+                                    // If plaintext is still unavailable and we have encrypted password then get the corresponding plaintext from backend
                                     if (!intf.get('v4PPPoEPassword') && intf.get('v4PPPoEPasswordEncrypted')) {
                                         intf.set('v4PPPoEPassword', Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                     }
+                                    // clear the temporary field
                                     intf.set('transientv4PPPoEPassword', null);
-                                } else {
-                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
-                                    intf.set('v4PPPoEPassword', null);
                                 }
 
                             }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -217,15 +217,15 @@ Ext.define('Ung.config.network.Interface', {
                                 window = me.up('window[itemId=interface]');
                             if (window) {
                                 var intf = window.getViewModel().get('intf');
-                                if (newValue !== "PPPOE") {
-                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
-                                    intf.set('v4PPPoEPassword', null);
-                                } else if (newValue === "PPPOE") {
+                                if (newValue === "PPPOE") {
                                     intf.set('v4PPPoEPassword', intf.get('transientv4PPPoEPassword'));
                                     if (!intf.get('v4PPPoEPassword') && intf.get('v4PPPoEPasswordEncrypted')) {
                                         intf.set('v4PPPoEPassword', Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                     }
                                     intf.set('transientv4PPPoEPassword', null);
+                                } else if (newValue !== "PPPOE") {
+                                    intf.set('transientv4PPPoEPassword', intf.get('v4PPPoEPassword'));
+                                    intf.set('v4PPPoEPassword', null);
                                 }
 
                             }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -526,8 +526,7 @@ Ext.define('Ung.config.network.Interface', {
                             var window = me.up('window[itemId=interface]');
                             if(window){
                                 var intf = window.getViewModel().get('intf');
-                                var isPppoeConfigEnabled = intf.get('getConfigType') !== 'DISABLED' && intf.get('v4ConfigType') === 'PPPOE';
-                                if(isPppoeConfigEnabled && intf.get('v4PPPoEPasswordEncrypted')){
+                                if((intf.get('getConfigType') !== 'DISABLED') && intf.get('v4PPPoEPasswordEncrypted')){
                                     me.setValue(Util.getDecryptedPassword(intf.get('v4PPPoEPasswordEncrypted')));
                                 }
                             }

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -8,6 +8,7 @@ Ext.define('Ung.config.network.Interface', {
     layout: 'border',
     modal: true,
     withValidation: true,
+    itemId: 'interface',
 
     items: [{
         region: 'north',
@@ -513,6 +514,19 @@ Ext.define('Ung.config.network.Interface', {
                     inputType: 'password',
                     bind: {
                         value: '{intf.v4PPPoEPassword}',
+                    },
+                    listeners: {
+                        afterrender: function() {
+                            var me = this;
+                            var window = me.up('window[itemId=interface]');
+                            if(window){
+                                var intf = window.getViewModel().get('intf');
+                                var isPppoeConfigEnabled = intf.get('getConfigType') !== 'DISABLED' && intf.get('v4ConfigType') === 'PPPOE';
+                                if(isPppoeConfigEnabled && intf.get('v4PPPoEPasswordEncrypted')){
+                                    me.setValue(Util.decrypt(intf.get('v4PPPoEPasswordEncrypted')));
+                                }
+                            }
+                        }
                     },
                     fieldLabel: 'Password'.t()
                 }, {


### PR DESCRIPTION
**Issue**
For PPPoE interfaces, the password is stored in plain text format in the network.js file.
(Config -- Network -- Interface)

**Requirement:** 
Passwords should not be stored in plain text in the network.js file for PPPoE interfaces.

**Implementation:**
Using the password encryption and decryption utility added in the https://github.com/untangle/ngfw_src/pull/872 , the password is encrypted before being saved in the network file and decrypted to be displayed on the UI.

![image](https://github.com/user-attachments/assets/edc4458a-4799-44d5-892d-338ed3e1d730)

**Previous structure of json file for PPPoE:**

![image](https://github.com/user-attachments/assets/a1ed26f2-8a1e-4926-954f-bc48bff060c1)


**Current structure of json file for for PPPoE:**

![image](https://github.com/user-attachments/assets/99faa1e8-c468-47cc-8525-a8719e8c8a72)


On the UI, the original password will be made visible by encrypting and decrypting it while it is masked.
![image](https://github.com/user-attachments/assets/220384ef-f6ab-4747-a1bf-5572d8d336f9)


