### PR TITLE
NGFW-14934 Fixed reports data retention test cases

### DIFF
--- a/reports/hier/usr/lib/python3/dist-packages/reports/sql_helper.py
+++ b/reports/hier/usr/lib/python3/dist-packages/reports/sql_helper.py
@@ -292,13 +292,14 @@ def create_schema(schema):
 def clean_table(tablename, cutoff):
     print("clean_table " + str(tablename) + " < " + str(cutoff))
     
+    cutoff_date = cutoff
     if type(cutoff) is datetime.datetime:
         # Convert cutoff to date
-        cutoff = cutoff.date()
+        cutoff_date = cutoff.date()
     for t, date in find_table_partitions(tablename):
         # if the entire table is before the date specified, just drop it
         # but only if the *entire* table is before the the cutoff
-        if date < cutoff:
+        if date < cutoff_date:
             print("DROP TABLE " + str(t))
             drop_table( t )
 

--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -46,6 +46,7 @@ orig_settings = None
 orig_mailsettings = None
 syslog_server_host = ""
 test_email_address = ""
+reports_clean_tables_script = "/usr/share/untangle/bin/reports-clean-tables.py"
 # pdb.set_trace()
 
 
@@ -1417,8 +1418,9 @@ class ReportsTests(NGFWTestCase):
         result = subprocess.check_output(global_functions.build_postgres_command(query="select count(*) from information_schema.tables where table_schema = 'reports'"), shell=True)
         start_count = int(result.decode("utf-8"))
 
-        # Run clean command from cron
-        result = subprocess.check_output('$(cat /etc/cron.daily/reports-cron | grep "reports-clean-tables.py")', shell=True)
+        # Create and run clean command 
+        clean_command = reports_clean_tables_script + " -d postgresql " + str(settings["dbRetention"]) + "| logger -t uvmreports"
+        result = subprocess.check_output(clean_command, shell=True)
 
         # Get post count of tables
         result = subprocess.check_output(global_functions.build_postgres_command(query="select count(*) from information_schema.tables where table_schema = 'reports'"), shell=True)

--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -11,6 +11,7 @@ import os
 import re
 import requests
 import runtests
+import random
 import subprocess
 import sys
 import unittest
@@ -1480,7 +1481,7 @@ class ReportsTests(NGFWTestCase):
         # Copy that original early record, update its timestamp to new early time.
         populate_sql_commands = [
                 f"create temporary table temp_table as (select * from reports.{original_table_name} where time_stamp = '{original_early_time_stamp_string}')",
-                f"update temp_table set time_stamp = '{new_early_time_stamp}'",
+                f"update temp_table set time_stamp = '{new_early_time_stamp}', session_id = '{random.randint(10**18, 10**19 - 1)}'",
         ]
         try:
             # Attempt to make record copy in original table.
@@ -1498,8 +1499,9 @@ class ReportsTests(NGFWTestCase):
         result = subprocess.check_output(global_functions.build_postgres_command(query=f"select count(*) from reports.sessions where time_stamp < '{original_latest_time_stamp_string}'"), shell=True)
         start_count = int(result.decode("utf-8"))
 
-        # Run clean
-        result = subprocess.check_output('$(cat /etc/cron.hourly/reports-cron | grep "reports-clean-tables.py")', shell=True)
+        # Create and run clean command 
+        clean_command = reports_clean_tables_script + " -d postgresql -h " + str(settings["dbRetentionHourly"]) + " " + str(settings["dbRetentionHourly"])
+        result = subprocess.check_output(clean_command, shell=True)
 
         # Get post clean record count
         result = subprocess.check_output(global_functions.build_postgres_command(query=f"select count(*) from reports.sessions where time_stamp < '{original_latest_time_stamp_string}'"), shell=True)


### PR DESCRIPTION
- Fixed `test_111_data_retention_days` and `test_112_data_retention_hours` test cases
- Generating random session_id for the unique constraint while inserting the record in DB.
- Modified `sql_helper.py` by introducing a new `cutoff_date` variable that contains only the date type value. Earlier, for `datetime` type, we were removing the time value from that date, which was ignoring the records with datetime.

Test result before fix:
```
== testing reports ==
Test success : test_010_client_is_online [2.1s] 
Test success : test_011_license_valid [0.0s] 
Test success : test_020_reinitialize_database [11.3s] 
Test skipped : test_040_remote_syslog [0.0s]
Test success : test_041_report_csv_vulnerability_via_report_user [0.8s] 
Test success : test_045_report_csv_vulnerability [1.1s] 
Test success : test_050_export_report_events [23.9s] 
Test skipped : test_100_email_report_admin [0.0s]
Test skipped : test_101_email_admin_override_custom_report [0.0s]
Test skipped : test_102_email_admin_override_custom_report_mobile [0.0s]
Test skipped : test_103_email_report_verify_apps [0.0s]
Test success : test_110_verify_report_users [0.7s] 
Test FAILED  : test_111_data_retention_days [0.5s]
Test FAILED  : test_112_data_retention_hours [0.5s]
Test success : test_500_sql_injection_pie_graph [11.0s] 
Test success : test_501_sql_injection_time_graph [10.2s] 
Test success : test_502_sql_injection_time_graph_dynamic [10.7s] 
Test success : test_503_sql_injection_text [8.9s] 
Test success : test_504_sql_injection_event_list [9.8s] 
Test FAILED  : test_600_session_minutes_referral [310.4s]
Test skipped : test_99_queue_process [0.3s]
== testing reports [447.8s] ==

Tests complete. [447.8 seconds]
12 passed, 6 skipped, 3 failed

Total          :   21
Passed         :   12
Skipped        :    6
Passed/Skipped :   18 [ 85.71%]
Failed         :    3 [ 14.29%]
```

Test result after fix:
```
== testing reports ==
Test success : test_010_client_is_online [2.1s] 
Test success : test_011_license_valid [0.0s] 
Test success : test_020_reinitialize_database [11.4s] 
Test skipped : test_040_remote_syslog [0.0s]
Test success : test_041_report_csv_vulnerability_via_report_user [0.8s] 
Test success : test_045_report_csv_vulnerability [1.1s] 
Test success : test_050_export_report_events [27.4s] 
Test skipped : test_100_email_report_admin [0.0s]
Test skipped : test_101_email_admin_override_custom_report [0.0s]
Test skipped : test_102_email_admin_override_custom_report_mobile [0.0s]
Test skipped : test_103_email_report_verify_apps [0.0s]
Test success : test_110_verify_report_users [0.9s] 
Test success : test_111_data_retention_days [0.7s] 
Test success : test_112_data_retention_hours [0.7s] 
Test success : test_500_sql_injection_pie_graph [11.4s] 
Test success : test_501_sql_injection_time_graph [10.1s] 
Test success : test_502_sql_injection_time_graph_dynamic [11.7s] 
Test success : test_503_sql_injection_text [9.8s] 
Test success : test_504_sql_injection_event_list [9.7s] 
Test FAILED  : test_600_session_minutes_referral [306.0s]
Test skipped : test_99_queue_process [0.3s]
== testing reports [449.8s] ==

Tests complete. [449.8 seconds]
14 passed, 6 skipped, 1 failed

Total          :   21
Passed         :   14
Skipped        :    6
Passed/Skipped :   20 [ 95.24%]
Failed         :    1 [  4.76%]