### PR TITLE
NGFW-14983 Hidding and disabling mandatory IPsec tunnel fields conditionally based on Remote Any field

### DIFF
--- a/ipsec-vpn/js/view/IpsecTunnels.js
+++ b/ipsec-vpn/js/view/IpsecTunnels.js
@@ -260,7 +260,11 @@ Ext.define('Ung.apps.ipsecvpn.view.IpsecTunnels', {
         },
         items: [{
             xtype: 'textfield',
-            bind: '{record.right}',
+        bind: {
+            value: '{record.right}',
+            hidden: '{record.rightAny == true}',
+            disabled: '{record.rightAny == true}'
+        },
             fieldLabel: 'Remote Host'.t(),
             labelWidth: 180,
             allowBlank: false,
@@ -408,8 +412,8 @@ Ext.define('Ung.apps.ipsecvpn.view.IpsecTunnels', {
             xtype: 'textfield',
             bind: {
                 value: '{record.rightSubnet}',
-                hidden: '{record.ikeVersion !== 1}',
-                disabled: '{record.ikeVersion !== 1}'
+                hidden: '{record.ikeVersion !== 1 || record.rightAny == true}',
+                disabled: '{record.ikeVersion !== 1 || record.rightAny == true}'
             },
             fieldLabel: 'Remote Network'.t(),
             labelWidth: 180,
@@ -420,8 +424,8 @@ Ext.define('Ung.apps.ipsecvpn.view.IpsecTunnels', {
             xtype: 'textfield',
             bind: {
                 value: '{record.rightSubnet}',
-                hidden: '{record.ikeVersion !== 2}',
-                disabled: '{record.ikeVersion !== 2}'
+                hidden: '{record.ikeVersion !== 2 || record.rightAny == true}',
+                disabled: '{record.ikeVersion !== 2 || record.rightAny == true}'
             },
             fieldLabel: 'Remote Network'.t(),
             labelWidth: 180,


### PR DESCRIPTION
- Fixed the case when an already created IPsec tunnel that allows connection from Any IP is Edited then the `Done` button was disabled.
- Needed to disable and hide `item` specific binding of the mandatory text fields.
- Verified tunnel creation with peer IP and Any IP after the fix.