### PR TITLE
NGFW-14982- Fixed Dicrectory Connector AD authentication issue

### DIFF
--- a/directory-connector/src/com/untangle/app/directory_connector/ActiveDirectoryManagerImpl.java
+++ b/directory-connector/src/com/untangle/app/directory_connector/ActiveDirectoryManagerImpl.java
@@ -321,6 +321,8 @@ public class ActiveDirectoryManagerImpl
         }
 
         boolean azure = false;
+        //Check all the AD servers before failing the authentication. 
+        //If any AD server is available, allow the authentication to pass.
         for(ActiveDirectoryLdapAdapter adAdapter : this.adAdapters){
             if(adAdapter == null){
                 continue;
@@ -347,7 +349,6 @@ public class ActiveDirectoryManagerImpl
                 }
             } catch (ServiceUnavailableException x) {
                 logger.warn("Active Directory authenticate failed: ", x);
-                return false;
             }
         }
 


### PR DESCRIPTION
**Issue:** When multiple AD servers are added, authentication fails if the first server is powered off, even if the second server is available.

**Fix:** Removed the return statement to allow the code to check all AD servers before failing authentication. If any server is available, authentication will pass.

