### PR TITLE
NGFW-15055: License changes for SBL removal

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -139,7 +139,6 @@ Architecture: all
 Conflicts: untangle-node-spam-blocker
 Replaces: untangle-node-spam-blocker
 Provides: untangle-node-spam-blocker
-Section: non-free/net
 Depends: ${misc:Depends}, untangle-vm, untangle-base-spam-blocker, untangle-app-smtp, untangle-spamassassin-update
 Description: Spam Blocker
  The Spam Blocker application.

--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -464,8 +464,6 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
             oldName = BRANDING_MANAGER_OLDNAME; break;
         case License.VIRUS_BLOCKER:
             oldName = VIRUS_BLOCKER_OLDNAME; break;
-        case License.SPAM_BLOCKER:
-            oldName = SPAM_BLOCKER_OLDNAME; break;
         case License.WAN_FAILOVER:
             oldName = WAN_FAILOVER_OLDNAME; break;
         case License.IPSEC_VPN:
@@ -730,6 +728,10 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                      * Complete Meta-data
                      */
                     license = iterator.next();
+                    //From v17.4 we will not add spam-blocker-lite license list
+                    if(license.getDisplayName().equals("Spam Blocker Lite")){
+                        continue;
+                    }
                     _setValidAndStatus(license);
                     if (license.getValid() != null && !license.getValid()) {
                         logger.warn("Removing invalid license from list: " + license);

--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -728,10 +728,6 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                      * Complete Meta-data
                      */
                     license = iterator.next();
-                    //From v17.4 we will not add spam-blocker-lite license list
-                    if(license.getDisplayName().equals("Spam Blocker Lite")){
-                        continue;
-                    }
                     _setValidAndStatus(license);
                     if (license.getValid() != null && !license.getValid()) {
                         logger.warn("Removing invalid license from list: " + license);


### PR DESCRIPTION
Removed unwanted code for requestTrail and removing sbl license form license list.

**Expected license behaviour:** 
**On Previous version (17.3) :** 
- If user have any app spam-blocker or spam-blocker-lite, they should not get any error related to licnese.

**After Upgrade on 17.4:** 
- If user have spam-blocker-lite app in 17.3 then after upgrade this app will be removed and in license only the spam-blocker licnese should be visible.
- If user have spam-blocker app then after upgrade this app will use sapmassaian service instead of untangle-spamcatd and in license only the spam-blocker licnese should be visible.