### PR TITLE
NGFW-15050- handling the empty password scenario for PPPOE

### DIFF
--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -1792,7 +1792,12 @@ public class NetworkManagerImpl implements NetworkManager
                 intf.setV4PPPoERootDev(intf.getSystemDev());
                 intf.setSystemDev("ppp" + pppCount);
                 intf.setSymbolicDev("ppp" + pppCount);
-                if(intf.getV4PPPoEPassword() != null){
+                // Handle empty password by setting encrypted password to null, ensuring the secret file contains "None" as per current behavior.
+                if(intf.getV4PPPoEPassword() == null && intf.getV4PPPoEPasswordEncrypted() != null){
+                    intf.setV4PPPoEPasswordEncrypted(null);
+                }
+                // Set encrypted password for non-empty password value
+                if(intf.getV4PPPoEPassword() != null){ 
                     intf.setV4PPPoEPasswordEncrypted(PasswordUtil.getEncryptPassword(intf.getV4PPPoEPassword()));
                     intf.setV4PPPoEPassword(null);
                 }


### PR DESCRIPTION
**ISSUE** : In case of PPPOE we allow blank value as password while upgrading if the the password value set to None getting error while encryptedpassword as it was null at time of upgrade.

**FIX:** Update the code to handle the scenarios for blank password.

**Current Behaviour (17.3)**
When setting PPPOE password as blank, the first call sets pasword as empty strings in both the settings file and chap-secret. On subsequent setSettings calls, the empty fields are set to null in setting file and "None" in chap-secret. This is an existing bug, which will be addressed in a another story.

**Implemetation Behaviour (17.4)**
Same as 17.3 behaviour When setting PPPOE  password as blank, the first call sets password as empty strings in chap-secret and in the settings file v4PPPoEPassword set as null and we strore encrypted value in v4PPPoEPasswordEncrypted field. 
On subsequent setSettings calls, the empty fields set to "None" in chap-secret and in settings file both v4PPPoEPasswordEncrypted and  v4PPPoEPassword field is set as null.

**TESTING:**
**On Fresh Setup:**
- Test the pppoe connection with empty pppoe password it should connect for first settings call and chap-secret file will have "" value as password and in network.js file v4PPPoEPasswordEncrypted field should be present.
- Call set settings again, check pppoe connection is lost as per bug in 17.3 and in chap-secret file will have "None" value as password and in network.js file v4PPPoEPasswordEncrypted field should not be present.
- Do pppoe setup with non-empty password and check connection should be made properly and in chap-secret file actual password should be present and in settings file v4PPPoEPasswordEncrypted field should be present.

**On Upgrade:**
- Before upgrade set pppoe connection with empty password and set the settings. Check pppoe connection is working and now upgrade the system. 
It should upgraded successfully. PPPOE connection might get lost because of existing bug in 17.3.Check chap-secret file might contain "" or None value as passsword and v4PPPoEPasswordEncrypted value might present in settings file if value is chap-secret file contain "" else v4PPPoEPasswordEncrypted will not be present in settings file.
- Before upgrade set pppoe connection with the non-empty passowrd check pppoe connection should be form successfully. Now upgrade the system.
Check the pppoe connection should be working as expected and check the setting file it should contain v4PPPoEPasswordEncrypted field and chap-secret file must have actual password.


SYNC SETTINGS :https://github.com/untangle/sync-settings/pull/2058