### PR TITLE
ngfw-14938 update restore script to restore v17.3

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-restore.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-restore.sh
@@ -11,7 +11,7 @@ WORKING_DIR=""
 TARBALL_FILE=""
 VERSION_FILE=""
 # To support multiple versions, separate with pipe character like:
-ACCEPTED_PREVIOUS_VERSION="17.2"
+ACCEPTED_PREVIOUS_VERSION="17.3"
 
 function debug() {
   if [ "true" == $VERBOSE ]; then


### PR DESCRIPTION
Update restore script to restore 17.3
Changed ACCEPTED_PREVIOUS_VERSION variable value to 17.3

Local Testing:

On restoring version 17.2 backup file we get the error as given below.
![Screenshot from 2024-12-31 11-52-21](https://github.com/user-attachments/assets/a2c402d2-0074-4bb3-877d-1dc8dd1f0bc6)


Supported backup file versions are 17.3 and 17.4. Backup files of these versions are restored.

![Screenshot from 2024-12-31 11-56-05](https://github.com/user-attachments/assets/d5a25446-7a0d-4977-bdfd-9daf1cb1804d)

