### PR TITLE
NGFW-15040 Reverting to old cipher conf for openvpn

### DIFF
--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
@@ -611,8 +611,7 @@ public class OpenVpnManager
     private void buildCommonConfiguration(OpenVpnSettings settings, StringBuilder sb) {
         sb.append("proto" + SPACE).append(settings.getProtocol()).append(LINE_BREAK);
         sb.append("port" + SPACE).append(settings.getPort()).append(LINE_BREAK);
-        sb.append("data-ciphers" + SPACE).append(settings.getCipher()).append(LINE_BREAK);
-        sb.append("data-ciphers-fallback" + SPACE).append(settings.getCipher()).append(LINE_BREAK);
+        sb.append("cipher" + SPACE).append(settings.getCipher()).append(LINE_BREAK);
     }
 
     /**


### PR DESCRIPTION
- Reverting to old `cipher` configuration for OpenVPN for older client support.