### PR TITLE
NGFW-14911 Fixed SSL rule Inspect all Google Oauth

### DIFF
--- a/uvm/hier/usr/share/untangle/conf/ut-oauth.conf
+++ b/uvm/hier/usr/share/untangle/conf/ut-oauth.conf
@@ -29,6 +29,7 @@ all|full|connectivitycheck.gstatic.com
 # These domains are required for Google OAuth
 google|full|accounts.google.com
 google|full|ssl.gstatic.com
+google|full|www.gstatic.com
 
 # These domains are required for Facebook OAuth
 facebook|full|m.facebook.com


### PR DESCRIPTION
Description:
Enabling the “Inspect All” rule in SSL Inspector will cause the redirect to return a 400 page.

Solution:
Fixed the issue where enabling the "Inspect All" rule in SSL Inspector caused Google OAuth redirects to return a 400 error by bypassing SSL inspection for OAuth traffic.

Before:
![image](https://github.com/user-attachments/assets/8f8bc864-6631-47e3-848c-86717ff43bfc)

After:
![image](https://github.com/user-attachments/assets/7e044404-5134-4930-973e-38d8cb3635ee)
![image](https://github.com/user-attachments/assets/fc2774e4-9d12-4d3e-b4cd-3a9a20b641a3)


