### PR TITLE
NGFW-14940:Fixed local user deletion issue

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -1131,6 +1131,25 @@ class UvmTests(NGFWTestCase):
         assert user.get('password') is None, "password is not None"
         #Clear the created user
         global_functions.uvmContext.localDirectory().setUsers(remove_local_directory_user())
+
+    def test_169_test_local_user_deletion(self):
+        """
+        Verify local user removal
+        """
+        # Create local directory user 'test'
+        global_functions.uvmContext.localDirectory().setUsers(create_local_directory_user())
+
+        #test user creation
+        users = global_functions.uvmContext.localDirectory().getUsers()
+        assert len(users['list']) == 1, f"Assertion failed: Users list is empty."
+
+
+        #Clear the created user
+        global_functions.uvmContext.localDirectory().setUsers(remove_local_directory_user())
+
+        #Check the deletion of user
+        users = global_functions.uvmContext.localDirectory().getUsers()
+        assert len(users['list']) == 0, f"Assertion failed: Users list is not empty, it contains {len(users['list'])} elements."
         
 
     def test_170_log_retention(self):

--- a/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
+++ b/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
@@ -416,10 +416,6 @@ public class LocalDirectoryImpl implements LocalDirectory
      */
     public void setUsers(LinkedList<LocalDirectoryUser> users)
     {
-        if (users == null || users.isEmpty()) {
-            logger.info("Users list is empty");
-            return;
-        }
         HashSet<String> usersSeen = new HashSet<>();
 
         /**


### PR DESCRIPTION
**ISSUE:**  Not able to delete all the local users from local directory.

**FIX:** Removed the empty check from setUsers() because users can delete all entries, and the list can be empty in that case. Additionally, removed the null check since it is already handled within the loadUsersList() method.

**TEST:**

1. Navigate to Config > Local Directory > Local Users.
2. Add multiple user with a valid email address and save.
3. Delete single user and save.
4. Check user should deleted successfully.
5. Now delete all users and save.
6. Check all user should deleted successfully.
![Screenshot from 2025-01-03 17-23-09](https://github.com/user-attachments/assets/37fd5be2-a0a2-46e3-9a1c-4d1909dcdc0a)

