### PR TITLE
ngfw-15053 refactored code to write remote server option in openvpn client config files

### DIFF
--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
@@ -596,34 +596,18 @@ public class OpenVpnManager
          */
         NetworkSettings networkSettings = UvmContextFactory.context().networkManager().getNetworkSettings();
         for (InterfaceSettings interfaceSettings : networkSettings.getInterfaces()) {
-            if (interfaceSettings.getIsWan() && 
-                interfaceSettings.getV4ConfigType() == InterfaceSettings.V4ConfigType.STATIC) {
-                    
-                sb.append("remote ")
-                .append(interfaceSettings.getV4StaticAddress().getHostAddress())
-                .append(SPACE)
-                .append(settings.getPort())
-                .append(" # static WAN ")
-                .append(interfaceSettings.getInterfaceId())
-                .append(LINE_BREAK);
-            }
-            if (interfaceSettings.getIsWan() && 
-                interfaceSettings.getV4ConfigType() == InterfaceSettings.V4ConfigType.AUTO) {
-
-                InetAddress dhcpWanAddress = UvmContextFactory.context()
-                    .networkManager()
-                    .getInterfaceStatus(interfaceSettings.getInterfaceId())
-                    .getV4Address();
-
-                if (dhcpWanAddress != null && !dhcpWanAddress.getHostAddress().equals(publicAddress)) {
-                    sb.append("remote ")
-                    .append(dhcpWanAddress.getHostAddress())
-                    .append(SPACE)
-                    .append(settings.getPort())
-                    .append(" # DHCP WAN ")
-                    .append(interfaceSettings.getInterfaceId())
-                    .append(LINE_BREAK);
+            if (interfaceSettings.getIsWan()) {
+                String remoteAddress = null;
+                if (interfaceSettings.getV4ConfigType() == InterfaceSettings.V4ConfigType.STATIC) {
+                    remoteAddress = interfaceSettings.getV4StaticAddress().getHostAddress();
+                } else if (interfaceSettings.getV4ConfigType() == InterfaceSettings.V4ConfigType.AUTO) {
+                    InetAddress dhcpWanAddress = UvmContextFactory.context().networkManager().getInterfaceStatus( interfaceSettings.getInterfaceId() ).getV4Address();
+                    if (dhcpWanAddress != null && !dhcpWanAddress.getHostAddress().equals(publicAddress)) {
+                        remoteAddress = dhcpWanAddress.getHostAddress();
+                    }
                 }
+                if (remoteAddress != null)
+                    sb.append(String.format("remote %s %d # %s WAN %s%s", remoteAddress, settings.getPort(), interfaceSettings.getV4ConfigType(), interfaceSettings.getInterfaceId(), LINE_BREAK));
             }
         }
 


### PR DESCRIPTION
**Changes:** Refactored code to write remote option in openvpn client config files.

**Local Testing:**
For interfaces setup as shown below
![Screenshot from 2025-03-07 14-16-30](https://github.com/user-attachments/assets/943b6eb0-4c84-45e0-ad78-e6cb3f587472)

the ovpn client configuration file would look like as shown in below screenshot if publicAddress equals firstWanAddress
![Screenshot from 2025-03-07 14-16-57](https://github.com/user-attachments/assets/a66706bc-8599-4503-8686-2665d7c4049c)

else it would consider firstWanAddress as a DHCP WAN and add it explicitly in config as shown below.
![Screenshot from 2025-03-07 14-18-33](https://github.com/user-attachments/assets/18d7ed82-c482-4140-9081-61dbb359617a)
