### PR TITLE
Ngfw 14928 wireguard make dns server optional

### DIFF
--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -59,7 +59,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         'pingInterval': 60,
         'pingConnectionEvents': true,
         'pingUnreachableEvents': false,
-        'assignDnsServer': true
+        'assignDnsServer': false
     },
 
     importValidationJavaClass: true,

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -58,7 +58,8 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         'networks': '',
         'pingInterval': 60,
         'pingConnectionEvents': true,
-        'pingUnreachableEvents': false
+        'pingUnreachableEvents': false,
+        'assignDnsServer': true
     },
 
     importValidationJavaClass: true,
@@ -268,6 +269,14 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
                 console.log(err);
                 return true;
             }                        
+        }
+    }, {
+        xtype: 'checkbox',
+        fieldLabel: 'Assign DNS Server'.t(),
+        bind: {
+            value: '{record.assignDnsServer}',
+            hidden: '{!record.endpointDynamic}',
+            disabled: '{!record.endpointDynamic}'
         }
     }, {
         xtype: 'fieldset',

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnTunnel.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnTunnel.java
@@ -36,6 +36,7 @@ public class WireGuardVpnTunnel implements Serializable, JSONString
     private Integer pingInterval = 60;
     private Boolean pingConnectionEvents = true;
     private Boolean pingUnreachableEvents = false;
+    private Boolean assignDnsServer = true;
 
     public Boolean getEnabled() { return enabled; }
     public void setEnabled( Boolean newValue ) { this.enabled = newValue; }
@@ -82,6 +83,9 @@ public class WireGuardVpnTunnel implements Serializable, JSONString
 
     public Boolean getPingUnreachableEvents() { return pingUnreachableEvents; }
     public void setPingUnreachableEvents( Boolean newValue ) { this.pingUnreachableEvents = newValue; }
+
+    public Boolean getAssignDnsServer() { return assignDnsServer; }
+    public void setAssignDnsServer(Boolean assignDnsServer) { this.assignDnsServer = assignDnsServer; }
 
     public String toJSONString()
     {

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnTunnel.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnTunnel.java
@@ -36,7 +36,8 @@ public class WireGuardVpnTunnel implements Serializable, JSONString
     private Integer pingInterval = 60;
     private Boolean pingConnectionEvents = true;
     private Boolean pingUnreachableEvents = false;
-    private Boolean assignDnsServer = true;
+    // Only required for dynamic endpoints
+    private Boolean assignDnsServer = false;
 
     public Boolean getEnabled() { return enabled; }
     public void setEnabled( Boolean newValue ) { this.enabled = newValue; }


### PR DESCRIPTION
**Change:** For Wireguard Roaming profiles added an checkbox to make DNS Server and DNS Search Domain optional
`Assign DNS Server` field will be unchecked by default

![Screenshot from 2025-01-28 20-04-00](https://github.com/user-attachments/assets/9dc27f91-6307-4aa8-bf8f-dfdd11749cc7)

Static profiles configuration will be as it was before.
![Screenshot from 2025-01-28 20-13-01](https://github.com/user-attachments/assets/841ed2c4-387d-4f60-a43c-edbf66db6a30)

If Assign DNS Server is unchecked then config file will ommit DNS line.
![Screenshot from 2025-01-28 20-06-56](https://github.com/user-attachments/assets/ac5abcb7-8852-44b8-a382-0af3cc16ee02)
