### PR TITLE
Ngfw 14930 test fix for IPSEC settings override tests

### DIFF
--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -48,8 +48,8 @@ appFW = None
 tunnelUp = False
 ipsecTestLAN = ""
 orig_netsettings = None
-remote_uvm_context = None
 remote_app = None
+org_remote_ipsec_settings = None
 
 local_host_ip = None
 local_host_lan_ip = None
@@ -810,7 +810,7 @@ class IPsecTests(NGFWTestCase):
         """
         Verify ipsec tunnel with any remote does't ping pingAddress and generate Tunnel Connection Events
         """
-        global remote_uvm_context, remote_app
+        global remote_app, org_remote_ipsec_settings
 
         # Configure local tunnel with remote any
         org_ipsec_settings = self._app.getSettings()
@@ -844,15 +844,13 @@ class IPsecTests(NGFWTestCase):
         events = global_functions.get_events("IPsec VPN",'Tunnel Connection Events',None,5)
         found = global_functions.check_events( events.get('list'), 5, 
                                               "event_type", "UNREACHABLE" )
-        assert(found == False)
-
         # set to original settings
         self._app.setSettings(org_ipsec_settings)
-        remote_app.setSettings(org_remote_ipsec_settings)
+        assert(found == False)
 
     @classmethod
     def final_extra_tear_down(cls):
-        global appAD, appFW, remote_uvm_context, remote_app
+        global appAD, appFW, remote_app, org_remote_ipsec_settings
 
         # Restore original settings to return to initial settings
         # print("orig_netsettings <%s>" % orig_netsettings)
@@ -867,9 +865,9 @@ class IPsecTests(NGFWTestCase):
             global_functions.uvmContext.appManager().destroy( appFW.getAppSettings()["id"] )
             appFW = None
         # Remove created remote app
-        if remote_uvm_context != None and remote_app!= None:
-            remote_uvm_context.appManager().destroy( remote_app.getAppSettings()["id"] )
-            remote_uvm_context = None
+        if remote_app != None and org_remote_ipsec_settings != None:
+            remote_app.setSettings(org_remote_ipsec_settings)
+            org_remote_ipsec_settings = None
 
 
 test_registry.register_module("ipsec-vpn", IPsecTests)

--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -48,7 +48,8 @@ appFW = None
 tunnelUp = False
 ipsecTestLAN = ""
 orig_netsettings = None
-ipsec_remote_settings = None
+remote_uvm_context = None
+remote_app = None
 
 local_host_ip = None
 local_host_lan_ip = None
@@ -809,8 +810,7 @@ class IPsecTests(NGFWTestCase):
         """
         Verify ipsec tunnel with any remote does't ping pingAddress and generate Tunnel Connection Events
         """
-        global ipsec_remote_settings
-        global remote_app
+        global remote_uvm_context, remote_app
 
         # Configure local tunnel with remote any
         ipsec_settings = self._app.getSettings()
@@ -851,8 +851,8 @@ class IPsecTests(NGFWTestCase):
 
     @classmethod
     def final_extra_tear_down(cls):
-        global appAD
-        global appFW
+        global appAD, appFW, remote_uvm_context, remote_app
+
         # Restore original settings to return to initial settings
         # print("orig_netsettings <%s>" % orig_netsettings)
         if orig_netsettings:
@@ -865,11 +865,10 @@ class IPsecTests(NGFWTestCase):
         if appFW != None:
             global_functions.uvmContext.appManager().destroy( appFW.getAppSettings()["id"] )
             appFW = None
-        # Reset remote ipsec settings to original settings
-        if ipsec_remote_settings != None:
-            remote_app.setSettings(ipsec_remote_settings)
-            ipsec_remote_settings = None
-
+        # Remove created remote app
+        if remote_uvm_context != None:
+            remote_uvm_context.appManager().destroy( remote_app.getAppSettings()["id"] )
+            remote_uvm_context = None
 
 
 test_registry.register_module("ipsec-vpn", IPsecTests)

--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -867,7 +867,7 @@ class IPsecTests(NGFWTestCase):
             global_functions.uvmContext.appManager().destroy( appFW.getAppSettings()["id"] )
             appFW = None
         # Remove created remote app
-        if remote_uvm_context != None:
+        if remote_uvm_context != None and remote_app!= None:
             remote_uvm_context.appManager().destroy( remote_app.getAppSettings()["id"] )
             remote_uvm_context = None
 

--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -813,7 +813,8 @@ class IPsecTests(NGFWTestCase):
         global remote_uvm_context, remote_app
 
         # Configure local tunnel with remote any
-        ipsec_settings = self._app.getSettings()
+        org_ipsec_settings = self._app.getSettings()
+        ipsec_settings = copy.deepcopy(org_ipsec_settings)
         ipsec_settings["tunnels"]["list"] = [build_ipsec_tunnel(remote_ip="%any", remote_lan=IPSEC_HOST_LAN)]
         self._app.setSettings(ipsec_settings)
 
@@ -827,9 +828,9 @@ class IPsecTests(NGFWTestCase):
             remote_app = remote_uvm_context.appManager().instantiate(appName, default_policy_id)
         remote_app.start()
 
-        ipsec_remote_settings = remote_app.getSettings()
+        org_remote_ipsec_settings = remote_app.getSettings()
 
-        remote_ipsec_settings = copy.deepcopy(ipsec_remote_settings)
+        remote_ipsec_settings = copy.deepcopy(org_remote_ipsec_settings)
         remote_ipsec_settings["tunnels"]["list"] = [build_ipsec_tunnel(remote_ip=local_host_ip, remote_lan=local_host_lan_ip)]
         remote_app.setSettings(remote_ipsec_settings)
         time.sleep(10)
@@ -845,10 +846,9 @@ class IPsecTests(NGFWTestCase):
                                               "event_type", "UNREACHABLE" )
         assert(found == False)
 
-        # removed added tunnel lists
-        ipsec_settings["tunnels"]["list"] = []
-        ipsec_settings = self._app.getSettings()
-        self._app.setSettings(ipsec_settings)
+        # set to original settings
+        self._app.setSettings(org_ipsec_settings)
+        remote_app.setSettings(org_remote_ipsec_settings)
 
     @classmethod
     def final_extra_tear_down(cls):

--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -848,6 +848,7 @@ class IPsecTests(NGFWTestCase):
         # removed added tunnel lists
         ipsec_settings["tunnels"]["list"] = []
         ipsec_settings = self._app.getSettings()
+        self._app.setSettings(ipsec_settings)
 
     @classmethod
     def final_extra_tear_down(cls):


### PR DESCRIPTION
**Description:**
For the test test_082_any_remote_tunnel_ping, the actual settings were not being reverted after the test execution, which could affect other test environments and subsequent tests.

**Fixed:**
For the test_082_any_remote_tunnel_ping test, the modified settings are now reverted back to their original values after the test is executed. This ensures that no changes persist, preventing any potential impact on other test boxes and future tests.
Test Result on local machine:
![image](https://github.com/user-attachments/assets/cd73af85-de22-416e-a1a7-020f39da652b)
