### PR TITLE
NGFW-14925 Fixed backup upload report failure when hostname contains white spaces

### DIFF
--- a/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
+++ b/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
@@ -16,7 +16,9 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Random;
 
 import com.untangle.uvm.logging.ConfigurationBackupEvent;
 import org.apache.commons.lang3.StringUtils;
@@ -36,6 +38,7 @@ import com.untangle.uvm.util.I18nUtil;
 public class ConfigurationBackupApp extends AppBase
 {
     private final Logger logger = LogManager.getLogger(ConfigurationBackupApp.class);
+    private static final Random random = new Random();
 
     private static final String CRON_STRING = "* * * root /usr/share/untangle/bin/configuration-backup-send-backup.py >/dev/null 2>&1";
     private static final File CRON_FILE = new File("/etc/cron.d/untangle-configuration-backup-nightly");
@@ -111,15 +114,14 @@ public class ConfigurationBackupApp extends AppBase
     @Override
     public void initializeSettings()
     {
-        ConfigurationBackupSettings settings = new ConfigurationBackupSettings();
+        settings = new ConfigurationBackupSettings();
         logger.info("Initializing Settings...");
 
         //Doesn't really matter when the backup takes place, but we
         //want it to be random so all customers do not post-back
         //their data files concurrently.
-        java.util.Random r = new java.util.Random();
-        settings.setHourInDay(r.nextInt(24));
-        settings.setMinuteInHour(r.nextInt(60));
+        settings.setHourInDay(random.nextInt(24));
+        settings.setMinuteInHour(random.nextInt(60));
 
         setSettings( settings );
     }
@@ -161,7 +163,7 @@ public class ConfigurationBackupApp extends AppBase
         }
 
         try {
-            backupFile.delete();
+            Files.delete(backupFile.toPath());
         } catch (Exception e) {
             logger.warn("Failed to delete backup file",e);
         }
@@ -177,7 +179,7 @@ public class ConfigurationBackupApp extends AppBase
         String settingsFileName = System.getProperty("uvm.settings.dir") + "/configuration-backup/settings_" + appID + ".js";
 
         ConfigurationBackupSettings readSettings = null;
-        logger.info("Loading settings from " + settingsFileName );
+        logger.info("Loading settings from {}", settingsFileName );
 
         try {
             // first we try to read our json settings
@@ -195,7 +197,7 @@ public class ConfigurationBackupApp extends AppBase
 
             // otherwise apply the loaded or imported settings from the file
             else {
-                logger.info("Loaded settings from " + settingsFileName);
+                logger.info("Loaded settings from {}", settingsFileName);
                 this.settings = readSettings;
             }
         } catch (Exception exn) {
@@ -266,9 +268,11 @@ public class ConfigurationBackupApp extends AppBase
         logger.info("Backup command: {}", Arrays.toString(cmd));
 
         Integer exitCode = 0;
+        String result = null;
         try {
             ExecManagerResultReader reader = UvmContextFactory.context().execManager().execEvil(cmd);
             exitCode = reader.waitFor();
+            result = reader.readFromOutput();
         } catch (Exception e) {
             exitCode = 99;
             logger.warn("Exception running backup",e);
@@ -301,6 +305,7 @@ public class ConfigurationBackupApp extends AppBase
                 reason = "Unknown error";
             }
             logger.error("Backup failed: {}", reason);
+            logger.error("Execution details:\n{}", result);
             this.logEvent( new ConfigurationBackupEvent(false, reason, I18nUtil.marktr("My Account")) );
         }
         else {

--- a/uvm/api/com/untangle/uvm/util/Constants.java
+++ b/uvm/api/com/untangle/uvm/util/Constants.java
@@ -9,7 +9,19 @@ package com.untangle.uvm.util;
  */
 public class Constants {
 
+    /**
+     * Private constructor to hide implicit constructor of utility class (RSPEC-1118)
+     */
+    private Constants() {
+        // no-op
+    }
+
+
     // Symbols
+    public static final String DOT = ".";
+    public static final String UNDERSCORE = "_";
+    public static final String SPACE = " ";
+
     public static final String EQUALS_TO = "=";
 
     // Boolean

--- a/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
@@ -138,7 +138,7 @@ public class BackupManagerImpl implements BackupManager
         File restoreFile = new File(System.getProperty("uvm.conf.dir") + "/restore.tar.gz");
         ExecManagerResult checkResult = null;
 
-        logger.info("restoreBackup( {} ,  + maintainRegex + {}", restoreFile , " );");
+        logger.info("restoreBackup( {} \"{}\"", restoreFile, maintainRegex);
 
         try {
             //Copy the bytes to a temp file

--- a/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
@@ -8,8 +8,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Calendar;
 import java.text.SimpleDateFormat;
@@ -18,15 +16,18 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
-import com.untangle.uvm.UvmContextFactory;
-import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.util.I18nUtil;
 import com.untangle.uvm.util.IOUtil;
 import com.untangle.uvm.servlet.UploadHandler;
 import com.untangle.uvm.servlet.DownloadHandler;
+
+import static com.untangle.uvm.util.Constants.DOT;
+import static com.untangle.uvm.util.Constants.SPACE;
+import static com.untangle.uvm.util.Constants.UNDERSCORE;
 
 /**
  * Helper class to do backup/restore
@@ -35,7 +36,7 @@ public class BackupManagerImpl implements BackupManager
 {
     private static final String DATE_FORMAT_NOW = "yyyy_MM_dd_HH_mm";
 
-    private static final String BACKUP_SCRIPT = System.getProperty("uvm.home") + "/bin/ut-backup.sh";;
+    private static final String BACKUP_SCRIPT = System.getProperty("uvm.home") + "/bin/ut-backup.sh";
     private static final String RESTORE_SCRIPT = System.getProperty("uvm.home") + "/bin/ut-restore.sh";
 
     private final Logger logger = LogManager.getLogger(BackupManagerImpl.class);
@@ -94,20 +95,26 @@ public class BackupManagerImpl implements BackupManager
     public String restoreBackup(File restoreFile, String maintainRegex)
     {
         FileInputStream fileInputStream = null;
-        ExecManagerResult execResult;
         byte[] fileData = new byte[(int)restoreFile.length()];
 
         // read the raw backup data into a byte array
         try {
             fileInputStream = new FileInputStream(restoreFile);
             fileInputStream.read(fileData);
-            fileInputStream.close();
         } catch (Exception exn) {
             return exn.getMessage();
+        } finally {
+            if (fileInputStream != null) {
+                try {
+                    fileInputStream.close();
+                } catch (IOException e) {
+                    logger.error("Failed to close input stream", e);
+                }
+            }
         }
 
         try {
-            execResult = restoreBackup(fileData, maintainRegex);
+            restoreBackup(fileData, maintainRegex);
         } catch (Exception exn) {
             return exn.getMessage();
         }
@@ -130,9 +137,8 @@ public class BackupManagerImpl implements BackupManager
     {
         File restoreFile = new File(System.getProperty("uvm.conf.dir") + "/restore.tar.gz");
         ExecManagerResult checkResult = null;
-        ExecManagerResult result = null;
 
-        logger.info("restoreBackup( " + restoreFile + " , \"" + maintainRegex + "\" );");
+        logger.info("restoreBackup( {} ,  + maintainRegex + {}", restoreFile , " );");
 
         try {
             //Copy the bytes to a temp file
@@ -144,10 +150,10 @@ public class BackupManagerImpl implements BackupManager
             throw ex;
         }
 
-        logger.info("Restore Backup: " + restoreFile);
+        logger.info("Restore Backup: {}", restoreFile);
 
         // just check the backup file
-        logger.info("Restore Backup: check file " + restoreFile);
+        logger.info("Restore Backup: check file {}", restoreFile);
         checkResult = UvmContextFactory.context().execManager().exec(RESTORE_SCRIPT + " -i " + restoreFile.getAbsolutePath() + " -v -c");
 
         // if the backup file is not legitimate then just return the results
@@ -156,7 +162,7 @@ public class BackupManagerImpl implements BackupManager
         }
 
         // run same command with nohup and without -c check-only flag
-        logger.info("Restore Backup: launching restore " + restoreFile);
+        logger.info("Restore Backup: launching restore {}", restoreFile);
         UvmContextFactory.context().execManager().execSafe(System.getProperty("uvm.bin.dir") + "/ut-backup-restore-helper.sh restore " + restoreFile.getAbsolutePath() + "  \"" + maintainRegex +"\"");
 
         logger.info("Restore Backup: returning");
@@ -170,13 +176,12 @@ public class BackupManagerImpl implements BackupManager
      */
     private static String createBackupFileName()
     {
-        String version = UvmContextFactory.context().version().replace(".", "_");
-        String hostName = UvmContextFactory.context().networkManager().getNetworkSettings().getHostName().replace(".", "_");
-        String domainName = UvmContextFactory.context().networkManager().getNetworkSettings().getDomainName().replace(".", "_");
+        String version = UvmContextFactory.context().version().replace(DOT, UNDERSCORE);
+        // NGFW-14925 replace space with empty string
+        String hostName = UvmContextFactory.context().networkManager().getNetworkSettings().getHostName().replace(DOT, UNDERSCORE).replace(SPACE, StringUtils.EMPTY);
+        String domainName = UvmContextFactory.context().networkManager().getNetworkSettings().getDomainName().replace(DOT, UNDERSCORE).replace(SPACE, StringUtils.EMPTY);
         String dateStr = (new SimpleDateFormat(DATE_FORMAT_NOW)).format((Calendar.getInstance()).getTime());
-        String filename = hostName + "_" + domainName + "-" + "configuration_backup" + "_v" + version + "-" + dateStr + ".backup";
-
-        return filename;
+        return hostName + UNDERSCORE + domainName + "-" + "configuration_backup" + "_v" + version + "-" + dateStr + ".backup";
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
@@ -10,15 +10,12 @@ import com.untangle.uvm.network.InterfaceStatus;
 import com.untangle.uvm.network.DhcpStaticEntry;
 import com.untangle.uvm.network.DeviceStatus;
 import com.untangle.uvm.event.EventSettings;
-import com.untangle.uvm.UvmContext;
 import com.untangle.uvm.app.Reporting;
 
 import java.text.SimpleDateFormat;
-import java.util.GregorianCalendar;
 import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.TimeZone;
-import java.util.Calendar;
 import java.util.TreeMap;
 import java.util.List;
 import java.util.Date;
@@ -30,7 +27,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileNotFoundException;
 import java.io.BufferedReader;
 import java.io.IOException;
 
@@ -101,7 +97,7 @@ public class ConfigManagerImpl implements ConfigManager
             logger.warn("Exception creating JSON response", exn);
         }
 
-        logger.debug("RESPONSE = " + response.toString());
+        logger.debug("RESPONSE = {}", response);
         return response;
     }
 
@@ -242,7 +238,7 @@ public class ConfigManagerImpl implements ConfigManager
      */
     public JSONObject setHostName(String argName)
     {
-        logger.info("CMAN_HIST setHostName() = " + argName);
+        logger.info("CMAN_HIST setHostName() = {}", argName);
 
         NetworkSettings netSettings = context.networkManager().getNetworkSettings();
         String oldName = netSettings.getHostName();
@@ -279,7 +275,7 @@ public class ConfigManagerImpl implements ConfigManager
      */
     public JSONObject setDomainName(String argName)
     {
-        logger.info("CMAN_HIST setDomainName() = " + argName);
+        logger.info("CMAN_HIST setDomainName() = {}", argName);
 
         NetworkSettings netSettings = context.networkManager().getNetworkSettings();
         String oldName = netSettings.getDomainName();
@@ -397,7 +393,7 @@ public class ConfigManagerImpl implements ConfigManager
      */
     public JSONObject setDeviceTime(String argTime, String argZone)
     {
-        logger.info("CMAN_HIST setDeviceTime() = " + argTime + "|" + argZone);
+        logger.info("CMAN_HIST setDeviceTime() = {}|{}", argTime , argZone);
 
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         Date setTime;
@@ -406,7 +402,7 @@ public class ConfigManagerImpl implements ConfigManager
         try {
             setTime = formatter.parse(argTime);
         } catch (Exception exn) {
-            logger.warn("Exception parsing argTime: " + argTime, exn);
+            logger.warn("Exception parsing argTime: {}", argTime, exn);
             return createResponse(1, exn.toString());
         }
 
@@ -432,7 +428,7 @@ public class ConfigManagerImpl implements ConfigManager
      */
     public JSONObject setAdminCredentials(String argUsername, String argPassword)
     {
-        logger.info("CMAN_HIST setAdminCredentials() = " + argUsername);
+        logger.info("CMAN_HIST setAdminCredentials() = {}", argUsername);
 
         // get the list of admin users
         AdminSettings adminSettings = context.adminManager().getSettings();
@@ -536,7 +532,7 @@ public class ConfigManagerImpl implements ConfigManager
      */
     public Object setSyslogServer(boolean argEnabled, String argHost, int argPort, String argProtocol)
     {
-        logger.info("CMAN_HIST setSyslogServer() = " + argEnabled + "|" + argHost + "|" + argPort + "|" + argProtocol);
+        logger.info("CMAN_HIST setSyslogServer() = {}|{}|{}|{}", argEnabled , argHost , argPort , argProtocol);
 
         String protoName = null;
 
@@ -572,13 +568,13 @@ public class ConfigManagerImpl implements ConfigManager
 
         NetworkSettings netSettings = context.networkManager().getNetworkSettings();
         List<DeviceStatus> devStatusList = context.networkManager().getDeviceStatus();
-        LinkedList<InterfaceMetrics> metricList = new LinkedList<InterfaceMetrics>();
+        LinkedList<InterfaceMetrics> metricList = new LinkedList<>();
         BufferedReader reader;
         String readLine;
 
         // we read and parse /proc/net/dev for the raw interface stats
         try {
-            reader = new BufferedReader(new FileReader(new File("/proc/net/dev")));
+            reader = new BufferedReader(new FileReader("/proc/net/dev"));
         } catch (Exception exn) {
             logger.warn("Exception opening /proc/net/dev", exn);
             return metricList;
@@ -605,7 +601,7 @@ public class ConfigManagerImpl implements ConfigManager
 
             // if we don't find exactly the number of columns we expect ignore the line
             if (column.length != 17) {
-                logger.warn("Invalid device line: " + readLine);
+                logger.warn("Invalid device line: {}", readLine);
                 continue;
             }
 
@@ -765,7 +761,7 @@ public class ConfigManagerImpl implements ConfigManager
      */
     public Object restoreSystemBackup(String argFileName, String maintainRegex)
     {
-        logger.info("CMAN_HIST restoreSystemBackup() = " + argFileName + "|" + maintainRegex);
+        logger.info("CMAN_HIST restoreSystemBackup() = {}|{}", argFileName , maintainRegex);
 
         // The UI currently passes the following maintainRegex values to restoreBackup:
         // Restore all settings = ''
@@ -806,7 +802,7 @@ public class ConfigManagerImpl implements ConfigManager
      */
     public Object doDatabaseQuery(String argQuery)
     {
-        logger.info("CMAN_HIST doDatabaseQuery() = " + argQuery);
+        logger.info("CMAN_HIST doDatabaseQuery() = {}", argQuery);
 
         String problem = null;
 
@@ -826,8 +822,8 @@ public class ConfigManagerImpl implements ConfigManager
         TreeMap<String, Object> info = new TreeMap<>();
         info.put("Query", argQuery);
 
-        List<JSONObject> resultData = new LinkedList<JSONObject>();
-        List<String> columnList = new ArrayList<String>();
+        List<JSONObject> resultData = new LinkedList<>();
+        List<String> columnList = new ArrayList<>();
         PreparedStatement statement = null;
         ResultSetMetaData metaData = null;
         ResultSet resultSet = null;
@@ -938,6 +934,7 @@ public class ConfigManagerImpl implements ConfigManager
             }
             json.put(name, item.toString());
         } catch (Exception exn) {
+            logger.error(exn);
         }
     }
 
@@ -1039,7 +1036,6 @@ public class ConfigManagerImpl implements ConfigManager
 
         try {
             File temperatureFile = new File(temperatureSourceFile);
-            String capture = null;
             if (temperatureFile.exists()) {
                 reader = new BufferedReader(new FileReader(temperatureFile));
                 string = reader.readLine();
@@ -1092,13 +1088,12 @@ public class ConfigManagerImpl implements ConfigManager
 
             try {
                 File sensorFile = new File("/sys/devices/virtual/thermal/" + zone.getName() + "/type");
-                String capture = null;
                 if (sensorFile.exists()) {
                     reader = new BufferedReader(new FileReader(sensorFile));
                     string = reader.readLine();
                     if ((string != null) && (string.equals("x86_pkg_temp"))) {
                         discoveryFile = zone.getAbsolutePath() + "/temp";
-                        logger.info("Discovered system temperature source: " + discoveryFile);
+                        logger.info("Discovered system temperature source: {}", discoveryFile);
                     }
                 }
             } catch (Exception exn) {
@@ -1136,7 +1131,6 @@ public class ConfigManagerImpl implements ConfigManager
         SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd-HHmmss");
         StringBuilder fileName = new StringBuilder();
 
-        TimeZone timezone = context.systemManager().getTimeZone();
         Date date = new Date(System.currentTimeMillis());
         fileName.append("/tmp/diagdump");
         fileName.append("_");
@@ -1247,7 +1241,7 @@ public class ConfigManagerImpl implements ConfigManager
     {
         logger.info("CMAN_HIST getActiveDhcpLeases()");
 
-        LinkedList<DhcpStaticEntry> activeList = new LinkedList<DhcpStaticEntry>();
+        LinkedList<DhcpStaticEntry> activeList = new LinkedList<>();
 
         BufferedReader reader;
         String readLine;
@@ -1277,7 +1271,7 @@ public class ConfigManagerImpl implements ConfigManager
 
             // if we don't find exactly the number of columns we expect ignore the line
             if (column.length != 5) {
-                logger.warn("Invalid reservation line: " + readLine);
+                logger.warn("Invalid reservation line: {}", readLine);
                 continue;
             }
 
@@ -1288,7 +1282,7 @@ public class ConfigManagerImpl implements ConfigManager
             try {
                 hostAddr = InetAddress.getByName(column[2]);
             } catch (Exception exn) {
-
+                logger.error(exn);
             }
 
             if (hostAddr == null) continue;


### PR DESCRIPTION
- Backup filename is generated on the basis on hostname and domain. A hostname containing spaces was causing issue while identifying if the backup succeeded or not. We are now generating the backup file with name that does not contain white spaces.
- Test case result
```
== testing configuration-backup ==
Test success : test_010_clientIsOnline [1.3s] 
Test success : test_011_license_valid [0.0s] 
Test success : test_020_backupNow [17.8s] 
Test success : test_030_verifyBackupCronjob [0.0s] 
Test success : test_140_compare_cloud_backup [21.1s] 
== testing configuration-backup [41.4s] ==

Tests complete. [41.4 seconds]
5 passed, 0 skipped, 0 failed

Total          :    5
Passed         :    5
Skipped        :    0
Passed/Skipped :    5 [100.00%]
Failed         :    0 [  0.00%]