### PR TITLE
ngfw-14909: Fixed to code to enable QoS only for the valid QoS value

### DIFF
--- a/bandwidth-control/hier/usr/lib/python3/dist-packages/tests/test_bandwidth_control.py
+++ b/bandwidth-control/hier/usr/lib/python3/dist-packages/tests/test_bandwidth_control.py
@@ -665,12 +665,10 @@ class BandwidthControlTests(NGFWTestCase):
         # Test with invalid QoS value
         self._app.stop()
         networkSettings['qosSettings']['qosEnabled']=False
-        i = 0
         for interface in networkSettings['interfaces']['list']:
             if interface['isWan']:
-                networkSettings['interfaces']['list'][i]['downloadBandwidthKbps']=0
-                networkSettings['interfaces']['list'][i]['uploadBandwidthKbps']=0
-            i += 1
+                interface['downloadBandwidthKbps']=0
+                interface['uploadBandwidthKbps']=0
         uvmContext.networkManager().setNetworkSettings(networkSettings)
         self._app.start()
         networkSettings = uvmContext.networkManager().getNetworkSettings()

--- a/bandwidth-control/js/MainController.js
+++ b/bandwidth-control/js/MainController.js
@@ -10,6 +10,7 @@ Ext.define('Ung.apps.bandwidthcontrol.MainController', {
 
     afterRender: function () {
         this.getSettings();
+        this.fetchQosData();
     },
 
     // use a callback function needed for config wizard

--- a/bandwidth-control/js/view/Status.js
+++ b/bandwidth-control/js/view/Status.js
@@ -50,17 +50,17 @@ Ext.define('Ung.apps.bandwidthcontrol.view.Status', {
                 }
             }, {
                 xtype: 'component',
+                html: '<i class="fa fa-exclamation-triangle fa-red"></i><span style="color: red;">' + ' WARNING: Bandwidth Control is enabled, but QoS is not enabled. Bandwidth Control requires QoS to be enabled.'.t() + '</span>',
+                hidden: true,
+                bind: {
+                    hidden: '{qosEnabled}'
+                }
+            }, {
+                xtype: 'component',
                 html: 'Bandwidth Control is configured'.t(),
                 hidden: true,
                 bind: {
                     hidden: '{!isConfigured}'
-                }
-            }, {
-                xtype: 'component',
-                html: 'Bandwidth Control is enabled, but QoS is not enabled. Bandwidth Control requires QoS to be enabled.'.t(),
-                hidden: true,
-                bind: {
-                    hidden: '{qosEnabled}'
                 }
             }, {
                 xtype: 'button',

--- a/bandwidth-control/src/com/untangle/app/bandwidth_control/BandwidthControlApp.java
+++ b/bandwidth-control/src/com/untangle/app/bandwidth_control/BandwidthControlApp.java
@@ -134,9 +134,14 @@ public class BandwidthControlApp extends AppBase
         if(networkSettings.getQosSettings().getQosEnabled()){
             return;
         }
-        networkSettings.getQosSettings().setQosEnabled(true);
-        UvmContextFactory.context().networkManager().setNetworkSettings(networkSettings);
-        logger.info("QosEnabled set to true");
+        boolean isValidQosValue = networkSettings.getInterfaces().stream().anyMatch(network -> network.getIsWan() && network.getDownloadBandwidthKbps() > 0 && network.getUploadBandwidthKbps() > 0);
+        if(isValidQosValue){
+            networkSettings.getQosSettings().setQosEnabled(true);
+            UvmContextFactory.context().networkManager().setNetworkSettings(networkSettings);
+            logger.info("QosEnabled set to true");
+        }else{
+            logger.error("bandwidth control would not be able to enable QoS. Please configure valid Qos values.");
+        }
     }
 
     /**


### PR DESCRIPTION
 **ISSUE:**
We are enabled QoS if Bandwidth Control is enabled even if QoS values are not set.

**FIX:** Added additional condition to verify the bandwidth values before enabling QoS, at app start.

**TEST:** Implemented unit test case to verify the same.
![Screenshot from 2024-12-10 19-11-17](https://github.com/user-attachments/assets/004b4af5-06ec-4919-96bf-a3bb0b29ba4b)
