### PR TITLE
NGFW-14986: Captive Network Assistant for iOS does not work with Google Authentication

### DIFF
--- a/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalSSLEngine.java
+++ b/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalSSLEngine.java
@@ -102,6 +102,8 @@ public class CaptivePortalSSLEngine extends SslEngineBase
                 if ((item.provider.equals("google")) && ((authType == CaptivePortalSettings.AuthenticationType.GOOGLE) || (authType == CaptivePortalSettings.AuthenticationType.ANY_OAUTH))) {
                     if (item.match.equals("full") && sniHostname.toLowerCase().equals(item.name)) allowed = true;
                     if (item.match.equals("end") && sniHostname.toLowerCase().endsWith(item.name)) allowed = true;
+                    //In some case accounts.google.co. is also getting hit after google auth flow
+                    if (item.match.equals("end") && sniHostname.toLowerCase().startsWith("accounts.google.co.")) allowed = true;
                 }
 
                 // check PROVIDER = facebook

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
@@ -619,6 +619,8 @@ public class SslInspectorParserEventHandler extends AbstractEventHandler
                 if ((item.provider.equals("google")) && ((captureFlag == "GOOGLE") || (captureFlag == "ANY_OAUTH"))) {
                     if (item.match.equals("full") && sniHostname.toLowerCase().equals(item.name)) allowed = true;
                     if (item.match.equals("end") && sniHostname.toLowerCase().endsWith(item.name)) allowed = true;
+                    //in some case accounts.google.co. is also getting hit after google auth flow
+                    if (item.match.equals("end") && sniHostname.toLowerCase().startsWith("accounts.google.co.")) allowed = true;
                 }
 
                 // check PROVIDER = facebook

--- a/uvm/hier/usr/share/untangle/conf/ut-oauth.conf
+++ b/uvm/hier/usr/share/untangle/conf/ut-oauth.conf
@@ -30,6 +30,7 @@ all|full|connectivitycheck.gstatic.com
 google|full|accounts.google.com
 google|full|ssl.gstatic.com
 google|full|www.gstatic.com
+google|end|accounts.google.co.
 
 # These domains are required for Facebook OAuth
 facebook|full|m.facebook.com


### PR DESCRIPTION
During debugging the issue, google auth accounts.google.co.<country code> was also seen  it was showing 400 error code, but internet was working. Presently have whitelisted in captive portal and ssl handler. As the country can be variable have added logic to check for startsWith method.
Error Screenshot
![PHOTO-2025-03-04-17-51-13](https://github.com/user-attachments/assets/ef41ed96-9b9e-4a36-a678-43e390a9f099)


Details of the whole issue in
https://awakesecurity.atlassian.net/browse/NGFW-14986