### PR TITLE
NGFW-14932:Fixed RuleCondition dropDrown field value for DC AD Group and Domain

### DIFF
--- a/uvm/servlets/admin/app/cmp/ConditionsEditor.js
+++ b/uvm/servlets/admin/app/cmp/ConditionsEditor.js
@@ -552,44 +552,40 @@ Ext.define('Ung.cmp.ConditionsEditor', {
                         }];
 
                         if (field) {
-                            Rpc.asyncData('rpc.appManager.app', 'directory-connector')
+                            return Rpc.asyncData('rpc.appManager.app', 'directory-connector')
                                 .then(function (app) {
                                     if (Util.isDestroyed(field)) {
-                                        return;
+                                        return data;
                                     }
                                     if (app) {
-                                        Rpc.asyncData(app, 'getRuleConditonalUserEntries')
+                                        return Rpc.asyncData(app, 'getRuleConditionalGroupEntries')
                                             .then(function (result) {
                                                 if (Util.isDestroyed(field)) {
-                                                    return;
+                                                    return data;
                                                 }
-                                                Ext.Array.each(data.reverse(), function (record) {
-                                                    result.list.unshift(record);
-                                                });
-                                                data = result.list;
+                                                return  me.ProcessDCUserNGroupDataMerge(data, result);
                                             }, function (ex) {
                                                 Util.handleException(ex);
+                                                return data;
                                             });
                                     }
                                 }, function (ex) {
                                     Util.handleException(ex);
+                                    return data;
                                 });
                         } else {
                             try {
                                 var appData = Rpc.directData('rpc.appManager.app', 'directory-connector');
                                 if (appData) {
                                     var result = Rpc.directData(appData, 'getRuleConditionalGroupEntries');
-                                    Ext.Array.each(data.reverse(), function (record) {
-                                        result.list.unshift(record);
-                                    });
-                                    data = result.list;
+                                    return { keyName: 'SAMAccountName', data: me.ProcessDCUserNGroupDataMerge(data, result) };
                                 }
                             } catch (ex) {
                                 Util.handleException(ex);
+                                return { keyName: 'SAMAccountName', data: data };
                             }
                         }
-
-                        return field ? data : { keyName: 'SAMAccountName', data: data };
+                        return data;
                     };
 
                     currItem["widgetCreator"] = function (widget, valueBind, condition) {
@@ -615,8 +611,11 @@ Ext.define('Ung.cmp.ConditionsEditor', {
                             },
                             listeners: {
                                 afterrender: function (field) {
-                                    var fetchedData = condition.getData(field);
-                                    field.getStore().loadData(fetchedData);
+                                    condition.getData(field).then(function(data) {
+                                        field.getStore().loadData(data);
+                                    },function(error) {
+                                        console.log("Error occurred while loading directory connector groups:", error);
+                                    }); 
                                 }
                             }
                         });
@@ -629,47 +628,50 @@ Ext.define('Ung.cmp.ConditionsEditor', {
                         var data = [{
                             value: '*', description: 'Any Domain'
                         }];
+                        var handleDCDomainDataMerge = function(data, result) {
+                            Ext.Array.each( result.list, function (record) {
+                                data.push({value: record, description: record});
+                            });
+                            return data;
+                        };
+                    
 
                         if (field) {
-                            Rpc.asyncData('rpc.appManager.app', 'directory-connector')
+                            return Rpc.asyncData('rpc.appManager.app', 'directory-connector')
                                 .then(function (app) {
                                     if (Util.isDestroyed(field)) {
-                                        return;
+                                        return data;
                                     }
                                     if (app) {
-                                        Rpc.asyncData(app, 'getRuleConditonalUserEntries')
+                                        return Rpc.asyncData(app, 'getRuleConditionalDomainEntries')
                                             .then(function (result) {
                                                 if (Util.isDestroyed(field)) {
-                                                    return;
+                                                    return data;
                                                 }
-                                                Ext.Array.each(data.reverse(), function (record) {
-                                                    result.list.unshift(record);
-                                                });
-                                                data = result.list;
+                                                return handleDCDomainDataMerge(data, result);
                                             }, function (ex) {
                                                 Util.handleException(ex);
+                                                return data;
                                             });
                                     }
                                 }, function (ex) {
                                     Util.handleException(ex);
+                                    return data;
                                 });
                         } else {
                             try {
                                 var appData = Rpc.directData('rpc.appManager.app', 'directory-connector');
                                 if (appData) {
                                     var result = Rpc.directData(appData, 'getRuleConditionalDomainEntries');
-                                    Ext.Array.each(data.reverse(), function (record) {
-                                        result.list.unshift(record);
-                                    });
-                                    data = result.list;
+                                    return { keyName: 'value', data: handleDCDomainDataMerge(data, result) };
                                 }
                             } catch (ex) {
                                 Util.handleException(ex);
+                                return { keyName: 'value', data: data };
                             }
                         }
 
-                        return field ? data : { keyName: 'value', data: data };
-
+                        return data;
                     };
 
                     currItem["widgetCreator"] = function (widget, valueBind, condition){
@@ -695,8 +697,11 @@ Ext.define('Ung.cmp.ConditionsEditor', {
                             },
                             listeners: {
                                 afterrender: function (field) {
-                                    var fetchedData = condition.getData(field);
-                                    field.getStore().loadData(fetchedData);
+                                    condition.getData(field).then(function(data) {
+                                        field.getStore().loadData(data);
+                                    },function(error) {
+                                        console.log("Error occurred while loading directory connector domains:", error);
+                                    });  
                                 }
                             }
                         });


### PR DESCRIPTION
**ISSUE:** The DC AD Domain and Group field in the ruleCondition drop-down does not display group and domain from the Active Directory (AD) server. 

**FIX:** FIxed the correct method calls and written logic to ensure that the function returns the result of the asynchronous operation directly. The data should only be returned after the asynchronous call finishes to ensure the correct AD Domain and Groups are populated in the drop-down.

**TEST:**

1. Configure Directory Connector app to connect to a AD server.

2. In Web Filter go to rules and add Domain condition to a new rule.

3. Notice on the value field, the dropbox should list the Domain from the AD server.

![Screenshot from 2024-12-19 17-41-55](https://github.com/user-attachments/assets/e2c82bc0-d028-4e17-849d-1932d46559dc)

4. Import the rules having valid domain entry, file should imported successfully.

![Screenshot from 2024-12-19 17-13-41](https://github.com/user-attachments/assets/915d8840-b2fd-4ad7-a0eb-c8420fc13c33)

5.  Import the rules having invalid domain entry, error should be shown as below.

![Screenshot from 2024-12-19 17-14-47](https://github.com/user-attachments/assets/a6682573-bd29-4e88-9d9e-e3ce067d320c)

6. In Web Filter go to rules and add Group condition to a new rule

7. Notice on the value field, the dropbox should list the Group from the AD server.

![Screenshot from 2024-12-19 17-11-39](https://github.com/user-attachments/assets/335dd9e5-f62e-4225-8975-ce562ba8b132)

8. Import the rules having invalid Group entry, error should be shown as below.

![Screenshot from 2024-12-19 17-15-31](https://github.com/user-attachments/assets/18614c57-f70b-45b5-b857-dda1f4204925)
