### PR TITLE
NGFW-14918:Fixed the DC username UI load issue in rulecondition

### DIFF
--- a/uvm/servlets/admin/app/cmp/ConditionsEditor.js
+++ b/uvm/servlets/admin/app/cmp/ConditionsEditor.js
@@ -552,44 +552,40 @@ Ext.define('Ung.cmp.ConditionsEditor', {
                         }];
 
                         if (field) {
-                            Rpc.asyncData('rpc.appManager.app', 'directory-connector')
+                            return Rpc.asyncData('rpc.appManager.app', 'directory-connector')
                                 .then(function (app) {
                                     if (Util.isDestroyed(field)) {
-                                        return;
+                                        return data;
                                     }
                                     if (app) {
-                                        Rpc.asyncData(app, 'getRuleConditonalUserEntries')
+                                        return Rpc.asyncData(app, 'getRuleConditionalGroupEntries')
                                             .then(function (result) {
                                                 if (Util.isDestroyed(field)) {
-                                                    return;
+                                                    return data;
                                                 }
-                                                Ext.Array.each(data.reverse(), function (record) {
-                                                    result.list.unshift(record);
-                                                });
-                                                data = result.list;
+                                                return  me.ProcessDCUserNGroupDataMerge(data, result);
                                             }, function (ex) {
                                                 Util.handleException(ex);
+                                                return data;
                                             });
                                     }
                                 }, function (ex) {
                                     Util.handleException(ex);
+                                    return data;
                                 });
                         } else {
                             try {
                                 var appData = Rpc.directData('rpc.appManager.app', 'directory-connector');
                                 if (appData) {
                                     var result = Rpc.directData(appData, 'getRuleConditionalGroupEntries');
-                                    Ext.Array.each(data.reverse(), function (record) {
-                                        result.list.unshift(record);
-                                    });
-                                    data = result.list;
+                                    return { keyName: 'SAMAccountName', data: me.ProcessDCUserNGroupDataMerge(data, result) };
                                 }
                             } catch (ex) {
                                 Util.handleException(ex);
+                                return { keyName: 'SAMAccountName', data: data };
                             }
                         }
-
-                        return field ? data : { keyName: 'SAMAccountName', data: data };
+                        return data;
                     };
 
                     currItem["widgetCreator"] = function (widget, valueBind, condition) {
@@ -615,8 +611,11 @@ Ext.define('Ung.cmp.ConditionsEditor', {
                             },
                             listeners: {
                                 afterrender: function (field) {
-                                    var fetchedData = condition.getData(field);
-                                    field.getStore().loadData(fetchedData);
+                                    condition.getData(field).then(function(data) {
+                                        field.getStore().loadData(data);
+                                    },function(error) {
+                                        console.log("Error occurred while loading directory connector groups:", error);
+                                    }); 
                                 }
                             }
                         });
@@ -629,47 +628,50 @@ Ext.define('Ung.cmp.ConditionsEditor', {
                         var data = [{
                             value: '*', description: 'Any Domain'
                         }];
+                        var handleDCDomainDataMerge = function(data, result) {
+                            Ext.Array.each( result.list, function (record) {
+                                data.push({value: record, description: record});
+                            });
+                            return data;
+                        };
+                    
 
                         if (field) {
-                            Rpc.asyncData('rpc.appManager.app', 'directory-connector')
+                            return Rpc.asyncData('rpc.appManager.app', 'directory-connector')
                                 .then(function (app) {
                                     if (Util.isDestroyed(field)) {
-                                        return;
+                                        return data;
                                     }
                                     if (app) {
-                                        Rpc.asyncData(app, 'getRuleConditonalUserEntries')
+                                        return Rpc.asyncData(app, 'getRuleConditionalDomainEntries')
                                             .then(function (result) {
                                                 if (Util.isDestroyed(field)) {
-                                                    return;
+                                                    return data;
                                                 }
-                                                Ext.Array.each(data.reverse(), function (record) {
-                                                    result.list.unshift(record);
-                                                });
-                                                data = result.list;
+                                                return handleDCDomainDataMerge(data, result);
                                             }, function (ex) {
                                                 Util.handleException(ex);
+                                                return data;
                                             });
                                     }
                                 }, function (ex) {
                                     Util.handleException(ex);
+                                    return data;
                                 });
                         } else {
                             try {
                                 var appData = Rpc.directData('rpc.appManager.app', 'directory-connector');
                                 if (appData) {
                                     var result = Rpc.directData(appData, 'getRuleConditionalDomainEntries');
-                                    Ext.Array.each(data.reverse(), function (record) {
-                                        result.list.unshift(record);
-                                    });
-                                    data = result.list;
+                                    return { keyName: 'value', data: handleDCDomainDataMerge(data, result) };
                                 }
                             } catch (ex) {
                                 Util.handleException(ex);
+                                return { keyName: 'value', data: data };
                             }
                         }
 
-                        return field ? data : { keyName: 'value', data: data };
-
+                        return data;
                     };
 
                     currItem["widgetCreator"] = function (widget, valueBind, condition){
@@ -695,8 +697,11 @@ Ext.define('Ung.cmp.ConditionsEditor', {
                             },
                             listeners: {
                                 afterrender: function (field) {
-                                    var fetchedData = condition.getData(field);
-                                    field.getStore().loadData(fetchedData);
+                                    condition.getData(field).then(function(data) {
+                                        field.getStore().loadData(data);
+                                    },function(error) {
+                                        console.log("Error occurred while loading directory connector domains:", error);
+                                    });  
                                 }
                             }
                         });


### PR DESCRIPTION
**ISSUE:** The Username field in the ruleCondition drop-down does not display users from the Active Directory (AD) server. This is because the function responsible for fetching AD usernames is written within an asynchronous call, but the return statement is placed before the asynchronous operation completes, causing only the default data to be returned instead of the data from the AD server.

**FIX:**  Written logic to ensure that the function returns the result of the asynchronous operation directly. The data should only be returned after the asynchronous call finishes to ensure the correct AD usernames are populated in the drop-down.

**TEST:**

1. Configure Directory Connector app to connect to a AD server.
2. In Web Filter go to rules and add username condition to a new rule
3. Notice on the value field, the dropbox should list the users from the AD server. 

![Screenshot from 2024-12-19 16-44-52](https://github.com/user-attachments/assets/e6f15e82-e1ff-4a41-82c1-1117bbca1896)

4. Export the setting try to import the setting, file should be imported with valid username only.

![Screenshot from 2024-12-19 16-45-51](https://github.com/user-attachments/assets/c2e89620-7c95-40c8-95e1-391bfd7d6ecc)

5. For invalid username entry in import file, below error is expected.

![Screenshot from 2024-12-19 16-47-14](https://github.com/user-attachments/assets/7e9aba38-c044-4a90-8085-b0b3cb79060e)




