### PR TITLE
ngfw-14961 enable null selection for DHCP netmask override field

### DIFF
--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -1118,7 +1118,7 @@ Ext.define('Ung.config.network.Interface', {
                     bind: '{intf.dhcpPrefixOverride}',
                     fieldLabel: 'Netmask Override'.t(),
                     editable: false,
-                    store: Util.getV4NetmaskList(false, true),
+                    store: Util.getV4NetmaskList(true, true),
                     queryMode: 'local'
                 }, {
                     // dns override


### PR DESCRIPTION
**Changes:** Enabling null selection for `DHCP Configuration --> Netmask Override Field`

![Screenshot from 2025-01-17 15-35-00](https://github.com/user-attachments/assets/278441c5-9b56-4ee2-ac40-e9facbbdbaf3)
