### PR TITLE
Ngfw 14960 update untangle domains to arista

### DIFF
--- a/Dockerfile.bullseye-base
+++ b/Dockerfile.bullseye-base
@@ -25,5 +25,5 @@ RUN apt clean
 RUN rm -rf /var/lib/apt/lists/*
 
 # FIXME: right now there is no bullseye release on updates.u.c
-#RUN echo "deb http://foo:foo@updates.untangle.com/public/${REPOSITORY} ${STABLE_VERSION} main non-free" > /etc/apt/sources.list.d/${STABLE_VERSION}.list
+#RUN echo "deb http://foo:foo@updates.edge.arista.com/public/${REPOSITORY} ${STABLE_VERSION} main non-free" > /etc/apt/sources.list.d/${STABLE_VERSION}.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 735A9E18E8F62EDF413592460B9D6AE3627BF103

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 For developer build: rake && ./dist/etc/init.d/untangle-vm restart
 Building with Docker: docker-compose build
 For Debian packages: debuild -us -uc
-For more information: http://wiki.untangle.com/index.php/Developer_Wiki
+For more information: http://wiki.edge.arista.com/index.php/Developer_Wiki

--- a/application-control-lite/js/view/Status.js
+++ b/application-control-lite/js/view/Status.js
@@ -18,7 +18,7 @@ Ext.define('Ung.apps.applicationcontrollite.view.Status', {
                 '<h3>Application Control Lite</h3>' +
                 '<p>' + 'Application Control Lite identifies, logs, and blocks sessions based on the session content using manually added custom signatures.'.t() +
                 '<br><br>' + 'Upgrade to Application Control to perform deep packet (DP) and deep flow (DF) inspection of network traffic, enabling you to block, flag or allow thousands of common applications.'.t() +
-                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.untangle.com/shop/Application-Control') + '">LEARN MORE<a/></p>'
+                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.edge.arista.com/shop/Application-Control') + '">LEARN MORE<a/></p>'
         }, {
             xtype: 'appstate',
         }, {

--- a/application-control-lite/js/view/Status.js
+++ b/application-control-lite/js/view/Status.js
@@ -18,7 +18,7 @@ Ext.define('Ung.apps.applicationcontrollite.view.Status', {
                 '<h3>Application Control Lite</h3>' +
                 '<p>' + 'Application Control Lite identifies, logs, and blocks sessions based on the session content using manually added custom signatures.'.t() +
                 '<br><br>' + 'Upgrade to Application Control to perform deep packet (DP) and deep flow (DF) inspection of network traffic, enabling you to block, flag or allow thousands of common applications.'.t() +
-                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.edge.arista.com/shop/Application-Control') + '">LEARN MORE<a/></p>'
+                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://edge.arista.com/shop/Application-Control') + '">LEARN MORE<a/></p>'
         }, {
             xtype: 'appstate',
         }, {

--- a/buildtools/uri-analyzer.py
+++ b/buildtools/uri-analyzer.py
@@ -73,11 +73,11 @@ class UriAnalyzer():
 
         "http://standards.ieee.org/cgi-bin/ouisearch?",
         "https://wiki.edge.arista.com/index.php/OpenVPN",
-        "https://www.untangle.com/shop/virus-blocker",
-        "https://www.untangle.com/shop/web-filter",
-        "https://www.untangle.com/shop/Spam-Blocker",
-        "https://www.untangle.com/shop/Live-Support",
-        "https://www.untangle.com/shop/Application-Control",
+        "https://www.edge.arista.com/shop/virus-blocker",
+        "https://www.edge.arista.com/shop/web-filter",
+        "https://www.edge.arista.com/shop/Spam-Blocker",
+        "https://www.edge.arista.com/shop/Live-Support",
+        "https://www.edge.arista.com/shop/Application-Control",
 
         "https://easylist-downloads.adblockplus.org/easylist.txt",
         "https://www.edge.arista.com/favicon.ico",

--- a/buildtools/uri-analyzer.py
+++ b/buildtools/uri-analyzer.py
@@ -85,7 +85,7 @@ class UriAnalyzer():
 
         "https://wiki.edge.arista.com/get.php",
         "https://edge.arista.com/feedback",
-        "https://downloads.untangle.com/bdam/config",
+        "https://downloads.edge.arista.com/bdam/config",
 
         # From test_network.py
         "http://1.2.3.4/test/testPage1.html",

--- a/buildtools/uri-analyzer.py
+++ b/buildtools/uri-analyzer.py
@@ -73,14 +73,14 @@ class UriAnalyzer():
 
         "http://standards.ieee.org/cgi-bin/ouisearch?",
         "https://wiki.edge.arista.com/index.php/OpenVPN",
-        "https://www.edge.arista.com/shop/virus-blocker",
-        "https://www.edge.arista.com/shop/web-filter",
-        "https://www.edge.arista.com/shop/Spam-Blocker",
-        "https://www.edge.arista.com/shop/Live-Support",
-        "https://www.edge.arista.com/shop/Application-Control",
+        "https://edge.arista.com/shop/virus-blocker",
+        "https://edge.arista.com/shop/web-filter",
+        "https://edge.arista.com/shop/Spam-Blocker",
+        "https://edge.arista.com/shop/Live-Support",
+        "https://edge.arista.com/shop/Application-Control",
 
         "https://easylist-downloads.adblockplus.org/easylist.txt",
-        "https://www.edge.arista.com/favicon.ico",
+        "https://edge.arista.com/favicon.ico",
         "https://edge.arista.com/legal",
 
         "https://wiki.edge.arista.com/get.php",

--- a/captive-portal/hier/usr/share/untangle/web/capture/handler.py
+++ b/captive-portal/hier/usr/share/untangle/web/capture/handler.py
@@ -117,7 +117,7 @@ def index(req):
         if authenticationType in list(OAUTH_PROVIDERS.keys()):
             if authmode == "Empty":
                 authmode = authenticationType
-            ut = Uvm().getUvmContext().uriManager().getUriTranslationByHost("auth-relay.untangle.com")
+            ut = Uvm().getUvmContext().uriManager().getUriTranslationByHost("auth-relay.edge.arista.com")
             port = ""
             if ut['port'] != -1:
                 ut['port'] = ":" + str(ut['port'])
@@ -483,7 +483,7 @@ def generate_page(req,captureSettings,args,extra='',page=None,template_name=None
         page = replace_marker(page,'$.GoogleState.$', urllib.parse.quote(target + "&authmode=GOOGLE"))
         page = replace_marker(page,'$.MicrosoftState.$', urllib.parse.quote(target + "&authmode=MICROSOFT"))
 
-        page = replace_marker(page,'$.AuthRelayUri.$', uvmContext.uriManager().getUri("https://auth-relay.untangle.com/callback.php"))
+        page = replace_marker(page,'$.AuthRelayUri.$', uvmContext.uriManager().getUri("https://auth-relay.edge.arista.com/callback.php"))
 
     # plug the values into the hidden form fields of the authentication page
     # page by doing  search and replace for each of the placeholder text tags

--- a/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
+++ b/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
@@ -43,7 +43,7 @@ public class ConfigurationBackupApp extends AppBase
     private static final String CRON_STRING = "* * * root /usr/share/untangle/bin/configuration-backup-send-backup.py >/dev/null 2>&1";
     private static final File CRON_FILE = new File("/etc/cron.d/untangle-configuration-backup-nightly");
 
-    private static final String BACKUP_URL = UvmContextFactory.context().uriManager().getUri("https://boxbackup.untangle.com/boxbackup/backup.php");
+    private static final String BACKUP_URL = UvmContextFactory.context().uriManager().getUri("https://boxbackup.edge.arista.com/boxbackup/backup.php");
     private static final String TIMEOUT_SEC = "1200";
 
     private final PipelineConnector[] connectors = new PipelineConnector[] { };

--- a/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
+++ b/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
@@ -147,7 +147,7 @@ public class ConfigurationBackupApp extends AppBase
         }
 
         /**
-         * Upload to untangle.com
+         * Upload to edge.arista.com
          */
         uploadBackup( backupFile );
 
@@ -248,7 +248,7 @@ public class ConfigurationBackupApp extends AppBase
     }
 
     /**
-     * Upload the backup to untangle.com
+     * Upload the backup to edge.arista.com
      *
      * @param backupFile
      *  Handle of file to backup.

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -84,8 +84,8 @@ services:
       entrypoint: ./buildtools/remote-dev-build.sh
 
     # External server for testing/development of:
-    # - translations.untangle.com
-    # (this is suitable to expand to other things hosted on bd.untangle.com)
+    # - translations.edge.arista.com
+    # (this is suitable to expand to other things hosted on bd.edge.arista.com)
     external-services:
       image: nginx:latest
       container_name: external-services

--- a/docs/README
+++ b/docs/README
@@ -5,12 +5,12 @@ The xml files can be loaded at https://www.draw.io
 reports-generate-docs-db-schema.py:
 This generates a list of all tables and their schemas (in wiki format)
 instructions:
-run and upload output to https://wiki.untangle.com/index.php/Database_Schema
+run and upload output to https://wiki.edge.arista.com/index.php/Database_Schema
 
 reports-generate-docs-report-entries.py:
 This generates a list of all report entries (in wiki format)
 instructions:
-run and upload output to https://wiki.untangle.com/index.php/All_Reports
+run and upload output to https://wiki.edge.arista.com/index.php/All_Reports
 
 EventsDocumentationExtension:
 This generates a list of all events (in wiki format)
@@ -18,7 +18,7 @@ instructions:
 cp docs/EventsDocumentationExtensionImpl.java reports/src/com/untangle/app/reports/ExtensionImpl.java
 rake
 dist/etc/init.d/untangle-vm restart
-copy and edit output from /var/log/uvm/console.log and upload to https://wiki.untangle.com/index.php/Events
+copy and edit output from /var/log/uvm/console.log and upload to https://wiki.edge.arista.com/index.php/Events
 
 EventsDescriptionExtension:
 This generates a javascript definite of all events

--- a/i18ntools/lib/python/i18n/status_file.py
+++ b/i18ntools/lib/python/i18n/status_file.py
@@ -14,7 +14,7 @@ class StatusFile:
     """
     url_base = None
     url_translate_base = None
-    last_author = "translations@translations.untangle.com"
+    last_author = "translations@translations.edge.arista.com"
     default_last_author = "FULL NAME <EMAIL@ADDRESS>"
 
     status = {

--- a/i18ntools/lib/python/i18n/status_record.py
+++ b/i18ntools/lib/python/i18n/status_record.py
@@ -16,8 +16,8 @@ class StatusRecord:
         "code": None,
         "name": None,
         "translated_percent": 0.0,
-        "url": "http://translations.untangle.com/engage/ngfw/fr/",
-        "url_translate": "http://translations.untangle.com/projects/ngfw/official/fr/"
+        "url": "http://translations.edge.arista.com/engage/ngfw/fr/",
+        "url_translate": "http://translations.edge.arista.com/projects/ngfw/official/fr/"
     }
 
     def __init__(self, source_id="official", po_file=None):
@@ -41,8 +41,8 @@ class StatusRecord:
 
         self.status["translated_percent"] = int(po_file.updated_record_count() / po_file.total_record_count() * 100)
 
-        self.status["url"] = f"http://translations.untangle.com/engage/ngfw/{po_file.language_id}/"
-        self.status["url_translate"] = f"http://translations.untangle.com/projects/ngfw/{self.source_id}/{po_file.language_id}/"
+        self.status["url"] = f"http://translations.edge.arista.com/engage/ngfw/{po_file.language_id}/"
+        self.status["url_translate"] = f"http://translations.edge.arista.com/projects/ngfw/{self.source_id}/{po_file.language_id}/"
 
     def get_status(self):
         """

--- a/i18ntools/po/official/de/untangle-de.po
+++ b/i18ntools/po/official/de/untangle-de.po
@@ -4084,16 +4084,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Glückwunsch! {0} kann jetzt konfiguriert werden."
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "Registrieren Sie sich bitte für ein Konto von untangle.com, bevor Sie fortfahren."
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "Registrieren Sie sich bitte für ein Konto von edge.arista.com, bevor Sie fortfahren."
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Die Registrierung bietet folgende Vorteile:"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "Zugriff auf Ihr Konto bei untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "Zugriff auf Ihr Konto bei edge.arista.com"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid "Manage your licences, renewals, servers, and contact info all from one dashboard."

--- a/i18ntools/po/official/es/untangle-es.po
+++ b/i18ntools/po/official/es/untangle-es.po
@@ -6898,16 +6898,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "! Felicidades {0} está listo para ser configurado."
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "Por favor, registrarse en una cuenta untangle.com antes de continuar."
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "Por favor, registrarse en una cuenta edge.arista.com antes de continuar."
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Registro de usted obtiene los siguientes beneficios:"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "El acceso a su cuenta en untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "El acceso a su cuenta en edge.arista.com"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid "Manage your licences, renewals, servers, and contact info all from one dashboard."

--- a/i18ntools/po/official/fr/untangle-fr.po
+++ b/i18ntools/po/official/fr/untangle-fr.po
@@ -6885,16 +6885,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Félicitations! {0} est prêt à être configuré."
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "S'il vous plaît vous inscrire avec un compte untangle.com avant de continuer."
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "S'il vous plaît vous inscrire avec un compte edge.arista.com avant de continuer."
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Enregistrement vous obtient les avantages suivants:"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "L'accès à votre compte sur untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "L'accès à votre compte sur edge.arista.com"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid "Manage your licences, renewals, servers, and contact info all from one dashboard."

--- a/i18ntools/po/official/ja/untangle-ja.po
+++ b/i18ntools/po/official/ja/untangle-ja.po
@@ -4084,16 +4084,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "お待たせしました。{0}を構成する準備が整いました。"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "先に進む前に、untangle.comアカウントに登録してください。"
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "先に進む前に、edge.arista.comアカウントに登録してください。"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "登録すると、次のようなメリットがあります："
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "untangle.com上のアカウントへのアクセス"
+msgid "Access to your account on edge.arista.com"
+msgstr "edge.arista.com上のアカウントへのアクセス"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid "Manage your licences, renewals, servers, and contact info all from one dashboard."

--- a/i18ntools/po/official/pt_BR/untangle-pt_BR.po
+++ b/i18ntools/po/official/pt_BR/untangle-pt_BR.po
@@ -6878,16 +6878,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Parabéns! {0} está pronto para ser configurado."
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "Por favor, registre com uma conta untangle.com antes de continuar."
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "Por favor, registre com uma conta edge.arista.com antes de continuar."
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Registrando você recebe os seguintes benefícios:"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "Acesso à sua conta no untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "Acesso à sua conta no edge.arista.com"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid "Manage your licences, renewals, servers, and contact info all from one dashboard."

--- a/i18ntools/po/official/xx/untangle-xx.po
+++ b/i18ntools/po/official/xx/untangle-xx.po
@@ -6199,16 +6199,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "XCongratulations! {0} is ready to be configured.X"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "XPlease register with an untangle.com account before continuing.X"
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "XPlease register with an edge.arista.com account before continuing.X"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "XRegistering gets you the following benefits:X"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "XAccess to your account on untangle.comX"
+msgid "Access to your account on edge.arista.com"
+msgstr "XAccess to your account on edge.arista.comX"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid "Manage your licences, renewals, servers, and contact info all from one dashboard."

--- a/i18ntools/po/official/zh_CN/untangle-zh_CN.po
+++ b/i18ntools/po/official/zh_CN/untangle-zh_CN.po
@@ -6565,16 +6565,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "恭喜{0}已准备好进行配置。"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "在继续之前请与untangle.com账号注册。"
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "在继续之前请与edge.arista.com账号注册。"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "注册得到以下好处："
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "访问您的帐户untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "访问您的帐户edge.arista.com"
 
 #: /ngfw/build/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid "Manage your licences, renewals, servers, and contact info all from one dashboard."

--- a/intrusion-prevention/hier/usr/lib/python3/dist-packages/tests/test_intrusion_prevention.py
+++ b/intrusion-prevention/hier/usr/lib/python3/dist-packages/tests/test_intrusion_prevention.py
@@ -441,7 +441,7 @@ class IntrusionPreventionTests(NGFWTestCase):
                 print("cannot remove existing current_path = {current_path}".format(current_path=current_path))
                 return False
 
-        run_ips_updates(url="https://ids.untangle.com/last_suricatasignatures.tar.gz")
+        run_ips_updates(url="https://ids.edge.arista.com/last_suricatasignatures.tar.gz")
 
         # Remove previously saved update tarballs.
         for file_name in glob.glob( "{updates_path}/*.tar.gz".format(updates_path=IntrusionPreventionTests.updates_path)):
@@ -492,7 +492,7 @@ class IntrusionPreventionTests(NGFWTestCase):
                 print("cannot remove existing current_path = {current_path}".format(current_path=current_path))
                 return False
 
-        run_ips_updates(url="https://ids.untangle.com/last_suricatasignatures.tar.gz")
+        run_ips_updates(url="https://ids.edge.arista.com/last_suricatasignatures.tar.gz")
 
         # Remove previously saved update tarballs.
         for file_name in glob.glob( "{updates_path}/*.tar.gz".format(updates_path=IntrusionPreventionTests.updates_path)):
@@ -556,7 +556,7 @@ class IntrusionPreventionTests(NGFWTestCase):
                 print("cannot remove existing current_path = {current_path}".format(current_path=current_path))
                 return False
 
-        run_ips_updates(url="https://ids.untangle.com/last_suricatasignatures.tar.gz")
+        run_ips_updates(url="https://ids.edge.arista.com/last_suricatasignatures.tar.gz")
 
         # Remove previously saved update tarballs.
         for file_name in glob.glob( "{updates_path}/*.tar.gz".format(updates_path=IntrusionPreventionTests.updates_path)):

--- a/intrusion-prevention/hier/usr/share/untangle/bin/intrusion-prevention-get-updates
+++ b/intrusion-prevention/hier/usr/share/untangle/bin/intrusion-prevention-get-updates
@@ -37,9 +37,9 @@ Update_ran_file_name = "/tmp/intrusion-prevention-update.ran"
 # get signature translated URI
 def get_signature_template_uri():
 	try:
-		return Uvm().getUvmContext().uriManager().getUri('https://ids.untangle.com/suricatasignatures.tar.gz')
+		return Uvm().getUvmContext().uriManager().getUri('https://ids.edge.arista.com/suricatasignatures.tar.gz')
 	except:
-		return 'https://ids.untangle.com/suricatasignatures.tar.gz'
+		return 'https://ids.edge.arista.com/suricatasignatures.tar.gz'
 
 try:
     Uvm_context = Uvm().getUvmContext(hostname="localhost", username=None, password=None)

--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -55,7 +55,7 @@ import com.untangle.uvm.UriTranslation;
 public class LicenseManagerImpl extends AppBase implements LicenseManager
 {
     private static final String LICENSE_URL_PROPERTY = "uvm.license.url";
-    private static final String DEFAULT_LICENSE_URL = "https://license.untangle.com/license.php";
+    private static final String DEFAULT_LICENSE_URL = "https://license.edge.arista.com/license.php";
 
     private static final double LIENENCY_PERCENT = 1.25; /* the enforced seat limit is the license seat limit TIMES this value */
     private static final int    LIENENCY_CONSTANT = 5; /* the enforced seat limit is the license seat limit PLUS this value */
@@ -437,7 +437,7 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
         
         String licenseUrl = System.getProperty( "uvm.license.url" );
         if ( licenseUrl == null )
-            licenseUrl = "https://license.untangle.com/license.php";
+            licenseUrl = "https://license.edge.arista.com/license.php";
         licenseUrl = UvmContextFactory.context().uriManager().getUri(licenseUrl);
 
 
@@ -761,7 +761,7 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
     private boolean _testLicenseConnectivity()
     {
         Socket socket = null;
-        UriTranslation licenseUri = UvmContextFactory.context().uriManager().getUriTranslationByHost("license.untangle.com");
+        UriTranslation licenseUri = UvmContextFactory.context().uriManager().getUriTranslationByHost("license.edge.arista.com");
 
         String host = null;
         int port = 0;
@@ -769,7 +769,7 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
 
         try {
             socket = new Socket();
-            host = licenseUri.getHost() != null ? licenseUri.getHost(): "license.untangle.com";
+            host = licenseUri.getHost() != null ? licenseUri.getHost(): "license.edge.arista.com";
             port = licenseUri.getPort() != -1 ? licenseUri.getPort() : 443;
             socket.connect(new InetSocketAddress(host, port), 30000);
         } catch (Exception e) {

--- a/live-support/js/MainController.js
+++ b/live-support/js/MainController.js
@@ -58,10 +58,10 @@ Ext.define('Ung.apps.livesupport.MainController', {
     // our Live-Support app page.
     learnMoreHandler: function(btn){
         var target = this.getViewModel().get('companyURL');
-        if ((target) && (target !== '') && (! target.includes('untangle.com'))) {
+        if ((target) && (target !== '') && (! target.includes('edge.arista.com'))) {
             window.open(target);
         } else {
-            window.open(rpc.uriManager.getUriWithPath("https://www.untangle.com/shop/Live-Support"));
+            window.open(rpc.uriManager.getUriWithPath("https://www.edge.arista.com/shop/Live-Support"));
         }
     }
 });

--- a/live-support/js/MainController.js
+++ b/live-support/js/MainController.js
@@ -61,7 +61,7 @@ Ext.define('Ung.apps.livesupport.MainController', {
         if ((target) && (target !== '') && (! target.includes('edge.arista.com'))) {
             window.open(target);
         } else {
-            window.open(rpc.uriManager.getUriWithPath("https://www.edge.arista.com/shop/Live-Support"));
+            window.open(rpc.uriManager.getUriWithPath("https://edge.arista.com/shop/Live-Support"));
         }
     }
 });

--- a/patch/prepare_system.sh
+++ b/patch/prepare_system.sh
@@ -6,7 +6,7 @@ ORIG_PATH=/root/orig
 SOURCES_FILE_NAME=/etc/apt/sources.list.d/untangle.list
 
 ## Point apt to packages
-## deb http://302e-9d2e-5023-5e62:untangle@updates.untangle.com/public/bullseye stable-166 main non-free
+## deb http://302e-9d2e-5023-5e62:untangle@updates.edge.arista.com/public/bullseye stable-166 main non-free
 ##
 BACKUP_SOURCES_FILE_NAME=/root/untangle.list
 if [ ! -f $BACKUP_SOURCES_FILE_NAME ] ; then
@@ -16,7 +16,7 @@ fi
 VERSION=$(cat /usr/share/untangle/lib/untangle-libuvm-api/PUBVERSION)
 
 sed -i $SOURCES_FILE_NAME \
-    -e 's/updates.untangle.com/package-server.untangle.int/' \
+    -e 's/updates.edge.arista.com/package-server.untangle.int/' \
     -e "s/stable-[[:digit:]]\+/ngfw-release-$VERSION/"
 
 ##

--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -1104,7 +1104,7 @@ class ReportsTests(NGFWTestCase):
         subprocess.call(('/bin/rm -f %s' % csv_tmp), shell=True)
 
         remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://test.untangle.com"))
-        remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://www.edge.arista.com"))
+        remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://edge.arista.com"))
         remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://news.google.com"))
         remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://www.yahoo.com"))
         remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://www.reddit.com"))

--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -1104,7 +1104,7 @@ class ReportsTests(NGFWTestCase):
         subprocess.call(('/bin/rm -f %s' % csv_tmp), shell=True)
 
         remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://test.untangle.com"))
-        remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://www.untangle.com"))
+        remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://www.edge.arista.com"))
         remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://news.google.com"))
         remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://www.yahoo.com"))
         remote_control.run_command(global_functions.build_wget_command(output_file="/dev/null", uri="http://www.reddit.com"))

--- a/smtp-casing/servlets/quarantine/src/com/untangle/app/smtp/web/euv/InboxMaintenenceServlet.java
+++ b/smtp-casing/servlets/quarantine/src/com/untangle/app/smtp/web/euv/InboxMaintenenceServlet.java
@@ -79,8 +79,8 @@ public class InboxMaintenenceServlet extends HttpServlet
         String account = null;
         try {
             if("test".equals(authToken)) { //Just for ui testing
-                account="test@edge.arista.com";
-                req.setAttribute( "forwardAddress", "remapped@edge.arista.com");
+                account="test@untangle.com";
+                req.setAttribute( "forwardAddress", "remapped@untangle.com");
                 req.setAttribute( "safelistData", buildJsonList(new String[] {"safeOne@test.com", "safeTwo@test.com"}));
                 req.setAttribute( "remapsData", "[]");
             } else {

--- a/smtp-casing/servlets/quarantine/src/com/untangle/app/smtp/web/euv/InboxMaintenenceServlet.java
+++ b/smtp-casing/servlets/quarantine/src/com/untangle/app/smtp/web/euv/InboxMaintenenceServlet.java
@@ -79,8 +79,8 @@ public class InboxMaintenenceServlet extends HttpServlet
         String account = null;
         try {
             if("test".equals(authToken)) { //Just for ui testing
-                account="test@untangle.com";
-                req.setAttribute( "forwardAddress", "remapped@unatangle.com");
+                account="test@edge.arista.com";
+                req.setAttribute( "forwardAddress", "remapped@edge.arista.com");
                 req.setAttribute( "safelistData", buildJsonList(new String[] {"safeOne@test.com", "safeTwo@test.com"}));
                 req.setAttribute( "remapsData", "[]");
             } else {

--- a/spam-blocker-lite/js/view/Status.js
+++ b/spam-blocker-lite/js/view/Status.js
@@ -20,7 +20,7 @@ Ext.define('Ung.apps.spamblockerlite.view.Status', {
                 '<h3>Spam Blocker Lite</h3>' +
                 '<p>' + 'Spam Blocker Lite detects, blocks, and quarantines spam before it reaches users\' mailboxes.'.t() +
                 '<br><br>' + 'Upgrade to Spam Blocker which includes additional anti-spam engines to provide a catch rate of 99.5% and minimal false positives.  Spam Blocker is updated in real-time, and quarantine is automatic.'.t() +
-                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.edge.arista.com/shop/Spam-Blocker') + '">LEARN MORE<a/></p>'
+                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://edge.arista.com/shop/Spam-Blocker') + '">LEARN MORE<a/></p>'
         }, {
             xtype: 'appstate',
         },{

--- a/spam-blocker-lite/js/view/Status.js
+++ b/spam-blocker-lite/js/view/Status.js
@@ -20,7 +20,7 @@ Ext.define('Ung.apps.spamblockerlite.view.Status', {
                 '<h3>Spam Blocker Lite</h3>' +
                 '<p>' + 'Spam Blocker Lite detects, blocks, and quarantines spam before it reaches users\' mailboxes.'.t() +
                 '<br><br>' + 'Upgrade to Spam Blocker which includes additional anti-spam engines to provide a catch rate of 99.5% and minimal false positives.  Spam Blocker is updated in real-time, and quarantine is automatic.'.t() +
-                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.untangle.com/shop/Spam-Blocker') + '">LEARN MORE<a/></p>'
+                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.edge.arista.com/shop/Spam-Blocker') + '">LEARN MORE<a/></p>'
         }, {
             xtype: 'appstate',
         },{

--- a/translations/community/af/untangle.po
+++ b/translations/community/af/untangle.po
@@ -9538,7 +9538,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9546,7 +9546,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11055,16 +11055,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/ar/untangle.po
+++ b/translations/community/ar/untangle.po
@@ -9542,7 +9542,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9550,7 +9550,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11059,16 +11059,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/bg/untangle.po
+++ b/translations/community/bg/untangle.po
@@ -9538,7 +9538,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9546,7 +9546,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11055,16 +11055,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/bs/untangle.po
+++ b/translations/community/bs/untangle.po
@@ -9577,7 +9577,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9585,7 +9585,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11107,16 +11107,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/cs/untangle.po
+++ b/translations/community/cs/untangle.po
@@ -9538,7 +9538,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9546,7 +9546,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11055,16 +11055,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/de/untangle.po
+++ b/translations/community/de/untangle.po
@@ -9693,9 +9693,9 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Herzlichen Glückwunsch! {0} jetzt zur Konfiguration bereit ist."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
-"Bitte registrieren Sie sich mit einer untangle.com Konto, bevor Sie "
+"Bitte registrieren Sie sich mit einer edge.arista.com Konto, bevor Sie "
 "fortfahren."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9703,8 +9703,8 @@ msgid "Registering gets you the following benefits:"
 msgstr "Registrierung bekommt man folgende Vorteile:"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "Zugang zu Ihrem Konto auf untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "Zugang zu Ihrem Konto auf edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11247,17 +11247,17 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "Fehler beim Entwirren zu verbinden. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "Fehler beim Entwirren zu verbinden. [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "Fehler beim Entwirren zu verbinden. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "Fehler beim Entwirren zu verbinden. [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "Fehler beim Entwirren zu verbinden. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "Fehler beim Entwirren zu verbinden. [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 msgid "Free Disk space is low."

--- a/translations/community/el/untangle.po
+++ b/translations/community/el/untangle.po
@@ -9533,7 +9533,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9541,7 +9541,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11049,16 +11049,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/es/untangle.po
+++ b/translations/community/es/untangle.po
@@ -9690,16 +9690,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "! Felicidades {0} está listo para ser configurado."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "Por favor, registrarse en una cuenta untangle.com antes de continuar."
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "Por favor, registrarse en una cuenta edge.arista.com antes de continuar."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Registro de usted obtiene los siguientes beneficios:"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "El acceso a su cuenta en untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "El acceso a su cuenta en edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11244,17 +11244,17 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "No se pudo conectar a desenredar. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "No se pudo conectar a desenredar. [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "No se pudo conectar a desenredar. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "No se pudo conectar a desenredar. [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "No se pudo conectar a desenredar. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "No se pudo conectar a desenredar. [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 msgid "Free Disk space is low."

--- a/translations/community/fa/untangle.po
+++ b/translations/community/fa/untangle.po
@@ -9541,7 +9541,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9549,7 +9549,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11058,16 +11058,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/fi/untangle.po
+++ b/translations/community/fi/untangle.po
@@ -9580,7 +9580,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9588,7 +9588,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11110,16 +11110,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/fr/untangle.po
+++ b/translations/community/fr/untangle.po
@@ -9693,17 +9693,17 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Félicitations! {0} est prêt à être configuré."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
-"S'il vous plaît vous inscrire avec un compte untangle.com avant de continuer."
+"S'il vous plaît vous inscrire avec un compte edge.arista.com avant de continuer."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Enregistrement vous obtient les avantages suivants:"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "L'accès à votre compte sur untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "L'accès à votre compte sur edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11247,17 +11247,17 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "Impossible de se connecter à démêler. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "Impossible de se connecter à démêler. [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "Impossible de se connecter à démêler. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "Impossible de se connecter à démêler. [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "Impossible de se connecter à démêler. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "Impossible de se connecter à démêler. [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 msgid "Free Disk space is low."

--- a/translations/community/hr/untangle.po
+++ b/translations/community/hr/untangle.po
@@ -9566,7 +9566,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9574,7 +9574,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11091,16 +11091,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/hu/untangle.po
+++ b/translations/community/hu/untangle.po
@@ -9543,7 +9543,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9551,7 +9551,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11076,16 +11076,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/it/untangle.po
+++ b/translations/community/it/untangle.po
@@ -9598,7 +9598,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9606,7 +9606,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11130,16 +11130,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/ja/untangle.po
+++ b/translations/community/ja/untangle.po
@@ -9709,16 +9709,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "おめでとうございます{0}に設定する準備が整いました。"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "続行する前にuntangle.comアカウントで登録してください。"
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "続行する前にedge.arista.comアカウントで登録してください。"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "登録は、次のような利点あなたを取得します。"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "untangle.com上の自分のアカウントへのアクセス"
+msgid "Access to your account on edge.arista.com"
+msgstr "edge.arista.com上の自分のアカウントへのアクセス"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11262,17 +11262,17 @@ msgid "DNS connectivity failed:"
 msgstr "DNS接続に失敗："
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "解くへの接続に失敗しました。 [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "解くへの接続に失敗しました。 [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "解くへの接続に失敗しました。 [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "解くへの接続に失敗しました。 [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "解くへの接続に失敗しました。 [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "解くへの接続に失敗しました。 [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 msgid "Free Disk space is low."

--- a/translations/community/ko/untangle.po
+++ b/translations/community/ko/untangle.po
@@ -9588,7 +9588,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9596,7 +9596,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11125,16 +11125,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/lo/untangle.po
+++ b/translations/community/lo/untangle.po
@@ -9533,7 +9533,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9541,7 +9541,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11049,16 +11049,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/nl/untangle.po
+++ b/translations/community/nl/untangle.po
@@ -9594,7 +9594,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9602,7 +9602,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11127,16 +11127,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/nn/untangle.po
+++ b/translations/community/nn/untangle.po
@@ -9542,7 +9542,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9550,7 +9550,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11065,16 +11065,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/pl/untangle.po
+++ b/translations/community/pl/untangle.po
@@ -9669,17 +9669,17 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Gratulacje! {0} jest gotowy do skonfigurowania."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
-"Proszę zarejestrować się za pomocą konta untangle.com przed kontynuowaniem."
+"Proszę zarejestrować się za pomocą konta edge.arista.com przed kontynuowaniem."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Rejestracja dostarcza następujących korzyści:"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "Dostęp do konta na untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "Dostęp do konta na edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11220,22 +11220,22 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
-"Próba połączenia z Untangle [updates.untangle.com:80] zakończona "
+"Próba połączenia z Untangle [updates.edge.arista.com:80] zakończona "
 "niepowodzeniem"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
-"Próba połączenia z Untangle [license.untangle.com:443] zakończona "
+"Próba połączenia z Untangle [license.edge.arista.com:443] zakończona "
 "niepowodzeniem"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
-"Próba połączenia z Untangle [cmd.untangle.com] zakończona niepowodzeniem"
+"Próba połączenia z Untangle [cmd.edge.arista.com] zakończona niepowodzeniem"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 msgid "Free Disk space is low."

--- a/translations/community/pt/untangle.po
+++ b/translations/community/pt/untangle.po
@@ -9589,7 +9589,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9597,7 +9597,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11117,16 +11117,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/pt_BR/untangle.po
+++ b/translations/community/pt_BR/untangle.po
@@ -9674,16 +9674,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Parabéns! {0} está pronto para ser configurado."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "Por favor, registre com uma conta untangle.com antes de continuar."
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "Por favor, registre com uma conta edge.arista.com antes de continuar."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Registrando você recebe os seguintes benefícios:"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "Acesso à sua conta no untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "Acesso à sua conta no edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11226,17 +11226,17 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "Falha ao conectar-se a Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "Falha ao conectar-se a Untangle. [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "Falha ao conectar-se a Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "Falha ao conectar-se a Untangle. [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "Falha ao conectar-se a Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "Falha ao conectar-se a Untangle. [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 msgid "Free Disk space is low."

--- a/translations/community/ro/untangle.po
+++ b/translations/community/ro/untangle.po
@@ -9534,7 +9534,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9542,7 +9542,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11050,16 +11050,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/ru/untangle.po
+++ b/translations/community/ru/untangle.po
@@ -9586,7 +9586,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9594,7 +9594,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11125,16 +11125,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/sk/untangle.po
+++ b/translations/community/sk/untangle.po
@@ -9558,7 +9558,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9566,7 +9566,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11087,16 +11087,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/sl/untangle.po
+++ b/translations/community/sl/untangle.po
@@ -9533,7 +9533,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9541,7 +9541,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11049,16 +11049,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/sr/untangle.po
+++ b/translations/community/sr/untangle.po
@@ -9573,7 +9573,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9581,7 +9581,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11103,16 +11103,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/sv/untangle.po
+++ b/translations/community/sv/untangle.po
@@ -9590,7 +9590,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9598,7 +9598,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11120,16 +11120,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/templates/untangle.pot
+++ b/translations/community/templates/untangle.pot
@@ -9375,7 +9375,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9383,7 +9383,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -10843,16 +10843,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/tr/untangle.po
+++ b/translations/community/tr/untangle.po
@@ -9541,7 +9541,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9549,7 +9549,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11060,16 +11060,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/community/zh_CN/untangle.po
+++ b/translations/community/zh_CN/untangle.po
@@ -9592,16 +9592,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "恭喜{0}已准备好进行配置。"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "在继续之前请与untangle.com账号注册。"
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "在继续之前请与edge.arista.com账号注册。"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "注册得到以下好处："
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "访问您的帐户untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "访问您的帐户edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11120,17 +11120,17 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "无法连接到解开。 [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "无法连接到解开。 [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "无法连接到解开。 [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "无法连接到解开。 [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "无法连接到解开。 [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "无法连接到解开。 [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 msgid "Free Disk space is low."

--- a/translations/community/zh_TW/untangle.po
+++ b/translations/community/zh_TW/untangle.po
@@ -9570,7 +9570,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9578,7 +9578,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -11095,16 +11095,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/official/de/untangle.po
+++ b/translations/official/de/untangle.po
@@ -4418,16 +4418,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Glückwunsch! {0} kann jetzt konfiguriert werden."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "Registrieren Sie sich bitte für ein Konto von untangle.com, bevor Sie fortfahren."
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "Registrieren Sie sich bitte für ein Konto von edge.arista.com, bevor Sie fortfahren."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Die Registrierung bietet folgende Vorteile:"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "Zugriff auf Ihr Konto bei untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "Zugriff auf Ihr Konto bei edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid "Manage your licences, renewals, servers, and contact info all from one dashboard."

--- a/translations/official/es/untangle.po
+++ b/translations/official/es/untangle.po
@@ -10099,16 +10099,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "! Felicidades {0} está listo para ser configurado."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "Por favor, registrarse en una cuenta untangle.com antes de continuar."
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "Por favor, registrarse en una cuenta edge.arista.com antes de continuar."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Registro de usted obtiene los siguientes beneficios:"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "El acceso a su cuenta en untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "El acceso a su cuenta en edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11800,17 +11800,17 @@ msgid "DNS connectivity failed:"
 msgstr "Conectividad DNS falló: "
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "No se pudo conectar a desenredar. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "No se pudo conectar a desenredar. [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "No se pudo conectar a desenredar. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "No se pudo conectar a desenredar. [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "No se pudo conectar a desenredar. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "No se pudo conectar a desenredar. [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 #, fuzzy
@@ -21512,10 +21512,10 @@ msgstr ""
 #~ msgstr "American Express"
 
 #~ msgid ""
-#~ "Your untangle.com account has subscriptions that are not assigned to any "
+#~ "Your edge.arista.com account has subscriptions that are not assigned to any "
 #~ "server."
 #~ msgstr ""
-#~ "Su cuenta untangle.com tiene suscripciones que no están asignados a "
+#~ "Su cuenta edge.arista.com tiene suscripciones que no están asignados a "
 #~ "ningún servidor."
 
 #~ msgid ""
@@ -21527,10 +21527,10 @@ msgstr ""
 
 #~ msgid ""
 #~ "If you do not wish to do this, you can skip this and do this at any time "
-#~ "in the future by visiting your account at untangle.com"
+#~ "in the future by visiting your account at edge.arista.com"
 #~ msgstr ""
 #~ "Si no desea hacer esto, puede saltarse esto y hacer esto en cualquier "
-#~ "momento en el futuro, visite su cuenta en untangle.com"
+#~ "momento en el futuro, visite su cuenta en edge.arista.com"
 
 #~ msgid "Open My Account"
 #~ msgstr "Abra Mi Cuenta"

--- a/translations/official/fr/untangle.po
+++ b/translations/official/fr/untangle.po
@@ -10100,17 +10100,17 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Félicitations! {0} est prêt à être configuré."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
-"S'il vous plaît vous inscrire avec un compte untangle.com avant de continuer."
+"S'il vous plaît vous inscrire avec un compte edge.arista.com avant de continuer."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Enregistrement vous obtient les avantages suivants:"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "L'accès à votre compte sur untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "L'accès à votre compte sur edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11798,17 +11798,17 @@ msgid "DNS connectivity failed:"
 msgstr "Connectivité DNS a échoué: "
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "Impossible de se connecter à démêler. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "Impossible de se connecter à démêler. [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "Impossible de se connecter à démêler. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "Impossible de se connecter à démêler. [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "Impossible de se connecter à démêler. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "Impossible de se connecter à démêler. [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 #, fuzzy
@@ -21519,10 +21519,10 @@ msgstr ""
 #~ msgstr "American Express"
 
 #~ msgid ""
-#~ "Your untangle.com account has subscriptions that are not assigned to any "
+#~ "Your edge.arista.com account has subscriptions that are not assigned to any "
 #~ "server."
 #~ msgstr ""
-#~ "Votre compte untangle.com a abonnements qui ne sont pas affectés à un "
+#~ "Votre compte edge.arista.com a abonnements qui ne sont pas affectés à un "
 #~ "serveur."
 
 #~ msgid ""
@@ -21534,10 +21534,10 @@ msgstr ""
 
 #~ msgid ""
 #~ "If you do not wish to do this, you can skip this and do this at any time "
-#~ "in the future by visiting your account at untangle.com"
+#~ "in the future by visiting your account at edge.arista.com"
 #~ msgstr ""
 #~ "Si vous ne souhaitez pas le faire, vous pouvez ignorer cela et le faire à "
-#~ "tout moment à l'avenir en vous rendant à votre compte sur untangle.com"
+#~ "tout moment à l'avenir en vous rendant à votre compte sur edge.arista.com"
 
 #~ msgid "Open My Account"
 #~ msgstr "Ouvrir mon compte"

--- a/translations/official/ja/untangle.po
+++ b/translations/official/ja/untangle.po
@@ -4418,16 +4418,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "お待たせしました。{0}を構成する準備が整いました。"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "先に進む前に、untangle.comアカウントに登録してください。"
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "先に進む前に、edge.arista.comアカウントに登録してください。"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "登録すると、次のようなメリットがあります："
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "untangle.com上のアカウントへのアクセス"
+msgid "Access to your account on edge.arista.com"
+msgstr "edge.arista.com上のアカウントへのアクセス"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid "Manage your licences, renewals, servers, and contact info all from one dashboard."

--- a/translations/official/pt_BR/untangle.po
+++ b/translations/official/pt_BR/untangle.po
@@ -10085,16 +10085,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "Parabéns! {0} está pronto para ser configurado."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "Por favor, registre com uma conta untangle.com antes de continuar."
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "Por favor, registre com uma conta edge.arista.com antes de continuar."
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "Registrando você recebe os seguintes benefícios:"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "Acesso à sua conta no untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "Acesso à sua conta no edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11780,17 +11780,17 @@ msgid "DNS connectivity failed:"
 msgstr "Conectividade DNS falhou: "
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "Falha ao conectar-se a Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "Falha ao conectar-se a Untangle. [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "Falha ao conectar-se a Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "Falha ao conectar-se a Untangle. [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "Falha ao conectar-se a Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "Falha ao conectar-se a Untangle. [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 #, fuzzy
@@ -21456,10 +21456,10 @@ msgstr ""
 #~ msgstr "American Express"
 
 #~ msgid ""
-#~ "Your untangle.com account has subscriptions that are not assigned to any "
+#~ "Your edge.arista.com account has subscriptions that are not assigned to any "
 #~ "server."
 #~ msgstr ""
-#~ "Sua conta untangle.com tem assinaturas que não são atribuídos a qualquer "
+#~ "Sua conta edge.arista.com tem assinaturas que não são atribuídos a qualquer "
 #~ "servidor."
 
 #~ msgid ""
@@ -21471,10 +21471,10 @@ msgstr ""
 
 #~ msgid ""
 #~ "If you do not wish to do this, you can skip this and do this at any time "
-#~ "in the future by visiting your account at untangle.com"
+#~ "in the future by visiting your account at edge.arista.com"
 #~ msgstr ""
 #~ "Se você não quiser fazer isso, você pode ignorar isso e fazer isso a "
-#~ "qualquer momento no futuro, visitando sua conta em untangle.com"
+#~ "qualquer momento no futuro, visitando sua conta em edge.arista.com"
 
 #~ msgid "Open My Account"
 #~ msgstr "Abra Minha Conta"

--- a/translations/official/templates/untangle.pot
+++ b/translations/official/templates/untangle.pot
@@ -9375,7 +9375,7 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
+msgid "Please register with an edge.arista.com account before continuing."
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
@@ -9383,7 +9383,7 @@ msgid "Registering gets you the following benefits:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
+msgid "Access to your account on edge.arista.com"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
@@ -10843,16 +10843,16 @@ msgid "DNS connectivity failed:"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
 msgstr ""
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312

--- a/translations/official/zh_CN/untangle.po
+++ b/translations/official/zh_CN/untangle.po
@@ -9982,16 +9982,16 @@ msgid "Congratulations! {0} is ready to be configured."
 msgstr "恭喜{0}已准备好进行配置。"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
-msgid "Please register with an untangle.com account before continuing."
-msgstr "在继续之前请与untangle.com账号注册。"
+msgid "Please register with an edge.arista.com account before continuing."
+msgstr "在继续之前请与edge.arista.com账号注册。"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:94
 msgid "Registering gets you the following benefits:"
 msgstr "注册得到以下好处："
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:96
-msgid "Access to your account on untangle.com"
-msgstr "访问您的帐户untangle.com"
+msgid "Access to your account on edge.arista.com"
+msgstr "访问您的帐户edge.arista.com"
 
 #: /ngfw/ngfw_src/uvm/servlets/admin/app/view/main/Registration.js:97
 msgid ""
@@ -11640,17 +11640,17 @@ msgid "DNS connectivity failed:"
 msgstr "DNS连接失败："
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:253
-msgid "Failed to connect to Untangle. [updates.untangle.com:80]"
-msgstr "无法连接到解开。 [updates.untangle.com:80]"
+msgid "Failed to connect to Untangle. [updates.edge.arista.com:80]"
+msgstr "无法连接到解开。 [updates.edge.arista.com:80]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:265
-msgid "Failed to connect to Untangle. [license.untangle.com:443]"
-msgstr "无法连接到解开。 [license.untangle.com:443]"
+msgid "Failed to connect to Untangle. [license.edge.arista.com:443]"
+msgstr "无法连接到解开。 [license.edge.arista.com:443]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:287
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:292
-msgid "Failed to connect to Untangle. [cmd.untangle.com]"
-msgstr "无法连接到解开。 [cmd.untangle.com]"
+msgid "Failed to connect to Untangle. [cmd.edge.arista.com]"
+msgstr "无法连接到解开。 [cmd.edge.arista.com]"
 
 #: /ngfw/ngfw_src/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java:312
 #, fuzzy
@@ -20894,9 +20894,9 @@ msgstr ""
 #~ msgstr "美国运通卡"
 
 #~ msgid ""
-#~ "Your untangle.com account has subscriptions that are not assigned to any "
+#~ "Your edge.arista.com account has subscriptions that are not assigned to any "
 #~ "server."
-#~ msgstr "您untangle.com帐户未分配到​​任何服务器订阅。"
+#~ msgstr "您edge.arista.com帐户未分配到​​任何服务器订阅。"
 
 #~ msgid ""
 #~ "If you wish to assign a subscription to this server visit your account "
@@ -20905,9 +20905,9 @@ msgstr ""
 
 #~ msgid ""
 #~ "If you do not wish to do this, you can skip this and do this at any time "
-#~ "in the future by visiting your account at untangle.com"
+#~ "in the future by visiting your account at edge.arista.com"
 #~ msgstr ""
-#~ "如果你不希望这样做，你可以跳过这一点，并访问您的帐户untangle.com做到这一点"
+#~ "如果你不希望这样做，你可以跳过这一点，并访问您的帐户edge.arista.com做到这一点"
 #~ "在将来任何时候"
 
 #~ msgid "Open My Account"

--- a/uvm/api/com/untangle/uvm/CloudManager.java
+++ b/uvm/api/com/untangle/uvm/CloudManager.java
@@ -8,9 +8,9 @@ import org.json.JSONObject;
 public interface CloudManager
 {
     /**
-     * Login to untangle.com with the provided login and password.
+     * Login to edge.arista.com with the provided login and password.
      *
-     * This returns the JSON result from the /api/v1/account/login from untangle.com
+     * This returns the JSON result from the /api/v1/account/login from edge.arista.com
      * Example: {"success":true,"token":"48fdc8e8ae3ef964ee2f3a88c5e57acb"}
      * Example: {"success":false,"customerMessage":"We were unable to validate your credentials.","developerMessage":"Provided password did not match stored password."}
      *
@@ -20,11 +20,11 @@ public interface CloudManager
     JSONObject accountLogin( String login, String password ) throws Exception;
 
     /**
-     * Login to untangle.com with the provided login and password.
+     * Login to edge.arista.com with the provided login and password.
      *
      * uid, applianceModel, majorVersion, installType are optional parameters that are sent to the auth service
      *
-     * This returns the JSON result from the /api/v1/account/login from untangle.com
+     * This returns the JSON result from the /api/v1/account/login from edge.arista.com
      * Example: {"success":true,"token":"48fdc8e8ae3ef964ee2f3a88c5e57acb"}
      * Example: {"success":false,"customerMessage":"We were unable to validate your credentials.","developerMessage":"Provided password did not match stored password."}
      *
@@ -34,9 +34,9 @@ public interface CloudManager
     JSONObject accountLogin( String email, String password, String uid, String applianceModel, String majorVersion, String installType ) throws Exception;
 
     /**
-     * Create an untangle.com account with the provided information.
+     * Create an edge.arista.com account with the provided information.
      *
-     * This returns the JSON result from the /api/v1/account/create from untangle.com
+     * This returns the JSON result from the /api/v1/account/create from edge.arista.com
      * Example: {"success":true, "token":"7a4905c9501c2eb9adc12e7e7d1176df"}
      * Example: {"success":false,"customerMessage":"We could not create your account.","developerMessage":"Could not create the Wordpress or Shopp account."}
      *

--- a/uvm/api/com/untangle/uvm/UriManagerSettings.java
+++ b/uvm/api/com/untangle/uvm/UriManagerSettings.java
@@ -19,8 +19,8 @@ public class UriManagerSettings implements Serializable, JSONString
     private Integer version = 5;
     private List<UriTranslation> uriTranslations = new LinkedList<>();
 
-    private String dnsTestHost = "updates.untangle.com";
-    private String tcpTestHost = "updates.untangle.com";
+    private String dnsTestHost = "updates.edge.arista.com";
+    private String tcpTestHost = "updates.edge.arista.com";
 
     public UriManagerSettings() { }
 

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_alerts.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_alerts.py
@@ -11,7 +11,7 @@ import runtests.overrides as overrides
 
 
 DNS_HOST = overrides.get("DNS_HOST", default="0.0.0.0")
-DNS_HOST_NAME = overrides.get("DNS_HOST", default="boxbackup.untangle.com")
+DNS_HOST_NAME = overrides.get("DNS_HOST", default="boxbackup.edge.arista.com")
 
 def create_alert_rule(description, field, operator, value, field2, operator2, value2, thresholdEnabled=False, thresholdLimit=None, thresholdTimeframeSec=None, thresholdGroupingField=None, sendEmail=False):
     return {

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -2554,8 +2554,8 @@ server=dynupdate.no-ip.com
         Troubleshooting, connectivity
         """
         output = get_troubleshooting_output(command='CONNECTIVITY',arguments={
-                "DNS_TEST_HOST": "updates.untangle.com", 
-                "TCP_TEST_HOST": "updates.untangle.com"
+                "DNS_TEST_HOST": "updates.edge.arista.com", 
+                "TCP_TEST_HOST": "updates.edge.arista.com"
             })
 
         # Don't care about success/failure just that we see the test ran

--- a/uvm/hier/usr/lib/python3/dist-packages/uvm/login_tools.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/uvm/login_tools.py
@@ -35,9 +35,9 @@ except ImportError:
 
 def get_auth_uri():
     try:
-        return Uvm().getUvmContext().uriManager().getUri('https://auth.untangle.com/v1/CheckTokenAccess')
+        return Uvm().getUvmContext().uriManager().getUri('https://auth.edge.arista.com/v1/CheckTokenAccess')
     except:
-        return 'https://auth.untangle.com/v1/CheckTokenAccess'
+        return 'https://auth.edge.arista.com/v1/CheckTokenAccess'
 
 
 class Totp:
@@ -266,7 +266,7 @@ def valid_token(token):
     """
     Returns true if token is valid.
 
-    token -- a token string that we will check against auth.untangle.com
+    token -- a token string that we will check against auth.edge.arista.com
     """
     try:
         uid = getuid()

--- a/uvm/hier/usr/share/untangle/bin/network-troubleshooting.sh
+++ b/uvm/hier/usr/share/untangle/bin/network-troubleshooting.sh
@@ -10,8 +10,8 @@
 # Verify basic DNS and TCP conn
 #
 # Environment variables:
-# DNS_TEST_HOST: dns address (e.g.,updates.untangle.com)
-# TCP_TEST_HOST: TCP reachable address (e.g.,updates.untangle.com)
+# DNS_TEST_HOST: dns address (e.g.,updates.edge.arista.com)
+# TCP_TEST_HOST: TCP reachable address (e.g.,updates.edge.arista.com)
 run_connectivity(){
     echo -n 'Testing DNS ... '
 

--- a/uvm/hier/usr/share/untangle/bin/ut-bdam-license-update.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-bdam-license-update.py
@@ -63,7 +63,7 @@ def get_license_from_curl():
     try:
         # Run curl command and capture both stdout and stderr
         result = subprocess.run(
-            ['curl', '-s', '-w', '%{http_code}', 'https://downloads.untangle.com/bdam/config'],
+            ['curl', '-s', '-w', '%{http_code}', 'https://downloads.edge.arista.com/bdam/config'],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True

--- a/uvm/hier/usr/share/untangle/bin/ut-dns-test
+++ b/uvm/hier/usr/share/untangle/bin/ut-dns-test
@@ -2,7 +2,7 @@
 
 DNS_TRIES=4
 DNS_TIMEOUT=2
-TEST_HOST="updates.untangle.com"
+TEST_HOST="updates.edge.arista.com"
 
 if [ $# -lt 1 ] ; then
     echo "Usage: $0 <dns-server-ip>"

--- a/uvm/hier/usr/share/untangle/conf/untangle-vm.conf
+++ b/uvm/hier/usr/share/untangle/conf/untangle-vm.conf
@@ -75,10 +75,10 @@ uvm_args += " -Dnetworkaddress.cache.ttl=30 -Dsun.net.inetaddr.ttl=30 -Dnetworka
 uvm_args += " -Djava.net.preferIPv4Stack=true"
 
 ## Alternative store
-#uvm_args += " -Duvm.store.url=https://develop.untangle.com/api/v1"
+#uvm_args += " -Duvm.store.url=https://develop-edge.arista.com/api/v1"
 
 ## Alternative cmd
-#uvm_args += " -Duvm.cmd.url=https://develop.untangle.com/cmd"
+#uvm_args += " -Duvm.cmd.url=https://develop-edge.arista.com/cmd"
 
 ## Alternative license server
 #uvm_args += " -Duvm.license.url=http://staging-license.untangle.com/license.php"

--- a/uvm/hier/usr/share/untangle/conf/ut-oauth.conf
+++ b/uvm/hier/usr/share/untangle/conf/ut-oauth.conf
@@ -23,7 +23,7 @@
 #------------------------------------------------------------------------------
 
 # These domains are allowed no matter which OAuth provider is used
-all|full|auth-relay.untangle.com
+all|full|auth-relay.edge.arista.com
 all|full|connectivitycheck.gstatic.com
 
 # These domains are required for Google OAuth

--- a/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  */
 public class DeviceTableImpl implements DeviceTable
 {
-    private static final String CLOUD_LOOKUP_URL = UvmContextFactory.context().uriManager().getUri("https://labs.untangle.com/Utility/v1/mac");
+    private static final String CLOUD_LOOKUP_URL = UvmContextFactory.context().uriManager().getUri("https://labs.edge.arista.com/Utility/v1/mac");
     private static final String CLOUD_LOOKUP_KEY = "B132C885-962B-4D63-8B2F-441B7A43CD93";
     private static final String CONTENT_LENGTH = "Content-length";
     private static final String CONTENT_TYPE = "Content-Type";

--- a/uvm/impl/com/untangle/uvm/GoogleManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/GoogleManagerImpl.java
@@ -21,7 +21,7 @@ public class GoogleManagerImpl implements GoogleManager
 {
     private static final String GOOGLE_DRIVE_PATH = "/var/lib/google-drive/";
     private static final String GOOGLE_DRIVE_TMP_PATH = "/tmp/google-drive/";
-    public String RELAY_SERVER_URL = "https://auth-relay.untangle.com";
+    public String RELAY_SERVER_URL = "https://auth-relay.edge.arista.com";
 
     private final Logger logger = LogManager.getLogger(getClass());
 

--- a/uvm/impl/com/untangle/uvm/LanguageManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/LanguageManagerImpl.java
@@ -53,7 +53,7 @@ public class LanguageManagerImpl implements LanguageManager
 {
     private static final String LANGUAGES_DIR;
     private static final String RESOURCES_DIR;
-    private static final String REMOTE_LANGUAGES_URL = UvmContextFactory.context().uriManager().getUri("http://translations.untangle.com/");
+    private static final String REMOTE_LANGUAGES_URL = UvmContextFactory.context().uriManager().getUri("http://translations.edge.arista.com/");
     private static final String REMOTE_LANGUAGES_PROJECT = "ngfw";
     private static final String LOCALE_DIR = "/usr/share/locale";
     private static final String DEFAULT_LANGUAGE = "en";

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1440,10 +1440,10 @@ public class NetworkManagerImpl implements NetworkManager
         }
 
         /**
-         * Prevent users from choosing untangle.com (#7574)
+         * Prevent users from choosing edge.arista.com (#7574)
          */
-        if ( "untangle.com".equals(networkSettings.getDomainName()) ) {
-            throw new RuntimeException( "untangle.com is not an allowed domain name." );
+        if ( "edge.arista.com".equals(networkSettings.getDomainName()) ) {
+            throw new RuntimeException( "edge.arista.com is not an allowed domain name." );
         }
 
         /**

--- a/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
@@ -268,14 +268,14 @@ public class NotificationManagerImpl implements NotificationManager
     private void testConnectivity(List<String> notificationList)
     {
         Socket socket = null;
-        UriTranslation updatesUri = UvmContextFactory.context().uriManager().getUriTranslationByHost("updates.untangle.com");
-        UriTranslation licenseUri = UvmContextFactory.context().uriManager().getUriTranslationByHost("license.untangle.com");
+        UriTranslation updatesUri = UvmContextFactory.context().uriManager().getUriTranslationByHost("updates.edge.arista.com");
+        UriTranslation licenseUri = UvmContextFactory.context().uriManager().getUriTranslationByHost("license.edge.arista.com");
 
         String host = null;
         int port = 0;
         try {
             socket = new Socket();
-            host = updatesUri.getHost() != null ? updatesUri.getHost(): "updates.untangle.com";
+            host = updatesUri.getHost() != null ? updatesUri.getHost(): "updates.edge.arista.com";
             port = updatesUri.getPort() != -1 ? updatesUri.getPort() : 80;
             socket.connect(new InetSocketAddress(host, port), 7000);
         } catch (Exception e) {
@@ -289,7 +289,7 @@ public class NotificationManagerImpl implements NotificationManager
 
         try {
             socket = new Socket();
-            host = licenseUri.getHost() != null ? licenseUri.getHost(): "license.untangle.com";
+            host = licenseUri.getHost() != null ? licenseUri.getHost(): "license.edge.arista.com";
             port = licenseUri.getPort() != -1 ? licenseUri.getPort() : 443;
             socket.connect(new InetSocketAddress(host, port), 7000);
         } catch (Exception e) {
@@ -303,17 +303,17 @@ public class NotificationManagerImpl implements NotificationManager
     }
 
     /**
-     * This test that pyconnector is connected to cmd.untangle.com
+     * This test that pyconnector is connected to cmd.edge.arista.com
      * 
      * @param notificationList - the current list of notifications
      */
     private void testConnector(List<String> notificationList)
     {
-        UriTranslation cmdUri = UvmContextFactory.context().uriManager().getUriTranslationByHost("cmd.untangle.com");
+        UriTranslation cmdUri = UvmContextFactory.context().uriManager().getUriTranslationByHost("cmd.edge.arista.com");
 
         String host = null;
         try {
-            host = cmdUri.getHost() != null ? cmdUri.getHost(): "cmd.untangle.com";
+            host = cmdUri.getHost() != null ? cmdUri.getHost(): "cmd.edge.arista.com";
             if (UvmContextFactory.context().isDevel()) return;
             if (!UvmContextFactory.context().systemManager().getSettings().getCloudEnabled()) return;
 

--- a/uvm/impl/com/untangle/uvm/UriManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/UriManagerImpl.java
@@ -242,63 +242,63 @@ public class UriManagerImpl implements UriManager
         LinkedList<UriTranslation> uriTranslations = new LinkedList<>();
 
         UriTranslation uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://ids.untangle.com/suricatasignatures.tar.gz");
+        uriTranslation.setUri("https://ids.edge.arista.com/suricatasignatures.tar.gz");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://labs.untangle.com/Utility/v1/mac");
+        uriTranslation.setUri("https://labs.edge.arista.com/Utility/v1/mac");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://auth-relay.untangle.com/callback.php");
+        uriTranslation.setUri("https://auth-relay.edge.arista.com/callback.php");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://auth.untangle.com/v1/CheckTokenAccess");
+        uriTranslation.setUri("https://auth.edge.arista.com/v1/CheckTokenAccess");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://telemetry.untangle.com/ngfw/v1/infection");
+        uriTranslation.setUri("https://telemetry.edge.arista.com/ngfw/v1/infection");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("http://updates.untangle.com/");
+        uriTranslation.setUri("http://updates.edge.arista.com/");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://cmd.untangle.com/");
+        uriTranslation.setUri("https://cmd.edge.arista.com/");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://license.untangle.com/license.php");
+        uriTranslation.setUri("https://license.edge.arista.com/license.php");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://classify.untangle.com/v1/md5s");
+        uriTranslation.setUri("https://classify.edge.arista.com/v1/md5s");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("http://bd.untangle.com/");
+        uriTranslation.setUri("http://bd.edge.arista.com/");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://boxbackup.untangle.com/boxbackup/backup.php");
+        uriTranslation.setUri("https://boxbackup.edge.arista.com/boxbackup/backup.php");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://boxbackup.untangle.com/api/index.php");
+        uriTranslation.setUri("https://boxbackup.edge.arista.com/api/index.php");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://downloads.untangle.com/download.php");
+        uriTranslation.setUri("https://downloads.edge.arista.com/download.php");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("http://translations.untangle.com/");
+        uriTranslation.setUri("http://translations.edge.arista.com/");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://queue.untangle.com/");
+        uriTranslation.setUri("https://queue.edge.arista.com/");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
@@ -309,7 +309,7 @@ public class UriManagerImpl implements UriManager
         // as a date-release for 15.0 and the update is not going to everyone, adding
         // multiple getXHots() will fail for those non-updated units.
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://supssh.untangle.com/");
+        uriTranslation.setUri("https://supssh.edge.arista.com/");
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
@@ -329,7 +329,7 @@ public class UriManagerImpl implements UriManager
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://auth-relay.untangle.com");
+        uriTranslation.setUri("https://auth-relay.edge.arista.com");
         uriTranslations.add(uriTranslation);
 
         settings.setUriTranslations(uriTranslations);

--- a/uvm/impl/com/untangle/uvm/UriManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/UriManagerImpl.java
@@ -302,7 +302,7 @@ public class UriManagerImpl implements UriManager
         uriTranslations.add(uriTranslation);
 
         uriTranslation = new UriTranslation();
-        uriTranslation.setUri("https://untangle.com/api/v1/appliance/OnSettingsUpdate");
+        uriTranslation.setUri("https://edge.arista.com/api/v1/appliance/OnSettingsUpdate");
         uriTranslations.add(uriTranslation);
 
         // On one hand, this is probably better handled as a host, but since this is being released

--- a/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/SetupContextImpl.java
+++ b/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/SetupContextImpl.java
@@ -207,7 +207,7 @@ public class SetupContextImpl implements UtJsonRpcServlet.SetupContext
             json.put("remote", getRemote());
             json.put("remoteUrl", this.context.getCmdUrl());
             json.put("serverUID", this.context.getServerUID());
-            json.put("licenseTestUrl", this.context.uriManager().getUriWithPath("https://www.edge.arista.com/favicon.ico"));
+            json.put("licenseTestUrl", this.context.uriManager().getUriWithPath("https://edge.arista.com/favicon.ico"));
 
         } catch (Exception e) {
             logger.error("Error generating WebUI startup object", e);

--- a/virus-blocker-base/src/com/untangle/app/virus_blocker/VirusCloudFeedback.java
+++ b/virus-blocker-base/src/com/untangle/app/virus_blocker/VirusCloudFeedback.java
@@ -23,7 +23,7 @@ public class VirusCloudFeedback extends Thread
 {
     private final Logger logger = LogManager.getLogger(VirusBlockerBaseApp.class);
 
-    private static final String CLOUD_FEEDBACK_URL = UvmContextFactory.context().uriManager().getUri("https://telemetry.untangle.com/ngfw/v1/infection");
+    private static final String CLOUD_FEEDBACK_URL = UvmContextFactory.context().uriManager().getUri("https://telemetry.edge.arista.com/ngfw/v1/infection");
     private static final String CLOUD_SCANNER_KEY = "B132C885-962B-4D63-8B2F-441B7A43CD93";
 
     VirusBlockerState virusState = null;

--- a/virus-blocker-base/src/com/untangle/app/virus_blocker/VirusCloudScanner.java
+++ b/virus-blocker-base/src/com/untangle/app/virus_blocker/VirusCloudScanner.java
@@ -23,7 +23,7 @@ public class VirusCloudScanner extends Thread
 {
     private final Logger logger = LogManager.getLogger(VirusBlockerBaseApp.class);
 
-    private static final String CLOUD_SCANNER_URL = "https://classify.untangle.com/v1/md5s";
+    private static final String CLOUD_SCANNER_URL = "https://classify.edge.arista.com/v1/md5s";
     private static final String CLOUD_SCANNER_KEY = "B132C885-962B-4D63-8B2F-441B7A43CD93";
     private static final String EICAR_TEST_MD5 = "44d88612fea8a8f36de82e1278abb02f";
 

--- a/virus-blocker-lite/js/view/Status.js
+++ b/virus-blocker-lite/js/view/Status.js
@@ -20,7 +20,7 @@ Ext.define('Ung.apps.virusblockerlite.view.Status', {
                 '<h3>Virus Blocker Lite</h3>' +
                 '<p>' + 'Virus Blocker Lite provides basic virus protection and can be resource intensive in some environments.'.t() +
                 '<br><br>' + 'Upgrade to Virus Blocker which efficiently leverages signatures from Bitdefender&reg, the leader in speed and efficiency, whose threat lab experts work 24-hours a day, 365-days a year to identify emerging threats.'.t() +
-                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.untangle.com/shop/virus-blocker') + '">LEARN MORE<a/></p>'
+                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.edge.arista.com/shop/virus-blocker') + '">LEARN MORE<a/></p>'
         }, {
             xtype: 'appstate',
         }, {

--- a/virus-blocker-lite/js/view/Status.js
+++ b/virus-blocker-lite/js/view/Status.js
@@ -20,7 +20,7 @@ Ext.define('Ung.apps.virusblockerlite.view.Status', {
                 '<h3>Virus Blocker Lite</h3>' +
                 '<p>' + 'Virus Blocker Lite provides basic virus protection and can be resource intensive in some environments.'.t() +
                 '<br><br>' + 'Upgrade to Virus Blocker which efficiently leverages signatures from Bitdefender&reg, the leader in speed and efficiency, whose threat lab experts work 24-hours a day, 365-days a year to identify emerging threats.'.t() +
-                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.edge.arista.com/shop/virus-blocker') + '">LEARN MORE<a/></p>'
+                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://edge.arista.com/shop/virus-blocker') + '">LEARN MORE<a/></p>'
         }, {
             xtype: 'appstate',
         }, {

--- a/wan-failover/hier/usr/share/untangle/bin/wan-failover-dns-test.sh
+++ b/wan-failover/hier/usr/share/untangle/bin/wan-failover-dns-test.sh
@@ -3,7 +3,7 @@
 . @PREFIX@/usr/share/untangle/bin/wan-failover-test.sh $@
 
 DNS_SERVER=$4
-HOSTNAME="www.untangle.com"
+HOSTNAME="www.edge.arista.com"
 
 if [ -z "$DNS_SERVER" ] || [ "${DNS_SERVER}x" = "0.0.0.0x" ] ; then
     # extract DNS server for this interface from the dnsmasq.conf file

--- a/wan-failover/hier/usr/share/untangle/bin/wan-failover-dns-test.sh
+++ b/wan-failover/hier/usr/share/untangle/bin/wan-failover-dns-test.sh
@@ -3,7 +3,7 @@
 . @PREFIX@/usr/share/untangle/bin/wan-failover-test.sh $@
 
 DNS_SERVER=$4
-HOSTNAME="www.edge.arista.com"
+HOSTNAME="edge.arista.com"
 
 if [ -z "$DNS_SERVER" ] || [ "${DNS_SERVER}x" = "0.0.0.0x" ] ; then
     # extract DNS server for this interface from the dnsmasq.conf file

--- a/web-monitor/js/view/Status.js
+++ b/web-monitor/js/view/Status.js
@@ -20,7 +20,7 @@ Ext.define('Ung.apps.webmonitor.view.Status', {
                 '<h3>Web Monitor</h3>' +
                 '<p>' + 'Web Monitor scans and categorizes web traffic to monitor network usage.'.t() +
                 '<br><br>' + 'Upgrade to Web Filter to control network usage and enforce policies that allow, block, flag or alert web traffic.'.t() +
-                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.edge.arista.com/shop/web-filter') + '">LEARN MORE<a/></p>'
+                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://edge.arista.com/shop/web-filter') + '">LEARN MORE<a/></p>'
         }, {
             xtype: 'applicense',
             hidden: true,

--- a/web-monitor/js/view/Status.js
+++ b/web-monitor/js/view/Status.js
@@ -20,7 +20,7 @@ Ext.define('Ung.apps.webmonitor.view.Status', {
                 '<h3>Web Monitor</h3>' +
                 '<p>' + 'Web Monitor scans and categorizes web traffic to monitor network usage.'.t() +
                 '<br><br>' + 'Upgrade to Web Filter to control network usage and enforce policies that allow, block, flag or alert web traffic.'.t() +
-                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.untangle.com/shop/web-filter') + '">LEARN MORE<a/></p>'
+                ' <a target="_blank" href="' + rpc.uriManager.getUriWithPath('https://www.edge.arista.com/shop/web-filter') + '">LEARN MORE<a/></p>'
         }, {
             xtype: 'applicense',
             hidden: true,


### PR DESCRIPTION
**Changes:** Replaced references to untangle domains with Arista domain.
[Servers and Domains](https://awakesecurity.atlassian.net/wiki/spaces/IT/pages/2830860307/Servers+Domains+Certificates+IPs)