### PR TITLE
ngfw-14938 update restore script to restore v17.2

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-restore.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-restore.sh
@@ -11,8 +11,7 @@ WORKING_DIR=""
 TARBALL_FILE=""
 VERSION_FILE=""
 # To support multiple versions, separate with pipe character like:
-#ACCEPTED_PREVIOUS_VERSION="15.1|16.0"
-ACCEPTED_PREVIOUS_VERSION="17.1"
+ACCEPTED_PREVIOUS_VERSION="17.2"
 
 function debug() {
   if [ "true" == $VERBOSE ]; then


### PR DESCRIPTION
Update restore script to restore 17.2
Changed ACCEPTED_PREVIOUS_VERSION variable value to 17.2

Local Testing:
- On restoring version 17.1.1 backup file we get the error as given below.

![Screenshot from 2024-12-30 13-23-43](https://github.com/user-attachments/assets/7c0d9b30-41bc-47cb-aa52-b1dc8f6c59d9)


- Supported backup file versions are 17.2 and 17.3. Backup files of these versions are restored.

![Screenshot from 2024-12-30 14-22-10](https://github.com/user-attachments/assets/3d37733b-2292-4b40-9d2a-c02b0a6eaaf6)


