### PR TITLE
NGFW-15042: UI :Option to force dynamic DNS updates to a specific WAN

### DIFF
--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -47,7 +47,7 @@ public class NetworkSettings implements Serializable, JSONString
     private String  dynamicDnsServicePassword = null;
     private String  dynamicDnsServiceZone = null;
     private String  dynamicDnsServiceHostnames = null;
-    private String  dynamicDnsServiceWan = "None";
+    private String  dynamicDnsServiceWan = "Default";
     private boolean enableSipNatHelper = false;
     private boolean sendIcmpRedirects = true;
     private boolean blockInvalidPackets = true;

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -47,7 +47,7 @@ public class NetworkSettings implements Serializable, JSONString
     private String  dynamicDnsServicePassword = null;
     private String  dynamicDnsServiceZone = null;
     private String  dynamicDnsServiceHostnames = null;
-
+    private String  dynamicDnsServiceWan = "None";
     private boolean enableSipNatHelper = false;
     private boolean sendIcmpRedirects = true;
     private boolean blockInvalidPackets = true;
@@ -128,6 +128,9 @@ public class NetworkSettings implements Serializable, JSONString
 
     public String getDynamicDnsServiceName() { return this.dynamicDnsServiceName; }
     public void setDynamicDnsServiceName( String newValue ) { this.dynamicDnsServiceName = newValue; }
+
+    public String getDynamicDnsServiceWan() { return this.dynamicDnsServiceWan; }
+    public void setDynamicDnsServiceWan( String newValue ) { this.dynamicDnsServiceWan = newValue; }
 
     public String getDynamicDnsServiceUsername() { return this.dynamicDnsServiceUsername; }
     public void setDynamicDnsServiceUsername( String newValue ) { this.dynamicDnsServiceUsername = newValue; }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -27,6 +27,7 @@ import com.untangle.uvm.network.DnsSettings;
 import com.untangle.uvm.network.DhcpStaticEntry;
 import com.untangle.uvm.network.DhcpRelay;
 import com.untangle.uvm.network.UpnpSettings;
+import com.untangle.uvm.network.InterfaceSettings.ConfigType;
 import com.untangle.uvm.network.UpnpRule;
 import com.untangle.uvm.network.UpnpRuleCondition;
 import com.untangle.uvm.network.NetflowSettings;
@@ -1343,6 +1344,9 @@ public class NetworkManagerImpl implements NetworkManager
          * This never makes sense if the netmasks are equal
          */
         for ( InterfaceSettings intf1 : networkSettings.getInterfaces() ) {
+            if(intf1.getConfigType() == InterfaceSettings.ConfigType.DISABLED && intf1.getName().equals(networkSettings.getDynamicDnsServiceWan())){
+                throw new RuntimeException("This WAN is used by the DDNS service. Please change the WAN from the DDNS configuration before disabling this WAN.");
+            }
             if ( intf1.getConfigType() != InterfaceSettings.ConfigType.ADDRESSED )
                 continue;
             if ( intf1.getV4ConfigType() != InterfaceSettings.V4ConfigType.STATIC )

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -128,6 +128,9 @@ Ext.define('Ung.config.network.Interface', {
                         if (newValue === 'BRIDGED' && win.getViewModel().get('intf.isWirelessInterface')) { // in case of Wireless interface
                             win.down('tabpanel').setActiveItem(2);
                         }
+                        if (newValue === 'DISABLED' && win.getViewModel().data.intf.data.name === win.getViewModel().linkData.settings.dynamicDnsServiceWan) {
+                            return Ext.MessageBox.alert('Warning'.t(), 'This WAN is used by the DDNS service. Please change the WAN from the DDNS configuration before disabling this WAN.'.t());
+                    }                    
                     }
                 }
             }, {

--- a/uvm/servlets/admin/config/network/Main.js
+++ b/uvm/servlets/admin/config/network/Main.js
@@ -17,7 +17,15 @@ Ext.define('Ung.config.network.Main', {
     controller: 'config-network',
 
     viewModel: {
-        type: 'config-network'
+        type: 'config-network',
+        data: {
+            allWanInterfaceNames: [],
+        },
+        stores: {
+            allWanInterfaceNamesStore: {
+                data: '{allWanInterfaceNames}',
+            },
+        },
     },
 
     // tabPosition: 'left',

--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -850,7 +850,7 @@ Ext.define('Ung.config.network.MainController', {
         var vm = this.getViewModel();
         var enabledWanname = [];
         var interfaces = Rpc.directData('rpc.networkManager.getEnabledInterfaces');
-        enabledWanname.push("None");
+        enabledWanname.push("Default");
 
         interfaces.list.forEach( function(intf){
             if(intf["isWan"] == true){

--- a/uvm/servlets/admin/config/network/MainController.js
+++ b/uvm/servlets/admin/config/network/MainController.js
@@ -49,7 +49,9 @@ Ext.define('Ung.config.network.MainController', {
         },
         '#troubleshooting #troubleshooting': {
             beforetabchange: Ung.controller.Global.onBeforeSubtabChange
-        }
+        },'#hostname': {
+            activate: 'getEnableInterfaceNames'
+        },
     },
 
     validateRange: function () {
@@ -147,6 +149,21 @@ Ext.define('Ung.config.network.MainController', {
         if (interfacesStore.getModifiedRecords().length > 0 ||
             interfacesStore.getNewRecords().length > 0 ||
             interfacesStore.getRemovedRecords().length > 0) {
+                for (var i =0 ; i < interfacesStore.getRemovedRecords().length; i++) {
+                    if(interfacesStore.getRemovedRecords()[i].data.name === vm.get('settings').dynamicDnsServiceWan){
+                        Ext.MessageBox.alert("Failed".t(), "This WAN is used by the DDNS service. Please change the WAN from the DDNS configuration before removing this WAN.".t());
+                        view.setLoading(false);
+                        return;
+                    }
+                }
+                for ( i =0 ; i < interfacesStore.getModifiedRecords().length; i++) {
+                    if((interfacesStore.getModifiedRecords()[i].data.name === vm.get('settings').dynamicDnsServiceWan) && interfacesStore.getModifiedRecords()[i].data.configType === "DISABLED"){
+                        Ext.MessageBox.alert("Failed".t(), "This WAN is used by the DDNS service. Please change the WAN from the DDNS configuration before disabling this WAN.".t());
+                        view.setLoading(false);
+                        return;
+                    }
+                }
+                
             vm.set('settings.interfaces.list', Ext.Array.pluck(interfacesStore.getRange(), 'data'));
         }
 
@@ -827,6 +844,20 @@ Ext.define('Ung.config.network.MainController', {
         exportForm.gridData.value = this.getExportData(false);
         exportForm.submit();
         Ext.MessageBox.hide();
+    },
+
+    getEnableInterfaceNames: function () {
+        var vm = this.getViewModel();
+        var enabledWanname = [];
+        var interfaces = Rpc.directData('rpc.networkManager.getEnabledInterfaces');
+        enabledWanname.push("None");
+
+        interfaces.list.forEach( function(intf){
+            if(intf["isWan"] == true){
+                enabledWanname.push(intf["name"]);
+            }
+        });
+        vm.set('allWanInterfaceNames', enabledWanname);
     },
 
 

--- a/uvm/servlets/admin/config/network/view/Hostname.js
+++ b/uvm/servlets/admin/config/network/view/Hostname.js
@@ -116,6 +116,14 @@ Ext.define('Ung.config.network.view.Hostname', {
             xtype: 'textfield',
             fieldLabel: 'Hostname(s)'.t(),
             bind: '{settings.dynamicDnsServiceHostnames}',
+        },{
+            xtype: 'combo',
+            editable: false,
+            fieldLabel: 'Interface'.t(),
+            bind: {
+                store : '{allWanInterfaceNames}',
+                value: '{settings.dynamicDnsServiceWan}',
+            }
         }]
     }, {
         xtype: 'radiogroup',


### PR DESCRIPTION
**Requirement**: As an admin managing an NGFW with multiple WANs, I need to choose which WAN is associated with my Dynamic DNS service to ensure that the IP address always resolves to my preferred WAN.

**Implementation**: 
- UI changes to add new field for DDNS  configuration it will show only the WAN interfaces which is currently enabled.
![image](https://github.com/user-attachments/assets/cbee3558-be89-4bf3-a02b-5300ee06e397)
![image](https://github.com/user-attachments/assets/ba387716-aa78-4b01-a888-8d89d7927d34)

**Validations**:
1- If user try to disable the WAN which is currently used by DDNS config
![Screenshot from 2025-03-05 22-25-58](https://github.com/user-attachments/assets/849a7a16-b8ce-439f-98db-a512b862e51e)

       - User will get an warning in UI 
       
![Screenshot from 2025-03-05 22-26-29](https://github.com/user-attachments/assets/ac9f4f3f-98a6-4a7b-9896-845fc1b52c80)

       - If user tried to save the same setting
       
![Screenshot from 2025-03-05 22-26-52](https://github.com/user-attachments/assets/b2c0e4b7-4b98-47e9-9a85-710a3a63dfb8)

2- If user try to delete the WAN which is currently used by DDNS config and save the settings below error will be shown
![Screenshot from 2025-03-05 22-29-57](https://github.com/user-attachments/assets/1a99bf3a-e42b-4044-90d1-6767f4b0a9a6)
![Screenshot from 2025-03-05 22-30-15](https://github.com/user-attachments/assets/32e89f49-422b-4c05-966b-9f434d6ba211)

Sync-Setting PR : https://github.com/untangle/sync-settings/pull/2044
