### PR TITLE
ngfw-15044 add secondary dhcp addresses in openvpn config

### DIFF
--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
@@ -589,13 +589,42 @@ public class OpenVpnManager
         sb.append("remote" + SPACE).append(publicAddress).append(SPACE).append(settings.getPort()).append(" # public address \n");
 
         /**
-         * Also write the static IP of any static WANs This will be used as a
+         * Also write the static IP of any static WANs and DHCP IP of 
+         * any non publicAddress DHCP WANs This will be used as a
          * backup if publicAddress fails or is wrong. This will help for
-         * multi-WAN failover Bug #10828
+         * multi-WAN failover Bug #10828 and NGFW-15044
          */
         NetworkSettings networkSettings = UvmContextFactory.context().networkManager().getNetworkSettings();
         for (InterfaceSettings interfaceSettings : networkSettings.getInterfaces()) {
-            if (interfaceSettings.getIsWan() && interfaceSettings.getV4ConfigType() == InterfaceSettings.V4ConfigType.STATIC) sb.append("remote" + SPACE).append(interfaceSettings.getV4StaticAddress().getHostAddress()).append(SPACE).append(settings.getPort()).append(" # static WAN ").append(interfaceSettings.getInterfaceId()).append(LINE_BREAK);
+            if (interfaceSettings.getIsWan() && 
+                interfaceSettings.getV4ConfigType() == InterfaceSettings.V4ConfigType.STATIC) {
+                    
+                sb.append("remote ")
+                .append(interfaceSettings.getV4StaticAddress().getHostAddress())
+                .append(SPACE)
+                .append(settings.getPort())
+                .append(" # static WAN ")
+                .append(interfaceSettings.getInterfaceId())
+                .append(LINE_BREAK);
+            }
+            if (interfaceSettings.getIsWan() && 
+                interfaceSettings.getV4ConfigType() == InterfaceSettings.V4ConfigType.AUTO) {
+
+                InetAddress dhcpWanAddress = UvmContextFactory.context()
+                    .networkManager()
+                    .getInterfaceStatus(interfaceSettings.getInterfaceId())
+                    .getV4Address();
+
+                if (dhcpWanAddress != null && !dhcpWanAddress.getHostAddress().equals(publicAddress)) {
+                    sb.append("remote ")
+                    .append(dhcpWanAddress.getHostAddress())
+                    .append(SPACE)
+                    .append(settings.getPort())
+                    .append(" # DHCP WAN ")
+                    .append(interfaceSettings.getInterfaceId())
+                    .append(LINE_BREAK);
+                }
+            }
         }
 
         File dir = new File(CLIENT_CONF_FILE_DIR);


### PR DESCRIPTION
**Changes:** 
Writing the IP of any non `publicAddress` DHCP WANs in client config files.
This will be used as a backup if `publicAddress` fails or is wrong.

**Local Testing:**
For interfaces setup as shown below 
![image](https://github.com/user-attachments/assets/41ae7206-818a-4c0d-93be-726fe77d9e32)

the ovpn client configuration file would look like as shown in below screenshot if `publicAddress` equals `firstWanAddress`
![Screenshot from 2025-03-06 17-30-04](https://github.com/user-attachments/assets/2e77127e-db31-4f82-899f-b499f351aad6)

else it would consider `firstWanAddress` as a DHCP WAN and add it explicitly in config as shown below.
![Screenshot from 2025-03-06 17-35-42](https://github.com/user-attachments/assets/d73b9c36-e5a3-47c2-b11c-c02f5fb52778)

Same change is applicable for all client configuration files (i.e. `.conf`, `.ovpn`, `.zip` ) 