### PR TITLE
ngfw-14919 Modified the warning message on QOS status if qos is disabled

### DIFF
--- a/bandwidth-control/js/MainController.js
+++ b/bandwidth-control/js/MainController.js
@@ -10,6 +10,7 @@ Ext.define('Ung.apps.bandwidthcontrol.MainController', {
 
     afterRender: function () {
         this.getSettings();
+        this.fetchQosData();
     },
 
     // use a callback function needed for config wizard

--- a/bandwidth-control/js/view/Status.js
+++ b/bandwidth-control/js/view/Status.js
@@ -48,7 +48,7 @@ Ext.define('Ung.apps.bandwidthcontrol.view.Status', {
                 bind: {
                     hidden: '{isConfigured}'
                 }
-            },  {
+            }, {
                 xtype: 'component',
                 html: '<i class="fa fa-exclamation-triangle fa-red"></i><span style="color: red;">' + ' WARNING: Bandwidth Control is enabled, but QoS is not enabled. Bandwidth Control requires QoS to be enabled.'.t() + '</span>',
                 hidden: true,

--- a/bandwidth-control/js/view/Status.js
+++ b/bandwidth-control/js/view/Status.js
@@ -48,19 +48,19 @@ Ext.define('Ung.apps.bandwidthcontrol.view.Status', {
                 bind: {
                     hidden: '{isConfigured}'
                 }
+            },  {
+                xtype: 'component',
+                html: '<i class="fa fa-exclamation-triangle fa-red"></i><span style="color: red;">' + ' WARNING: Bandwidth Control is enabled, but QoS is not enabled. Bandwidth Control requires QoS to be enabled.'.t() + '</span>',
+                hidden: true,
+                bind: {
+                    hidden: '{qosEnabled}'
+                }
             }, {
                 xtype: 'component',
                 html: 'Bandwidth Control is configured'.t(),
                 hidden: true,
                 bind: {
                     hidden: '{!isConfigured}'
-                }
-            }, {
-                xtype: 'component',
-                html: 'Bandwidth Control is enabled, but QoS is not enabled. Bandwidth Control requires QoS to be enabled.'.t(),
-                hidden: true,
-                bind: {
-                    hidden: '{qosEnabled}'
                 }
             }, {
                 xtype: 'button',


### PR DESCRIPTION
**Issue:** We are auto enabling QoS on bandwidth control app power on. But there is a scenario where we can save invalid bandwidth control value i.e. 0 by disabling QoS. In that case we can't auto enable QoS.

**Changes:** 
To handle above scenario we are adding a message on Bandwidth Control --> Status Page.
If Bandwidth control wizard setup is done but QOS is not enabled then below warning message will be shown

![Screenshot from 2024-12-11 14-19-36](https://github.com/user-attachments/assets/5c9f8d8b-22e8-4ec2-8f33-b37b63b80172)
