### PR TITLE
NGFW-14917 : Enable QoS Only for non-zero bandwidth value

### DIFF
--- a/bandwidth-control/js/view/Status.js
+++ b/bandwidth-control/js/view/Status.js
@@ -50,7 +50,7 @@ Ext.define('Ung.apps.bandwidthcontrol.view.Status', {
                 }
             }, {
                 xtype: 'component',
-                html: '<i class="fa fa-exclamation-triangle fa-red"></i><span style="color: red;">' + ' WARNING: Bandwidth Control is enabled, but QoS is not enabled. Bandwidth Control requires QoS to be enabled.'.t() + '</span>',
+                html: '<i class="fa fa-exclamation-triangle fa-red"></i><span style="color: red;">' + ' WARNING: Bandwidth Control is configured, but QoS is not enabled. Bandwidth Control requires QoS to be enabled.'.t() + '</span>',
                 hidden: true,
                 bind: {
                     hidden: '{!isConfigured || qosEnabled}'

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -118,7 +118,7 @@ public class NetworkManagerImpl implements NetworkManager
     {
         SettingsManager settingsManager = UvmContextFactory.context().settingsManager();
         NetworkSettings readSettings = null;
-        boolean qosDisableSettingChnages = false;
+        boolean qosDisableSettingChanges = false;
 
         UvmContextFactory.context().servletFileManager().registerDownloadHandler( new NetworkTestDownloadHandler() );
 
@@ -176,8 +176,8 @@ public class NetworkManagerImpl implements NetworkManager
             this.networkSettings = readSettings;
             updateNetworkReservations(readSettings);
             configureInterfaceSettingsArray();
-            //NGFW-14917 : To diasble QoS in buggy enviroment need to set updated setting in same version too.
-            if ( this.networkSettings.getVersion() < currentVersion || qosDisableSettingChnages) {
+            //NGFW-14917 : To disable QoS, we need to apply the updated settings in the same version.
+            if ( this.networkSettings.getVersion() < currentVersion || qosDisableSettingChanges) {
                 convertSettings();
             }
             logger.debug( "Loading Settings: " + this.networkSettings.toJSONString() );

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -168,7 +168,7 @@ public class NetworkManagerImpl implements NetworkManager
             boolean isValidQosValue = readSettings.getInterfaces().stream().anyMatch(network -> network.getIsWan() && network.getDownloadBandwidthKbps() > 0 && network.getUploadBandwidthKbps() > 0);
             if(!isValidQosValue){
                 readSettings.getQosSettings().setQosEnabled(false);
-                logger.debug("QosEnabled set to false. Please configure valid value.");
+                logger.debug("QosEnabled set to false.");
             }
             checkForNewDevices( readSettings );
             checkForRemovedDevices( readSettings );

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -165,6 +165,11 @@ public class NetworkManagerImpl implements NetworkManager
             }
         }
         else {
+            boolean isValidQosValue = readSettings.getInterfaces().stream().anyMatch(network -> network.getIsWan() && network.getDownloadBandwidthKbps() > 0 && network.getUploadBandwidthKbps() > 0);
+            if(!isValidQosValue){
+                readSettings.getQosSettings().setQosEnabled(false);
+                logger.debug("QosEnabled set to false. Please configure valid value.");
+            }
             checkForNewDevices( readSettings );
             checkForRemovedDevices( readSettings );
             

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -168,7 +168,7 @@ public class NetworkManagerImpl implements NetworkManager
         else {
             if(readSettings.getQosSettings().getQosEnabled() && !(readSettings.getInterfaces().stream().anyMatch(network -> network.getIsWan() && network.getDownloadBandwidthKbps() > 0 && network.getUploadBandwidthKbps() > 0))){
                 readSettings.getQosSettings().setQosEnabled(false);
-                qosDisableSettingChnages = true;
+                qosDisableSettingChanges = true;
             }
             checkForNewDevices( readSettings );
             checkForRemovedDevices( readSettings );


### PR DESCRIPTION
In previous buggy environment if  QoS enabled with invalid value due to [BUG](https://awakesecurity.atlassian.net/browse/NGFW-14909), QoS should be disabled while creating new Uvmcontext.