### PR TITLE
ngfw-15005 Wireguard Tunnels from Cloud should be Non-Editable

### DIFF
--- a/uvm/api/com/untangle/uvm/util/Constants.java
+++ b/uvm/api/com/untangle/uvm/util/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
     public static final String DOT = ".";
     public static final String UNDERSCORE = "_";
     public static final String SPACE = " ";
+    public static final String COMMA_STRING = ",";
 
     public static final String EQUALS_TO = "=";
 

--- a/uvm/js/common/ungrid/Grid.js
+++ b/uvm/js/common/ungrid/Grid.js
@@ -334,6 +334,10 @@ Ext.define('Ung.cmp.Grid', {
                         menuDisabled: true,
                         hideable: false,
                         isDisabled: function (table, rowIndex, colIndex, item, record) {
+                            // NGFW-15005 Wireguard VPN Tunnels pushed from cloud should be readonly
+                            if (record.data.javaClass === 'com.untangle.app.wireguard_vpn.WireGuardVpnTunnel') {
+                                return record.data.description.startsWith('CCTunnel');
+                            }
                             return record.get('readOnly') || table.up('grid').getController().isRecordRestricted(record) || false;
                         }
                     };

--- a/uvm/servlets/admin/app/overrides/form/field/VTypes.js
+++ b/uvm/servlets/admin/app/overrides/form/field/VTypes.js
@@ -24,7 +24,8 @@ Ext.define('Ung.overrides.form.field.VTypes', {
     },
 
     isSinglePortValid: function(val) {
-        val = val.trim();
+        if (typeof val === "string")
+            val = val.trim();
         /* check for values between 0 and 65536 */
         if (val < 1 || val > 65535) { return false; }
         /* verify its an integer (not a float) */

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnApp.java
@@ -32,6 +32,7 @@ import com.untangle.uvm.vnet.Fitting;
 import com.untangle.uvm.vnet.PipelineConnector;
 import com.untangle.uvm.network.InterfaceStatus;
 import com.untangle.uvm.network.NetworkSettings;
+import com.untangle.uvm.util.Constants;
 import com.untangle.uvm.util.I18nUtil;
 import com.untangle.uvm.network.NatRule;
 import com.untangle.uvm.network.NatRuleCondition;
@@ -153,6 +154,10 @@ public class WireGuardVpnApp extends AppBase
             if(tunnel.getPublicKey().equals("")){
                 tunnel.setPrivateKey(this.WireGuardVpnManager.createPrivateKey());
                 tunnel.setPublicKey(this.WireGuardVpnManager.getPublicKey(tunnel.getPrivateKey()));
+            }
+            // For tunnels pushed from ETM save the networks in NGFW format i.e. line seperated
+            if(tunnel.getDescription().startsWith("CCTunnel") && tunnel.getNetworks().contains(Constants.COMMA_STRING)) {
+                tunnel.setNetworks(tunnel.getNetworks().replaceAll(Constants.COMMA_STRING, Constants.NEW_LINE));
             }
         }
 


### PR DESCRIPTION
**Changes:** 
1. Disabled edit option for tunnels pushed from cloud.
2. Remote Networks are pushed with comma separated values for two or more networks. In NGFW we render and process those values considering line separated values. Modified `setSettings` API to handle this.
3. Resolved import validation bug in `VType` `isSinglePortValid`

**Local Testing:**
Tunnels description starting with `CCTunnel` will be non-editable. 
All values can be seen with inline grid view. User can enable and disable tunnel using inline checkbox.

![Screenshot from 2025-02-11 12-36-46](https://github.com/user-attachments/assets/def5f7b6-8fad-4d1e-af8e-2e1b83bda71c)


Tunnel networks will be stored with new line sepearator.

![Screenshot from 2025-02-11 12-38-53](https://github.com/user-attachments/assets/2db8ad1e-a605-461a-86f5-ec33d6a6144a)
