### PR TITLE
NGFW-14839 : Password Encryption/Decryption implementation for OpenVpn Client

### DIFF
--- a/openvpn/js/MainController.js
+++ b/openvpn/js/MainController.js
@@ -73,6 +73,7 @@ Ext.define('Ung.apps.openvpn.MainController', {
             }
 
             vm.set('settings', result);
+            me.getOrignalPasswd();
 
             vm.set('panel.saveDisabled', false);
             v.setLoading(false);
@@ -96,6 +97,19 @@ Ext.define('Ung.apps.openvpn.MainController', {
                 });
             }
         });
+    },
+
+    getOrignalPasswd: function() {
+        var vm = this.getViewModel();
+        servers = vm.get('settings.remoteServers.list');
+        if(servers){
+            servers.forEach(function(server){
+                encryptedPassword = server.remoteServerEncryptedPassword;
+                if(encryptedPassword != null && encryptedPassword != ""){
+                    server.authPassword = Util.getDecryptedPassword(server.remoteServerEncryptedPassword);
+                }
+            });
+        }
     },
 
     setSettings: function () {

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
@@ -25,6 +25,7 @@ import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.SettingsManager;
 import com.untangle.uvm.NetspaceManager;
 import com.untangle.uvm.NetspaceManager.NetworkSpace;
+import com.untangle.uvm.PasswordUtil;
 import com.untangle.uvm.NetspaceManager.IPVersion;
 import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.HookCallback;
@@ -50,7 +51,7 @@ import com.untangle.uvm.vnet.PipelineConnector;
 public class OpenVpnAppImpl extends AppBase
 {
 
-    private static final Integer SETTINGS_CURRENT_VERSION = 1;
+    private static final Integer SETTINGS_CURRENT_VERSION = 2;
 
     private final Logger logger = LogManager.getLogger(getClass());
 
@@ -291,6 +292,11 @@ public class OpenVpnAppImpl extends AppBase
         sanitizeSettings(newSettings);
 
         /**
+         * encrypt the password of remote server stroed in new Settings
+         */
+        setEncryptedPassword(newSettings);
+
+        /**
          * Save the settings
          */
         SettingsManager settingsManager = UvmContextFactory.context().settingsManager();
@@ -348,6 +354,22 @@ public class OpenVpnAppImpl extends AppBase
             cleanServerSettings();
         } catch (Exception exn) {
             logger.warn("Exception during client/server cleanup", exn);
+        }
+    }
+
+    /**
+     * Encrypt the password for Remote Servers
+     *
+     * @param settings
+     *      Settings to convert.
+     */
+    private void setEncryptedPassword( OpenVpnSettings settings ) {
+        List<OpenVpnRemoteServer> remoteServers = settings.getRemoteServers();
+        for(OpenVpnRemoteServer server : remoteServers) {
+            if(server.getAuthPassword() != null){
+                server.setRemoteServerEncryptedPassword(PasswordUtil.getEncryptPassword(server.getAuthPassword()));
+                server.setAuthPassword(null);
+            }
         }
     }
 

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.LogManager;
 
 import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.ExecManagerResult;
+import com.untangle.uvm.PasswordUtil;
 import com.untangle.uvm.app.IPMaskedAddress;
 import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.network.InterfaceSettings;
@@ -747,7 +748,7 @@ public class OpenVpnManager
         BufferedWriter authWriter;
         for (OpenVpnRemoteServer server : remoteServers) {
             if (!server.getEnabled()) continue;
-
+            String serverPassword;
             String name = server.getName();
             logger.info("Writing server configuration file for [" + name + "]");
 
@@ -795,10 +796,19 @@ public class OpenVpnManager
 
                 // if user+pass auth is enabled create the auth file
                 if (server.getAuthUserPass()) {
+                    if(server.getAuthPassword()!= null){
+                        serverPassword = server.getAuthPassword();
+                    }else{
+                        serverPassword = PasswordUtil.getDecryptPassword(server.getRemoteServerEncryptedPassword());
+                        if(serverPassword == null){
+                            logger.warn("Error occured while decrypting the encrypted passowrd for server : { }", name);
+                            continue;
+                        }
+                    }
                     File authFile = new File("/etc/openvpn/" + name + ".auth");
                     authWriter = new BufferedWriter(new FileWriter(authFile));
                     authWriter.write(server.getAuthUsername() + LINE_BREAK);
-                    authWriter.write(server.getAuthPassword() + LINE_BREAK);
+                    authWriter.write(serverPassword + LINE_BREAK);
                 }
 
                 count += 1;

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
@@ -796,15 +796,13 @@ public class OpenVpnManager
 
                 // if user+pass auth is enabled create the auth file
                 if (server.getAuthUserPass()) {
-                    if(server.getAuthPassword()!= null){
-                        serverPassword = server.getAuthPassword();
-                    }else{
-                        serverPassword = PasswordUtil.getDecryptPassword(server.getRemoteServerEncryptedPassword());
-                        if(serverPassword == null){
-                            logger.warn("Error occured while decrypting the encrypted passowrd for server : { }", name);
-                            continue;
-                        }
+
+                    serverPassword = PasswordUtil.getDecryptPassword(server.getRemoteServerEncryptedPassword());
+                    if(serverPassword == null){
+                        logger.warn("Error occured while decrypting the encrypted passowrd for server : { }", name);
+                        continue;
                     }
+                    
                     File authFile = new File("/etc/openvpn/" + name + ".auth");
                     authWriter = new BufferedWriter(new FileWriter(authFile));
                     authWriter.write(server.getAuthUsername() + LINE_BREAK);

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnRemoteServer.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnRemoteServer.java
@@ -18,6 +18,7 @@ public class OpenVpnRemoteServer implements java.io.Serializable, org.json.JSONS
     private boolean authUserPass = false;
     private String authUsername;
     private String authPassword;
+    private String remoteServerEncryptedPassword;
 
     public OpenVpnRemoteServer()
     {
@@ -39,6 +40,9 @@ public class OpenVpnRemoteServer implements java.io.Serializable, org.json.JSONS
 
     public String getAuthPassword() { return this.authPassword; }
     public void setAuthPassword( String newValue ) { this.authPassword = newValue; }
+
+    public String getRemoteServerEncryptedPassword() { return this.remoteServerEncryptedPassword; }
+    public void setRemoteServerEncryptedPassword( String newValue ) { this.remoteServerEncryptedPassword = newValue; }
 
 // THIS IS FOR ECLIPSE - @formatter:on
 

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -17,6 +17,7 @@ import urllib.request, urllib.error, urllib.parse
 import urllib
 import urllib3
 import fnmatch
+import base64
 
 from tests.common import NGFWTestCase
 import tests.global_functions as global_functions
@@ -72,6 +73,27 @@ def create_trigger_rule(action, tag_target, tag_name, tag_lifetime_sec, descript
             }]
         },
         "ruleId": 1
+    }
+
+def create_local_directory_user(directory_user='test',expire_time=0):
+    user_email = directory_user + "@test.untangle.com"
+    passwd_encoded = base64.b64encode("passwd".encode("utf-8"))
+    return {'javaClass': 'java.util.LinkedList',
+        'list': [{
+            'username': directory_user,
+            'firstName': '[firstName]',
+            'lastName': '[lastName]',
+            'javaClass': 'com.untangle.uvm.LocalDirectoryUser',
+            'expirationTime': expire_time,
+            'passwordBase64Hash': passwd_encoded.decode("utf-8"),
+            'email': user_email
+            },]
+    }
+
+
+def remove_local_directory_user():
+    return {'javaClass': 'java.util.LinkedList',
+        'list': []
     }
 
 def check_javascript_exceptions(errors):
@@ -1063,6 +1085,26 @@ class UvmTests(NGFWTestCase):
         # Check if encryption of None returns None or raises an exception
         self.assertIsNone(encrypted_password, "Encrypted password should be None when input is None.")
 
+
+    def test_168_password_encryption_setting_process(self):
+        """
+        Verify password encryption setting process
+        """
+        # Create local directory user 'test'
+        global_functions.uvmContext.localDirectory().setUsers(create_local_directory_user())
+
+        # Get local directory users 
+        users = global_functions.uvmContext.localDirectory().getUsers()
+
+        # Extract the user object
+        user = users['list'][0]
+
+        # Assert that encryptedPassword is present and password is None
+        assert user.get('encryptedPassword') is not None, "encryptedPassword is missing"
+        assert user.get('password') is None, "password is not None"
+        #Clear the created user
+        global_functions.uvmContext.localDirectory().setUsers(remove_local_directory_user())
+        
 
     def test_170_log_retention(self):
         """


### PR DESCRIPTION
**ISSUE:** Currently, the NGFW is storing passwords in plain text or base64 format for various features like LocalDirectory, Directory Connector, IPSec, TunnelVPN, OpenVPN, Captive Portal, and PPPoE.

**REQUIREMENT:** Passwords should not be stored in plain text in the settings.js file for any service.

**IMPLEMENTATION:** A utility method has been added in the PasswordUtil class to encrypt and decrypt passwords.

**Encryption**: We are using a binary file to encrypt the password and created a new variable to store the encrypted password. After encrypting the password, the original password is set to null to ensure it is not stored in plain text.
**Decryption**: The encrypted password is decrypted using the same binary file whenever the original password is required for authentication.
Additionally, the change includes log-level adjustments to hide the original password from logs.

> **Note**: This implementation only handles password fields. Shared secret keys are stored exactly as provided by the user. 

**Previous Structure of OpenVpn setting file:**
![Screenshot from 2024-12-03 17-44-30](https://github.com/user-attachments/assets/116839ec-664d-4cff-b6b7-bd6556377d52)

**Current Structure  of OpenVpn setting file:**
![Screenshot from 2024-12-03 17-15-59](https://github.com/user-attachments/assets/32a8e2c6-62f5-4ffa-bbe6-88bbdca9f0ef)

Added test case to verify the encryptedpassword field is getting generated in setting file and actual password is setting as null(LOCAL DIRECTORY)
![Screenshot from 2024-12-05 14-28-12](https://github.com/user-attachments/assets/471e9475-fbb0-4116-9bc2-a6ea4b35a169)
