### PR TITLE
NGFW-15047: iOS CNA browser cannot use Google oAuth

### DIFF
--- a/captive-portal/hier/usr/share/untangle/web/capture/authpage.html
+++ b/captive-portal/hier/usr/share/untangle/web/capture/authpage.html
@@ -14,6 +14,11 @@ input:-webkit-autofill {
 }
 </style>
 
+<script language="javascript">
+   var authConfig = { isEnabled : $.GOOGLEAUTH.$ } ;
+</script>
+
+
 <script type="text/javascript" src="/capture/secure.js"></script>
 
 <script language="javascript">
@@ -30,7 +35,7 @@ input:-webkit-autofill {
 
 <div class="form-login" style="padding: 15px;">
     <h2>$.WelcomeText.$</h2>
-    <p style="text-align: center; font-weight: bold; margin: 20px 0;">$.MessageText.$</p>
+    <p style="id="connect-message" ; text-align: center; font-weight: bold; margin: 20px 0;">$.MessageText.$</p>
     <form autocomplete="off" method="post" action="/capture/handler.py/authpost">
         <input name="method" id="method" type="hidden" value="$.method.$" />
         <input name="nonce" id="nonce" type="hidden" value="$.nonce.$" />

--- a/captive-portal/hier/usr/share/untangle/web/capture/handler.py
+++ b/captive-portal/hier/usr/share/untangle/web/capture/handler.py
@@ -431,6 +431,11 @@ def generate_page(req,captureSettings,args,extra='',page=None,template_name=None
     else:
         page = replace_marker(page,'$.SecureEndpointCheck.$','')
 
+
+    is_google_auth = "false"
+    if (captureSettings.get("authenticationType") == 'GOOGLE'):
+        is_google_auth = "true"
+    page = replace_marker(page,'$.GOOGLEAUTH.$', is_google_auth)
     if (captureSettings.get('pageType') == 'BASIC_LOGIN'):
         page = replace_marker(page,'$.CompanyName.$', captureSettings.get('companyName'))
         page = replace_marker(page,'$.PageTitle.$', captureSettings.get('basicLoginPageTitle'))

--- a/captive-portal/hier/usr/share/untangle/web/capture/infopage.html
+++ b/captive-portal/hier/usr/share/untangle/web/capture/infopage.html
@@ -11,6 +11,11 @@
 /* ]]> */
 </style>
 
+<script language="javascript">
+   var authConfig = { isEnabled : $.GOOGLEAUTH.$ } ;
+</script>
+
+
 <script type="text/javascript" src="/capture/secure.js"></script>
 
 <script language="javascript">

--- a/captive-portal/hier/usr/share/untangle/web/capture/secure.js
+++ b/captive-portal/hier/usr/share/untangle/web/capture/secure.js
@@ -75,3 +75,94 @@ function checkSecureEndpoint(isRequired) {
     img.onabort = (isRequired ? onRequireFailure : onCheckFailure);
     img.src = 'https://' + getServer() + '/images/BrandingLogo.png';
 }
+
+
+function isCaptivePortal() {
+    var userAgent = navigator.userAgent.toLowerCase();
+    if( userAgent.includes("chrome") || userAgent.includes("safari") )  {
+       return false;
+
+    }
+
+    // Captive portals restrict navigation and lack history navigation.
+    return !(window.history.length > 1 || window.opener || window.location.hash || document.referrer);
+}
+
+function addBrowserInstructions() {
+
+    var userAgent = navigator.userAgent.toLowerCase();
+    var isIOS = /iphone|ipad|ipod/.test(userAgent);
+
+    if (isIOS && isCaptivePortal()) {
+        // Hide Continue button and checkbox
+        var continueButton = document.querySelector("button[name='submit']");
+        var checkbox = document.querySelector("input[name='agree']");
+        var connectMessage = document.querySelector("p[style*='text-align: center'][style*='font-weight: bold']");
+        if (connectMessage) connectMessage.style.display = "none";
+
+        // Hide the "Clicking here means you agree to the terms above." checkbox label
+        var agreementLabel = document.querySelector("label");
+
+        if (agreementLabel) agreementLabel.style.display = "none";
+        if (continueButton) continueButton.style.display = "none";
+        if (checkbox) checkbox.style.display = "none";
+
+        var container = document.createElement("div");
+        container.id = "browser-instructions";
+        container.style.textAlign = "center";
+        container.style.padding = "15px";
+        container.style.margin = "20px auto";
+        container.style.width = "90%";
+        container.style.maxWidth = "400px";
+        container.style.borderRadius = "10px";
+        container.style.backgroundColor = "#E0E0E0"; /* Soft grey background to match parent */
+        container.style.boxShadow = "0px 4px 6px rgba(0, 0, 0, 0.1)";
+        container.innerHTML = `
+            <h3 style="font-size: 14px; font-weight: bold; color: #666; text-align: left; margin-bottom: 12px;">
+                Your browser is not supported.
+            </h3>
+            <p style="font-size: 14px; color: #666; text-align: left; margin-bottom: 15px; line-height: 1.5;">
+                To proceed with <b>Google Account</b> via Single Sign-On,
+            </p>
+            <ul style="text-align: left; font-size: 14px; color: #555; padding-left: 20px; margin-bottom: 15px;">
+                <li style="margin-bottom: 10px;">Click <b>Cancel</b></li>
+                <li style="margin-bottom: 10px;">Select <b>Use Without Internet</b></li>
+                <li style="margin-bottom: 10px;">Open <b>Safari</b> or <b>Chrome</b> copy and paste the link below</li>
+            </ul>
+            <input type="text" id="portalLink" value="${window.location.href}" readonly
+                style="width: 95%; padding: 10px; font-size: 14px; text-align: center; border: 1px solid #ccc;
+                border-radius: 5px; background-color: #fff; margin-bottom: 15px; display: block;">
+            <button id="copyLink" style="padding: 12px 16px; background-color: #007AFF;
+                color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 14px;
+                width: 100%; max-width: 200px; display: block; margin: 0 auto;">
+                Copy Link
+            </button>
+        `;
+
+        var form = document.querySelector("form");
+        if (form) {
+            form.parentNode.insertBefore(container, form);
+        } else {
+            document.body.appendChild(container);
+        }
+
+        // Copy link to clipboard
+        document.getElementById("copyLink").addEventListener("click", function () {
+            var portalLink = document.getElementById("portalLink");
+            portalLink.select();
+            document.execCommand("copy");
+            alert("Link copied! Open Safari or Chrome and paste it.");
+        });
+    }
+}
+
+// Add this logic in case of Google Auth
+document.addEventListener("DOMContentLoaded", function () {
+
+   if (authConfig.isEnabled) {
+    addBrowserInstructions();
+
+   }
+});
+
+


### PR DESCRIPTION
As per the issue
https://awakesecurity.atlassian.net/jira/software/c/projects/NGFW/boards/77?selectedIssue=NGFW-15047

IOS devices are unable to connect to captive portal with google auth, as google restricts access with embedded CNA browsers.

As a workaround users will have to navigate in safari or chrome browser in IOS devices,
Instructions will be present captive portal page as follows

Step 1: 
User will be presented with steps if device is IOS and configured auth in captive portal is google signon
Step2:
captive portal link which can be copied and opened on new browser

Step3
User should presented normal captive portal and redirected to google signon

This change will be only for IOS devices for other devices normal captive portal should be shown.
Screenshots added in Jira issue link above
