### PR TITLE
ngfw-14891 changed regex to get http status in upload backup script

### DIFF
--- a/configuration-backup/hier/usr/share/untangle/bin/configuration-backup-upload-backup.sh
+++ b/configuration-backup/hier/usr/share/untangle/bin/configuration-backup-upload-backup.sh
@@ -67,7 +67,7 @@ function doHelp() {
 # (is that "continue?) then a "404", so we choose the *last*
 # response code as the status.
 function getHTTPStatus() {
-  cat ${1} | sed -n "/HTTP\/1.1/ p" | awk '{ print $2; }' | tail -1
+  sed -n -E '/^HTTP\/[0-9]\.?[0-9]? [0-9]+/p' "$1" | awk '{ print $2; }' | tail -1
 }
 
 


### PR DESCRIPTION
**Changes:**
Modified `getHTTPStatus` method in `configuration-backup-upload-backup.sh` file to support HTTP 1.1 and HTTP 2 responses.
This regex will support all HTTP versions in format `HTTP/{v}` and `HTTP/{v.*}` [v in range (0,9)]

**Local Testing:**
Tested the debug statements in `configuration-backup-upload-backup.sh` using debug mode.
Tested the command with different HTTP version response
![Screenshot from 2025-02-27 11-19-39](https://github.com/user-attachments/assets/45b60857-a3d5-4169-b8b0-754f09eaa0bb)
