### PR TITLE
NGFW- 15008: Exception calling extractSNIhostname

### DIFF
--- a/http-casing/src/com/untangle/app/http/HttpUtility.java
+++ b/http-casing/src/com/untangle/app/http/HttpUtility.java
@@ -67,7 +67,7 @@ public class HttpUtility {
 
             // if not a valid ClientHello we throw an exception since
             // they may be blocking just this kind of invalid traffic
-            if (legacyType != CLIENT_HELLO) throw new TlsHandshakeException("Packet contains an invalid SSL handshake");
+            if (legacyType != CLIENT_HELLO) throw new TlsHandshakeException("Packet contains an invalid SSL handshake value "+ legacyType);
             // looks like a valid handshake message but the protocol does
             // not support SNI so we just return null
             logger.debug("No SNI available because SSLv2Hello was detected");
@@ -75,14 +75,14 @@ public class HttpUtility {
         }
 
         // not SSLv2Hello so proceed with TLS based on the table describe above
-        if (recordType != TLS_HANDSHAKE) throw new TlsHandshakeException("Packet contains an invalid SSL handshake");
+        if (recordType != TLS_HANDSHAKE) throw new TlsHandshakeException("Packet contains an invalid SSL handshake value " + recordType);
                
         int sslVersion = data.getShort();
         int recordLength = Math.abs(data.getShort());
 
         // make sure we have a ClientHello message
         int shakeType = Math.abs(data.get());
-        if (shakeType != CLIENT_HELLO) throw new TlsHandshakeException("Packet does not contain TLS ClientHello");    
+        if (shakeType != CLIENT_HELLO) throw new TlsHandshakeException("Packet does not contain TLS ClientHello value "+  shakeType);    
            
         // extract all the handshake data so we can get to the extensions
         int messageExtra = data.get();
@@ -202,7 +202,7 @@ public class HttpUtility {
             byte[] hostData = new byte[nameLength];
             data.get(hostData, 0, nameLength);
             String hostName = new String(hostData);
-            logger.debug("Extracted SNI hostname = " + hostName);
+            logger.debug("Extracted SNI hostname =  {}", hostName);
             return hostName.toLowerCase();
     }
 }

--- a/http-casing/src/com/untangle/app/http/HttpUtility.java
+++ b/http-casing/src/com/untangle/app/http/HttpUtility.java
@@ -67,7 +67,7 @@ public class HttpUtility {
 
             // if not a valid ClientHello we throw an exception since
             // they may be blocking just this kind of invalid traffic
-            if (legacyType != CLIENT_HELLO) throw new Exception("Packet contains an invalid SSL handshake");
+            if (legacyType != CLIENT_HELLO) throw new TlsHandshakeException("Packet contains an invalid SSL handshake");
             // looks like a valid handshake message but the protocol does
             // not support SNI so we just return null
             logger.debug("No SNI available because SSLv2Hello was detected");
@@ -75,14 +75,14 @@ public class HttpUtility {
         }
 
         // not SSLv2Hello so proceed with TLS based on the table describe above
-        if (recordType != TLS_HANDSHAKE) throw new Exception("Packet contains an invalid SSL handshake");
+        if (recordType != TLS_HANDSHAKE) throw new TlsHandshakeException("Packet contains an invalid SSL handshake");
                
         int sslVersion = data.getShort();
         int recordLength = Math.abs(data.getShort());
 
         // make sure we have a ClientHello message
         int shakeType = Math.abs(data.get());
-        if (shakeType != CLIENT_HELLO) throw new Exception("Packet does not contain TLS ClientHello");    
+        if (shakeType != CLIENT_HELLO) throw new TlsHandshakeException("Packet does not contain TLS ClientHello");    
            
         // extract all the handshake data so we can get to the extensions
         int messageExtra = data.get();

--- a/http-casing/src/com/untangle/app/http/TlsHandshakeException.java
+++ b/http-casing/src/com/untangle/app/http/TlsHandshakeException.java
@@ -1,0 +1,55 @@
+/**
+ * $Id: $
+ */
+
+package com.untangle.app.http;
+
+/**
+ * Custom exception for TLS_HANDSHAKE issue.
+ * 
+ */
+@SuppressWarnings("serial")
+public class TlsHandshakeException extends Exception {
+    /**
+     * Constructor
+     */
+    public TlsHandshakeException()
+    {
+        super();
+    }
+
+    /**
+     * Constructor
+     * 
+     * @param message
+     *        The exception message
+     */
+    public TlsHandshakeException(String message)
+    {
+        super(message);
+    }
+
+    /**
+     * Constructor
+     * 
+     * @param message
+     *        The exception message
+     * @param cause
+     *        The exception cause
+     */
+    public TlsHandshakeException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor
+     * 
+     * @param cause
+     *        The exception cause
+     */
+    public TlsHandshakeException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
@@ -14,6 +14,7 @@ import javax.naming.ldap.Rdn;
 import com.untangle.app.http.HttpMethod;
 import com.untangle.app.http.RequestLine;
 import com.untangle.app.http.RequestLineToken;
+import com.untangle.app.http.TlsHandshakeException;
 import com.untangle.app.http.HttpRedirect;
 import com.untangle.app.http.HttpRequestEvent;
 import com.untangle.app.http.HeaderToken;
@@ -167,6 +168,11 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
             return;
         }
 
+        // For any handshake exception we just log
+        catch (TlsHandshakeException exn) {
+            logger.warn("Exception while handling packet : ", exn.getMessage());
+        }
+
         // any other exception we just log, release, and return
         catch (Exception exn) {
             logger.warn("Exception calling extractSNIhostname ", exn);
@@ -177,7 +183,7 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
             return;
         }
 
-        if (domain != null) logger.debug("Detected SSL connection (via SNI) to: " + domain);
+        if (domain != null) logger.debug("Detected SSL connection (via SNI) to: {} " + domain);
 
         /**
          * If SNI information is not present then we fallback to using the

--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionHttpsSniHandler.java
@@ -137,7 +137,7 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
 
             // if no room in the hold buffer then just give up
             if ((hold.position() + buff.limit()) > hold.capacity()) {
-                logger.debug("Giving up after " + hold.position() + " bytes");
+                logger.debug("Giving up after {} bytes", hold.position());
                 sess.release();
                 ByteBuffer array[] = new ByteBuffer[1];
                 array[0] = hold;
@@ -150,7 +150,7 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
             buff.flip(); // flip the working buffer
         }
 
-        logger.debug("HANDLE_CHUNK = " + buff.toString());
+        logger.debug("HANDLE_CHUNK = {}", buff.toString());
 
         // scan the buffer for the SNI hostname
         try {
@@ -170,7 +170,7 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
 
         // For any handshake exception we just log
         catch (TlsHandshakeException exn) {
-            logger.warn("Exception while handling packet : ", exn.getMessage());
+            logger.warn("Exception while handling packet : {}", exn.getMessage());
         }
 
         // any other exception we just log, release, and return
@@ -183,7 +183,7 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
             return;
         }
 
-        if (domain != null) logger.debug("Detected SSL connection (via SNI) to: {} " + domain);
+        if (domain != null) logger.debug("Detected SSL connection (via SNI) to: {} ", domain);
 
         /**
          * If SNI information is not present then we fallback to using the
@@ -218,7 +218,7 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
             }
 
             if (domain != null) {
-                logger.debug("Detected SSL connection (via CERT) to: " + domain);
+                logger.debug("Detected SSL connection (via CERT) to: {}", domain);
             }
         }
 
@@ -253,9 +253,9 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
         if (requestLine == null) {
             requestLine = new RequestLine(sess.sessionEvent(), HttpMethod.GET, new byte[] { '/' });
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_REQUEST_LINE, requestLine);
-            logger.debug("Creating new requestLine: " + requestLine.toString());
+            logger.debug("Creating new requestLine: {}", requestLine.toString());
         } else {
-            logger.debug("Using existing requestLine: " + requestLine.toString());
+            logger.debug("Using existing requestLine: {}", requestLine.toString());
         }
 
         String encodedDomain = URLEncoder.encode(domain, StandardCharsets.UTF_8);
@@ -268,9 +268,9 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
             URI uri = new URI("https://" + encodedDomain + "/");
         } catch (Exception e) {
             if (e.getMessage().contains("Illegal character")) {
-                logger.error("Could not parse (illegal character): " + domain);
+                logger.error("Could not parse (illegal character): {}", domain);
             } else {
-                logger.error("Could not parse URI for " + domain, e);
+                logger.error("Could not parse URI for {}",  domain, e);
             }
 
             /**
@@ -298,9 +298,9 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
         if (rlt == null) {
             rlt = new RequestLineToken(requestLine, "HTTP/1.1");
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_REQUEST_TOKEN, rlt);
-            logger.debug("Creating new requestLineToken: " + rlt.toString());
+            logger.debug("Creating new requestLineToken: {}", rlt.toString());
         } else {
-            logger.debug("Using existing requestLine: " + rlt.toString());
+            logger.debug("Using existing requestLine: {}", rlt.toString());
         }
 
         /**
@@ -323,9 +323,9 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
             requestLine.setHttpRequestEvent(evt);
             this.app.logEvent(evt);
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_HTTP_REQUEST_EVENT, evt);
-            logger.debug("Creating new HttpRequestEvent: " + evt.toString());
+            logger.debug("Creating new HttpRequestEvent: {}", evt.toString());
         } else {
-            logger.debug("Using existing HttpRequestEvent: " + evt.toString());
+            logger.debug("Using existing HttpRequestEvent:{} ", evt.toString());
         }
 
         // attach the hostname we extracted to the session
@@ -340,8 +340,12 @@ public class ThreatPreventionHttpsSniHandler extends AbstractEventHandler
         // we have decided to block so we create the SSL engine and start
         // by passing it all the client data received thus far
         if (redirect != null) {
-            logger.debug(" ----------------BLOCKED: " + domain + " traffic----------------");
-            logger.debug("TCP: " + sess.getClientAddr().getHostAddress() + ":" + sess.getClientPort() + " -> " + sess.getServerAddr().getHostAddress() + ":" + sess.getServerPort());
+            logger.debug(" ----------------BLOCKED: {} traffic----------------", domain);
+            logger.debug("TCP: {}:{} -> {}:{}", 
+            sess.getClientAddr().getHostAddress(), 
+            sess.getClientPort(), 
+            sess.getServerAddr().getHostAddress(), 
+            sess.getServerPort());
 
             ThreatPreventionSSLEngine engine;
             if(app.getSettings().getCloseHttpsBlockEnabled()){

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
@@ -15,6 +15,7 @@ import com.untangle.app.http.HttpMethod;
 import com.untangle.app.http.HttpRedirect;
 import com.untangle.app.http.RequestLine;
 import com.untangle.app.http.RequestLineToken;
+import com.untangle.app.http.TlsHandshakeException;
 import com.untangle.app.http.HttpRequestEvent;
 import com.untangle.app.http.HttpUtility;
 import com.untangle.app.http.HeaderToken;
@@ -170,6 +171,11 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             return;
         }
 
+        // For any handshake exception we just log
+        catch (TlsHandshakeException exn) {
+            logger.warn("Exception while handling packet : ", exn.getMessage());
+        }
+
         // any other exception we just log, release, and return
         catch (Exception exn) {
             logger.warn("Exception calling extractSNIhostname ", exn);
@@ -180,7 +186,7 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             return;
         }
 
-        if (domain != null) logger.debug("Detected SSL connection (via SNI) to: " + domain);
+        if (domain != null) logger.debug("Detected SSL connection (via SNI) to: {}" + domain);
 
         /**
          * If SNI information is not present then we fallback to using the

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterHttpsSniHandler.java
@@ -140,7 +140,7 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
 
             // if no room in the hold buffer then just give up
             if ((hold.position() + buff.limit()) > hold.capacity()) {
-                logger.debug("Giving up after " + hold.position() + " bytes");
+                logger.debug("Giving up after {} bytes", hold.position() );
                 sess.release();
                 ByteBuffer array[] = new ByteBuffer[1];
                 array[0] = hold;
@@ -153,7 +153,7 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             buff.flip(); // flip the working buffer
         }
 
-        logger.debug("HANDLE_CHUNK = " + buff.toString());
+        logger.debug("HANDLE_CHUNK = {}", buff.toString());
         app.incrementScanCount();
 
         // scan the buffer for the SNI hostname
@@ -173,7 +173,7 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
 
         // For any handshake exception we just log
         catch (TlsHandshakeException exn) {
-            logger.warn("Exception while handling packet : ", exn.getMessage());
+            logger.warn("Exception while handling packet : {}", exn.getMessage());
         }
 
         // any other exception we just log, release, and return
@@ -186,7 +186,7 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             return;
         }
 
-        if (domain != null) logger.debug("Detected SSL connection (via SNI) to: {}" + domain);
+        if (domain != null) logger.debug("Detected SSL connection (via SNI) to: {}", domain);
 
         /**
          * If SNI information is not present then we fallback to using the
@@ -220,7 +220,7 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             }
 
             if (domain != null) {
-                logger.debug("Detected SSL connection (via CERT) to: " + domain);
+                logger.debug("Detected SSL connection (via CERT) to: {}", domain);
             }
         }
 
@@ -255,9 +255,9 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
         if (requestLine == null) {
             requestLine = new RequestLine(sess.sessionEvent(), HttpMethod.GET, new byte[] { '/' });
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_REQUEST_LINE, requestLine);
-            logger.debug("Creating new requestLine: " + requestLine.toString());
+            logger.debug("Creating new requestLine: {}", requestLine.toString());
         } else {
-            logger.debug("Using existing requestLine: " + requestLine.toString());
+            logger.debug("Using existing requestLine: {}", requestLine.toString());
         }
 
         String encodedDomain = URLEncoder.encode(domain, StandardCharsets.UTF_8);
@@ -277,9 +277,9 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
 
         } catch (Exception e) {
             if (e.getMessage().contains("Illegal character")) {
-                logger.error("Could not parse (illegal character): " + domain);
+                logger.error("Could not parse (illegal character): {}", domain);
             } else {
-                logger.error("Could not parse URI for " + domain, e);
+                logger.error("Could not parse URI for {}", domain, e);
             }
 
             /**
@@ -307,9 +307,9 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
         if (rlt == null) {
             rlt = new RequestLineToken(requestLine, "HTTP/1.1");
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_REQUEST_TOKEN, rlt);
-            logger.debug("Creating new requestLineToken: " + rlt.toString());
+            logger.debug("Creating new requestLineToken: {}", rlt.toString());
         } else {
-            logger.debug("Using existing requestLine: " + rlt.toString());
+            logger.debug("Using existing requestLine: {}", rlt.toString());
         }
 
         /**
@@ -332,9 +332,9 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
             requestLine.setHttpRequestEvent(evt);
             this.app.logEvent(evt);
             sess.globalAttach(AppSession.KEY_HTTPS_SNI_HTTP_REQUEST_EVENT, evt);
-            logger.debug("Creating new HttpRequestEvent: " + evt.toString());
+            logger.debug("Creating new HttpRequestEvent: {}" , evt.toString());
         } else {
-            logger.debug("Using existing HttpRequestEvent: " + evt.toString());
+            logger.debug("Using existing HttpRequestEvent: {}" , evt.toString());
         }
 
         // attach the hostname we extracted to the session
@@ -349,9 +349,13 @@ public class WebFilterHttpsSniHandler extends AbstractEventHandler
         // we have decided to block so we create the SSL engine and start
         // by passing it all the client data received thus far
         if (redirect != null) {
-            logger.debug(" ----------------BLOCKED: " + domain + " traffic----------------");
-            logger.debug("TCP: " + sess.getClientAddr().getHostAddress() + ":" + sess.getClientPort() + " -> " + sess.getServerAddr().getHostAddress() + ":" + sess.getServerPort());
-
+            logger.debug(" ----------------BLOCKED: {} traffic----------------", domain);
+            logger.debug("TCP: {}:{} -> {}:{}", 
+            sess.getClientAddr().getHostAddress(), 
+            sess.getClientPort(), 
+            sess.getServerAddr().getHostAddress(), 
+            sess.getServerPort());
+            
             if (redirect.getType() == HttpRedirect.RedirectType.BLOCK) {
                 app.incrementBlockCount();
             } else {


### PR DESCRIPTION
**ISSUE**:
While attempting to extract the SNI (Server Name Indication) hostname, the following exception occurs:

```
Feb  4 21:07:12 localhost app-12: [WebFilterHttpsSniHandler] <TCP113949517415754> WARN  Exception calling extractSNIhostname
Feb 04 21:07:12 localhost app-12:      java.lang.Exception: Packet contains an invalid SSL handshake
Feb 04 21:07:12 localhost app-12:      com.untangle.app.http.HttpUtility.extractSniHostname(HttpUtility.java:78)
```
This results in the session being released, which prevents further processing of domain checks based on the IP and certificate.

**FIX**:
When extracting the SNI hostname for web filtering and threat prevention, we should not immediately release the session when an "invalid packet" exception occurs. Instead, we need to continue checking the domain using the IP address and certificate. The fix involves adding a condition to ensure that the session is only released when the exception is not caused by an invalid packet.

**TEST:**
Run ATS test cases all test are passing for web-filter and threat prevention.