### PR TITLE
ngfw-14919 hide qos warning when bandwidth control is not configurred…

### DIFF
--- a/bandwidth-control/js/view/Status.js
+++ b/bandwidth-control/js/view/Status.js
@@ -53,7 +53,7 @@ Ext.define('Ung.apps.bandwidthcontrol.view.Status', {
                 html: '<i class="fa fa-exclamation-triangle fa-red"></i><span style="color: red;">' + ' WARNING: Bandwidth Control is enabled, but QoS is not enabled. Bandwidth Control requires QoS to be enabled.'.t() + '</span>',
                 hidden: true,
                 bind: {
-                    hidden: '{qosEnabled}'
+                    hidden: '{!isConfigured || qosEnabled}'
                 }
             }, {
                 xtype: 'component',


### PR DESCRIPTION
**Changes:** Modified QoS warning hidden condition.
`WARNING: Bandwidth Control is enabled, but QoS is not enabled. Bandwidth Control requires QoS to be enabled.` warning will only be shown when Bandwidth Control App is configured and QoS is disabled.


![Screenshot from 2024-12-11 17-23-16](https://github.com/user-attachments/assets/74c0022c-9d4e-49e1-9b69-996a1039081e)
 
 
![Screenshot from 2024-12-11 17-24-44](https://github.com/user-attachments/assets/253622b8-fde1-4125-949b-99dcd1a1bcdc)
