### PR TITLE
Ngfw-14795/NGFW-14841 pppoe password encryption

### DIFF
--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -24,7 +24,7 @@ public class NetworkSettings implements Serializable, JSONString
     public static final String PUBLIC_URL_HOSTNAME = "hostname";
     public static final String PUBLIC_URL_ADDRESS_AND_PORT = "address_and_port";
 
-    private Integer version;
+    private Integer version = Integer.valueOf(11);
 
     private List<InterfaceSettings> interfaces = null;
     private List<InterfaceSettings> virtualInterfaces = null;

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -24,7 +24,7 @@ public class NetworkSettings implements Serializable, JSONString
     public static final String PUBLIC_URL_HOSTNAME = "hostname";
     public static final String PUBLIC_URL_ADDRESS_AND_PORT = "address_and_port";
 
-    private Integer version = Integer.valueOf(11);
+    private Integer version;
 
     private List<InterfaceSettings> interfaces = null;
     private List<InterfaceSettings> virtualInterfaces = null;

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -174,6 +174,11 @@ public class NetworkManagerImpl implements NetworkManager
             updateNetworkReservations(readSettings);
             configureInterfaceSettingsArray();
 
+            // setSettings will set encrypted password and remove original password
+            if ( this.networkSettings.getVersion() < currentVersion ) {
+                this.networkSettings.setVersion(11);
+            }
+
             if ( this.networkSettings.getVersion() < currentVersion ) {
                 convertSettings();
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -174,7 +174,6 @@ public class NetworkManagerImpl implements NetworkManager
             updateNetworkReservations(readSettings);
             configureInterfaceSettingsArray();
 
-
             if ( this.networkSettings.getVersion() < currentVersion ) {
                 convertSettings();
             }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -97,7 +97,7 @@ public class NetworkManagerImpl implements NetworkManager
      * The current network settings
      */
     private NetworkSettings networkSettings;
-    private Integer currentVersion = 10;
+    private Integer currentVersion = 11;
 
     /**
      * This array holds the current interface Settings indexed by the interface ID.
@@ -174,10 +174,6 @@ public class NetworkManagerImpl implements NetworkManager
             updateNetworkReservations(readSettings);
             configureInterfaceSettingsArray();
 
-            // setSettings will set encrypted password and remove original password
-            if ( this.networkSettings.getVersion() < 11 ) {
-                this.networkSettings.setVersion(11);
-            }
 
             if ( this.networkSettings.getVersion() < currentVersion ) {
                 convertSettings();

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -175,7 +175,7 @@ public class NetworkManagerImpl implements NetworkManager
             configureInterfaceSettingsArray();
 
             // setSettings will set encrypted password and remove original password
-            if ( this.networkSettings.getVersion() < currentVersion ) {
+            if ( this.networkSettings.getVersion() < 11 ) {
                 this.networkSettings.setVersion(11);
             }
 


### PR DESCRIPTION
**Description:**
In an upgrade scenario, the settings file containing a plaintext password is encrypted and stored in the V4PPPoEPasswordEncrypted field, and the V4PPPoEPassword field is set to null.
Settings version should be upgraded to 11.

**Before upgrade:**
![image](https://github.com/user-attachments/assets/700efc28-80ba-40e7-a8cb-b7bb5c836da6)
**After upgarde:**
![image](https://github.com/user-attachments/assets/4418abb0-378d-44c2-9a38-da451d347d28)
