### PR TITLE
Ngfw 15088 wireguard routed network profiles

### DIFF
--- a/wireguard-vpn/js/Main.js
+++ b/wireguard-vpn/js/Main.js
@@ -103,6 +103,7 @@ Ext.define('Ung.apps.wireguard-vpn.Main', {
             return {
                     xtype: 'fieldset',
                     title: 'Local Service Information'.t(),
+                    itemId: 'localserviceinfo',
                     collapsible: collapsible ? true : false,
                     collapsed: collapsible && collapsed ? true : false,
                     layout: {
@@ -189,6 +190,27 @@ Ext.define('Ung.apps.wireguard-vpn.Main', {
                         }]
                     }]
             };
+        },
+
+        setLocalNetworks: function(rnlist, viewModel) {
+            var routedNetworks;
+            if(Ext.isArray(rnlist)) {
+                networksList = [];
+                rnlist.forEach(function(networks){
+                    var newList = networks.split(',');
+                    for (var i = 0; i < newList.length; i++) {
+                        var net = newList[i].trim();
+                        if (net && networksList.indexOf(net) === -1) {
+                            networksList.push(net);
+                        }
+                    }
+                });
+                routedNetworks = networksList.join(', ');
+            }
+            if(typeof rnlist === 'string') {
+                routedNetworks = rnlist;
+            }
+            viewModel.set('localNetworkList', routedNetworks);
         }
     }
 

--- a/wireguard-vpn/js/Main.js
+++ b/wireguard-vpn/js/Main.js
@@ -184,6 +184,9 @@ Ext.define('Ung.apps.wireguard-vpn.Main', {
                                     cls: 'x-selectable',
                                     bind: {
                                         value: '{localNetworkList}',
+                                    },
+                                    renderer: function(value) {
+                                        return value ? value.replace(/,\s*/g, ', ') : '';
                                     }
                                 }]
                             }]

--- a/wireguard-vpn/js/Main.js
+++ b/wireguard-vpn/js/Main.js
@@ -47,6 +47,9 @@ Ext.define('Ung.apps.wireguard-vpn.Main', {
             },
             networks: {
                 data: '{settings.networks.list}'
+            },
+            networkProfiles: {
+                data: '{settings.networkProfiles.list}'
             }
         },
 

--- a/wireguard-vpn/js/Main.js
+++ b/wireguard-vpn/js/Main.js
@@ -190,27 +190,6 @@ Ext.define('Ung.apps.wireguard-vpn.Main', {
                         }]
                     }]
             };
-        },
-
-        setLocalNetworks: function(rnlist, viewModel) {
-            var routedNetworks;
-            if(Ext.isArray(rnlist)) {
-                networksList = [];
-                rnlist.forEach(function(networks){
-                    var newList = networks.split(',');
-                    for (var i = 0; i < newList.length; i++) {
-                        var net = newList[i].trim();
-                        if (net && networksList.indexOf(net) === -1) {
-                            networksList.push(net);
-                        }
-                    }
-                });
-                routedNetworks = networksList.join(', ');
-            }
-            if(typeof rnlist === 'string') {
-                routedNetworks = rnlist;
-            }
-            viewModel.set('localNetworkList', routedNetworks);
         }
     }
 

--- a/wireguard-vpn/js/MainController.js
+++ b/wireguard-vpn/js/MainController.js
@@ -96,11 +96,12 @@ Ext.define('Ung.apps.wireguard-vpn.MainController', {
             });
 
             vm.get('settings.tunnels.list').forEach(function(tunnel) {
-                if(tunnel.routedNetworkProfiles && tunnel.routedNetworkProfiles.list && !tunnel.routedNetworkProfiles.javaClass) {
+                if(tunnel.routedNetworkProfiles && !tunnel.routedNetworkProfiles.javaClass) {
                     tunnel.routedNetworkProfiles.javaClass = 'java.util.LinkedList';
-                    if(typeof tunnel.routedNetworkProfiles.list === 'string') {
+                    if(!tunnel.routedNetworkProfiles.list)
+                        tunnel.routedNetworkProfiles.list = [];
+                    if(typeof tunnel.routedNetworkProfiles.list === 'string')
                         tunnel.routedNetworkProfiles.list = [ tunnel.routedNetworkProfiles.list ];
-                    }
                 }
             });
         }
@@ -480,7 +481,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
 
         localNetProfiles.forEach(function(profile) {
             items.push({
-                boxLabel: profile.profileName + ' - ' + profile.subnetsAsString,
+                boxLabel: profile.profileName,
                 name: 'list', 
                 inputValue: profile.profileName,
                 autoEl: {
@@ -531,7 +532,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
                     }
                 }
             });
-            routedNetworks = networksList.join(', ');
+            routedNetworks = networksList.join(',');
         }   
 
         vm.set('localNetworkList', routedNetworks);

--- a/wireguard-vpn/js/MainController.js
+++ b/wireguard-vpn/js/MainController.js
@@ -39,16 +39,6 @@ Ext.define('Ung.apps.wireguard-vpn.MainController', {
             vm.set('warning', warning);
             vm.set('hostname', networkSettings['hostName']);
 
-            var networks = result[0]['networks']['list'];
-            var netlist = "";
-            if(networks != null){
-                for(x = 0;x < networks.length;x++) {
-                    if (x != 0) netlist += ", ";
-                    netlist += networks[x].address;
-                }
-            }
-            vm.set('localNetworkList', netlist);
-
             v.setLoading(false);
         },function(ex){
             if(!Util.isDestroyed(v, vm)){
@@ -384,7 +374,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
 
     pasteTunnel: function(component){
         if(!component.target ||
-           !component.target.dataset.componentid ||
+           !component.target.dataset ||
            !component.target.dataset.componentid){
             return;
         }
@@ -447,6 +437,10 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
 
         this.callParent([view]);
 
+        var rnlist;
+        if(record.get('routedNetworks'))
+            rnlist = record.get('routedNetworks').list;
+        Ung.apps['wireguard-vpn'].Main.setLocalNetworks(rnlist, vm);
         view.down('form').add(
             Ung.apps['wireguard-vpn'].Main.hostDisplayFields(true, !record.get('markedForNew'), true)
         );
@@ -495,5 +489,23 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
             });
         });
         routedNetworks.add(items);
+    },
+
+    onRoutednetworkscbgroupChange: function(checkboxgroup, newValue, oldValue, eOpts) {
+        var editor = checkboxgroup.up('unwireguardvpntunnelrecordeditor'),
+            vm = editor.getViewModel(),
+            record = editor.record,
+            form = editor.down('form'),
+            localServiceInfo = form && form.down('#localserviceinfo');
+
+        if (localServiceInfo) {
+            form.remove(localServiceInfo, true);  // autoDestroy = true
+        }
+
+        Ung.apps['wireguard-vpn'].Main.setLocalNetworks(newValue.list, vm);
+        var newCmp = Ung.apps['wireguard-vpn'].Main.hostDisplayFields(true, false, true );
+
+        if (form) form.add(newCmp);
+
     }
 });

--- a/wireguard-vpn/js/MainController.js
+++ b/wireguard-vpn/js/MainController.js
@@ -104,6 +104,15 @@ Ext.define('Ung.apps.wireguard-vpn.MainController', {
                 var recordObj = JSON.parse(jsonRecord);
                 sequence.unshift(Rpc.directPromise(v.appManager, 'deleteTunnel', recordObj['publicKey']));
             });
+
+            vm.get('settings.tunnels.list').forEach(function(tunnel) {
+                if(tunnel.routedNetworks && tunnel.routedNetworks.list && !tunnel.routedNetworks.javaClass) {
+                    tunnel.routedNetworks.javaClass = 'java.util.LinkedList';
+                    if(typeof tunnel.routedNetworks.list === 'string') {
+                        tunnel.routedNetworks.list = [ tunnel.routedNetworks.list ];
+                    }
+                }
+            });
         }
 
         v.setLoading(true);
@@ -358,6 +367,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditor', {
     extend: 'Ung.cmp.RecordEditor',
     xtype: 'ung.cmp.unwireguardvpntunnelrecordeditor',
     alias: 'widget.unwireguardvpntunnelrecordeditor',
+    itemId: 'unwireguardvpntunnelrecordeditor',
 
     controller: 'unwireguardvpntunnelrecordeditorcontroller'
 });
@@ -365,6 +375,12 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditor', {
 Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController', {
     extend: 'Ung.cmp.RecordEditorController',
     alias: 'controller.unwireguardvpntunnelrecordeditorcontroller',
+
+    control: {
+        '#unwireguardvpntunnelrecordeditor': {
+            afterrender: 'afterTunnelsEditorRender'
+        }
+    },
 
     pasteTunnel: function(component){
         if(!component.target ||
@@ -458,5 +474,26 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
                 }
             }
         }
+    },
+
+    afterTunnelsEditorRender: function() {
+        var v = this.getView(),
+            vm = this.getViewModel(),
+            items = [],
+            routedNetworks = v.down('#routednetworkscbgroup'),
+            localNetProfiles = vm.get('settings.networkProfiles.list');
+
+        localNetProfiles.forEach(function(profile) {
+            items.push({
+                boxLabel: profile.profileName + ' - ' + profile.subnetsAsString,
+                name: 'list', 
+                inputValue: profile.subnetsAsString,
+                autoEl: {
+                    tag: 'div',
+                    'data-qtip': profile.subnetsAsString
+                }
+            });
+        });
+        routedNetworks.add(items);
     }
 });

--- a/wireguard-vpn/js/MainController.js
+++ b/wireguard-vpn/js/MainController.js
@@ -95,6 +95,7 @@ Ext.define('Ung.apps.wireguard-vpn.MainController', {
                 sequence.unshift(Rpc.directPromise(v.appManager, 'deleteTunnel', recordObj['publicKey']));
             });
 
+            // Format routedNetworkProfiles checkbox list value to java compatible object
             vm.get('settings.tunnels.list').forEach(function(tunnel) {
                 if(tunnel.routedNetworkProfiles && !tunnel.routedNetworkProfiles.javaClass) {
                     tunnel.routedNetworkProfiles.javaClass = 'java.util.LinkedList';
@@ -438,6 +439,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
 
         this.callParent([view]);
 
+        // Set routed networks from the profiles selected for a tunnel dynamically
         var rnProfileList;
         if(record.get('routedNetworkProfiles')) {
             rnProfileList = record.get('routedNetworkProfiles').list;
@@ -479,6 +481,8 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
             routedNetworks = v.down('#routednetworkscbgroup'),
             localNetProfiles = vm.get('settings.networkProfiles.list');
 
+        // Add all the Local Networks Profiles from settings page as checkboxes
+        // to be selected as Routed Network Profiles on tunnel add/edit window
         localNetProfiles.forEach(function(profile) {
             items.push({
                 boxLabel: profile.profileName,
@@ -493,6 +497,9 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
         routedNetworks.add(items);
     },
 
+    /**
+     * listener for Routed Network Profiles change 
+     */
     onRoutednetworkscbgroupChange: function(checkboxgroup, newValue, oldValue, eOpts) {
         var editor = checkboxgroup.up('unwireguardvpntunnelrecordeditor'),
             record = editor.record,
@@ -510,6 +517,9 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.WireGuardVpnTunnelRecordEditorController'
 
     },
 
+    /**
+     * Sets the routedNetworks from selected profile names in tunnel store
+     */
     setRoutedNetworksFromProfiles: function(profiles, record) {
         var vm = this.getViewModel(),
             localNetProfiles = vm.get('settings.networkProfiles.list'),

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -135,7 +135,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                 },
                 emptyRow: {
                     javaClass: 'com.untangle.app.wireguard_vpn.WireGuardVpnNetworkProfile',
-                    profileName: 'MyProfile',
+                    profileName: 'ProfileName',
                     subnetsAsString: '10.0.0.0/24,10.1.0.0/24',
                 },
                 columns: [{
@@ -148,10 +148,12 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                         emptyText: '[enter profile name]'.t(),
                         blankText: 'Invalid profile name'.t(),
                         validator: function(value) {
-                            console.log("In Validator");
                             var grid = this.up('grid[itemId=localNetworkGrid]'),
                                 store = grid.getStore(),
                                 record = grid.getSelectionModel().getSelection()[0];
+                            var me = this,
+                                defaultProfileName = me.up('#settings').down("#localNetworkGrid").initialConfig.emptyRow.profileName;
+                            if(value == defaultProfileName) return 'Change default ProfileName.'.t();
                             // Check if a record with the same name exists in the store
                             var isNameUnique = store.findBy(function(profile) {
                                 if(record === profile) return false;
@@ -191,26 +193,10 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
 
                                     var me = this,
                                         settings = me.up('#settings'),
-                                        localNetworkStoreFn = settings.down('#localNetworkGrid').getStore(),
                                         peerNetworkIp = settings.down('#peerNetworkIp').getValue(),
-                                        record = settings.down('#localNetworkGrid').getSelectionModel().getSelection()[0],
                                         localNetworkStore = [];
 
                                     if(peerNetworkIp) localNetworkStore.push(peerNetworkIp);
-
-                                    localNetworkStoreFn.each(function (profile){
-                                        if(record !== profile && profile.get("subnetsAsString") && profile.get("subnetsAsString") !== me.originalValue){
-                                            var subnets = profile.get("subnetsAsString").split(',');
-                                            for (var i = 0; i < subnets.length; i++) {
-                                                subnet = subnets[i].trim();
-                                                if(Util.networkValidator(subnet) === true && localNetworkStore.indexOf(subnet) === -1) 
-                                                    localNetworkStore.push(subnet);
-                                            }
-                                        }
-                                        // if(profile.get("address") && !(me.originalValue == "" && profile.get("address") == defaultNewRowAddress) && (profile.get("address") !== me.originalValue)){
-                                        //     localNetworkStore.push(profile.get("address"));
-                                        // }
-                                    });
 
                                     res = Util.findIpPoolConflict(networks[i], localNetworkStore, this, true);
                                     if(res != true) return res;
@@ -223,6 +209,11 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                         }
                     },
                 }]
+            }, {
+                xtype: 'label',
+                cls: 'warningLabel',
+                margin: '13 0 5 25',
+                html: '<span class="fa fa-exclamation-triangle" style="color: orange;" data-qtip="On profile edit clients will need to configure their connections!"></span>'
             }]
         }]
     }, {

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -121,10 +121,22 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                 listProperty: 'settings.networkProfiles.list',
                 width: 562,
                 bind: '{networkProfiles}',
+                restrictedRecords: {
+                    keyMatch: 'reserved',
+                    valueMatch: true
+                },
+                listeners: {
+                    cellclick: function(grid,td,cellIndex,record,tr,rowIndex,e,eOpts)  {
+                        if (record.data.profileName === 'Full Tunnel') { 
+                            record.set('reserved', true);
+                            return false; 
+                        }
+                    }
+                },
                 emptyRow: {
                     javaClass: 'com.untangle.app.wireguard_vpn.WireGuardVpnNetworkProfile',
-                    profileName: 'default',
-                    address: '10.0.0.0/24',
+                    profileName: 'MyProfile',
+                    subnetsAsString: '10.0.0.0/24, 10.32.0.0/24',
                 },
                 columns: [
                     {

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -118,59 +118,38 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                 itemId: 'localNetworkGrid',
                 tbar: ['@addInline'],
                 recordActions: ['delete'],
-                listProperty: 'settings.networks.list',
-                width: 300,
-                bind: '{networks}',
+                listProperty: 'settings.networkProfiles.list',
+                width: 562,
+                bind: '{networkProfiles}',
                 emptyRow: {
-                    javaClass: 'com.untangle.app.wireguard_vpn.WireGuardVpnNetwork',
-                    address: '10.0.0.0/24'
+                    javaClass: 'com.untangle.app.wireguard_vpn.WireGuardVpnNetworkProfile',
+                    profileName: 'default',
+                    address: '10.0.0.0/24',
                 },
-                columns: [{
-                    dataIndex: 'address',
-                    header: 'Network Address',
+                columns: [
+                    {
+                    dataIndex: 'profileName',
+                    header: 'Profile Name',
                     width: 200,
+                    editor:{
+                        xtype: 'textfield',
+                        allowBlank: false,
+                        emptyText: '[enter profile name]'.t(),
+                        blankText: 'Invalid profile name'.t(),
+                    },
+                }, 
+                {
+                    dataIndex: 'subnetsAsString',
+                    header: 'Network Addresses',
+                    width: 300,
                     flex: 1,
                     editor:{
                         xtype: 'textfield',
-                        vtype: 'cidrBlock',
+                        // vtype: 'cidrBlock',
                         allowBlank: false,
                         emptyText: '[enter address]'.t(),
                         blankText: 'Invalid address specified'.t(),
-                        validator: function(value) {
-                            try{
-                                var isValidVtypeField = Ext.form.field.VTypes[this.vtype](value);
-                                if(!isValidVtypeField){
-                                    return true;
-                                }
-                                var res = Util.networkValidator(value);
-                                if(res != true){
-                                    return res;
-                                }
-                                var me = this,
-                                    defaultNewRowAddress = me.up('#settings').down("#localNetworkGrid").initialConfig.emptyRow.address;
-                                
-                                var localNetworkStoreFn = this.up('#settings').down('#localNetworkGrid').getStore();
-                                var peerNetworkIp = this.up('#settings').down('#peerNetworkIp').getValue();
-
-                                var localNetworkStore = [];
-                  
-                                localNetworkStoreFn.each(function (item){
-                                    if(item.get("address") && !(me.originalValue == "" && item.get("address") == defaultNewRowAddress) && (item.get("address") !== me.originalValue)){
-                                        localNetworkStore.push(item.get("address"));
-                                    }
-                                });
-
-                                if(peerNetworkIp){
-                                    localNetworkStore.push(peerNetworkIp);
-                                }
-                                
-                                return Util.findIpPoolConflict(value, localNetworkStore, this, true);
-
-                            } catch(err) {
-                                console.log(err);
-                                return true;
-                            }                        
-                        }
+                        // TODO Add Validator
                     },
                 }]
             }]

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -131,11 +131,20 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                             record.set('reserved', true);
                             return false; 
                         }
+                    },
+                    afterrender: function(grid) {
+                        Ext.Function.defer(function() { 
+                            var store = grid.getStore();
+                            store.each(function(record) {
+                                if(record.get('profileName') === 'Full Tunnel')
+                                    record.set('reserved', true);
+                            });
+                        }, 1500);
                     }
                 },
                 emptyRow: {
                     javaClass: 'com.untangle.app.wireguard_vpn.WireGuardVpnNetworkProfile',
-                    profileName: 'ProfileName',
+                    profileName: 'DefaultProfileName',
                     subnetsAsString: '10.0.0.0/24,10.1.0.0/24',
                 },
                 columns: [{
@@ -153,7 +162,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                                 record = grid.getSelectionModel().getSelection()[0];
                             var me = this,
                                 defaultProfileName = me.up('#settings').down("#localNetworkGrid").initialConfig.emptyRow.profileName;
-                            if(value == defaultProfileName) return 'Change default ProfileName.'.t();
+                            if(value == defaultProfileName) return 'Change default profile name.'.t();
                             // Check if a record with the same name exists in the store
                             var isNameUnique = store.findBy(function(profile) {
                                 if(record === profile) return false;
@@ -167,6 +176,12 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                     header: 'Network Addresses',
                     width: 300,
                     flex: 1,
+                    renderer: function(value) {
+                        var qtip = value ? value.replace(/,\s*/g, ', ') : '';
+                        return '<span data-qtip="' + Ext.String.htmlEncode(qtip) + '">' +
+                               Ext.String.htmlEncode(value) +
+                               '</span>';
+                    },
                     editor:{
                         xtype: 'textfield',
                         vtype: 'cidrBlockList',
@@ -213,7 +228,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                 xtype: 'label',
                 cls: 'warningLabel',
                 margin: '13 0 5 25',
-                html: '<span class="fa fa-exclamation-triangle" style="color: orange;" data-qtip="On profile edit clients will need to configure their connections!"></span>'
+                html: '<span class="fa fa-exclamation-triangle" style="color: orange;" data-qtip="On profile name edit clients will need to configure their connections!"></span>'
             }]
         }]
     }, {

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -139,7 +139,7 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                                 if(record.get('profileName') === 'Full Tunnel')
                                     record.set('reserved', true);
                             });
-                        }, 1500);
+                        }, 2000);
                     }
                 },
                 emptyRow: {

--- a/wireguard-vpn/js/view/Status.js
+++ b/wireguard-vpn/js/view/Status.js
@@ -32,7 +32,6 @@ Ext.define('Ung.apps.wireguard-vpn.view.Status', {
         }, {
             xtype: 'appstate',
         },
-        Ung.apps['wireguard-vpn'].Main.hostDisplayFields(false),
         {
             xtype: 'fieldset',
             title: '<i class="fa fa-clock-o"></i> ' + 'Enabled Tunnels'.t(),

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -60,7 +60,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         'pingConnectionEvents': true,
         'pingUnreachableEvents': false,
         'assignDnsServer': false,
-        'routedNetworks': {
+        'routedNetworkProfiles': {
             'javaClass': 'java.util.LinkedList',
             'list': []
         }
@@ -257,12 +257,13 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
                 }) : [];
 
                 var res = null;
-                for(var i=0;i<localNetworkStore.length;i++){
-                    res = Util.networkValidator(localNetworkStore[i]);
-                    if(res!=true){
-                        break;
-                    }
-                }
+                // Need to remove this for full tunnel support
+                // for(var i=0;i<localNetworkStore.length;i++){
+                //     res = Util.networkValidator(localNetworkStore[i]);
+                //     if(res!=true){
+                //         break;
+                //     }
+                // }
                 if(res != true){
                     return res;
                 }
@@ -276,12 +277,12 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         }
     }, {
         xtype: 'checkboxgroup',
-        fieldLabel: 'Routed Networks'.t(),
+        fieldLabel: 'Routed Network Profiles'.t(),
         useParentDefinition: true,
         // labelWidth: 155,
         itemId: 'routednetworkscbgroup',
         bind: {
-            value: '{record.routedNetworks}'
+            value: '{record.routedNetworkProfiles}'
         },
         listeners: {
             change: 'onRoutednetworkscbgroupChange'

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -59,7 +59,11 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         'pingInterval': 60,
         'pingConnectionEvents': true,
         'pingUnreachableEvents': false,
-        'assignDnsServer': false
+        'assignDnsServer': false,
+        'routedNetworks': {
+            'javaClass': 'java.util.LinkedList',
+            'list': []
+        }
     },
 
     importValidationJavaClass: true,
@@ -270,6 +274,17 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
                 return true;
             }                        
         }
+    }, {
+        xtype: 'checkboxgroup',
+        fieldLabel: 'Routed Networks'.t(),
+        useParentDefinition: true,
+        // labelWidth: 155,
+        itemId: 'routednetworkscbgroup',
+        bind: {
+            value: '{record.routedNetworks}'
+        },
+        columns: 3,
+        vertical: true
     }, {
         xtype: 'checkbox',
         fieldLabel: 'Assign DNS Server'.t(),

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -283,6 +283,9 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         bind: {
             value: '{record.routedNetworks}'
         },
+        listeners: {
+            change: 'onRoutednetworkscbgroupChange'
+        },
         columns: 3,
         vertical: true
     }, {

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -63,7 +63,8 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         'routedNetworkProfiles': {
             'javaClass': 'java.util.LinkedList',
             'list': []
-        }
+        },
+        'routedNetworks':''
     },
 
     importValidationJavaClass: true,
@@ -255,18 +256,6 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
                 var localNetworkStore = remoteNetworks.length > 0 ? Ext.Array.map(remoteNetworks.split("\n"),function (remoteIpAddr){
                     return remoteIpAddr.trim();
                 }) : [];
-
-                var res = null;
-                // Need to remove this for full tunnel support
-                // for(var i=0;i<localNetworkStore.length;i++){
-                //     res = Util.networkValidator(localNetworkStore[i]);
-                //     if(res!=true){
-                //         break;
-                //     }
-                // }
-                if(res != true){
-                    return res;
-                }
                 
                 return Util.findIpPoolConflict(peerNetworkIp, localNetworkStore, this, false);
 

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnNetworkProfile.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnNetworkProfile.java
@@ -5,6 +5,7 @@
 package com.untangle.app.wireguard_vpn;
 
 import com.untangle.uvm.app.IPMaskedAddress;
+import com.untangle.uvm.util.Constants;
 import org.json.JSONObject;
 import org.json.JSONString;
 
@@ -35,7 +36,7 @@ public class WireGuardVpnNetworkProfile implements JSONString, Serializable {
             this.subnets = new LinkedList<>();
             return;
         }
-        this.subnets = Arrays.stream(subnetsAsString.split(","))
+        this.subnets = Arrays.stream(subnetsAsString.split(Constants.COMMA_STRING))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .map(addressStr -> {
@@ -53,7 +54,7 @@ public class WireGuardVpnNetworkProfile implements JSONString, Serializable {
         }
         return subnets.stream()
                 .map(wg -> wg.getAddress().toString())
-                .collect(Collectors.joining(","));
+                .collect(Collectors.joining(Constants.COMMA_STRING));
     }
 
     @Override

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnNetworkProfile.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnNetworkProfile.java
@@ -53,7 +53,7 @@ public class WireGuardVpnNetworkProfile implements JSONString, Serializable {
         }
         return subnets.stream()
                 .map(wg -> wg.getAddress().toString())
-                .collect(Collectors.joining(", "));
+                .collect(Collectors.joining(","));
     }
 
     @Override

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnNetworkProfile.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnNetworkProfile.java
@@ -15,8 +15,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * This class is used when storing a list of IPMaskedAddress objects
- * that will be managed using a UI grid control.
+ * This class is used to store the subnets in different local network profiles
+ * It will be managed using a UI grid control.
  */
 @SuppressWarnings("serial")
 public class WireGuardVpnNetworkProfile implements JSONString, Serializable {

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnNetworkProfile.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnNetworkProfile.java
@@ -1,0 +1,65 @@
+/**
+* $Id:
+*/
+
+package com.untangle.app.wireguard_vpn;
+
+import com.untangle.uvm.app.IPMaskedAddress;
+import org.json.JSONObject;
+import org.json.JSONString;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class is used when storing a list of IPMaskedAddress objects
+ * that will be managed using a UI grid control.
+ */
+@SuppressWarnings("serial")
+public class WireGuardVpnNetworkProfile implements JSONString, Serializable {
+
+    private String profileName;
+    private List<WireGuardVpnNetwork> subnets;
+    private String subnetsAsString;
+
+    public String getProfileName() { return profileName; }
+    public void setProfileName(String profileName) { this.profileName = profileName; }
+
+    public List<WireGuardVpnNetwork> getSubnets() { return subnets; }
+    public void setSubnets(List<WireGuardVpnNetwork> subnets) { this.subnets = subnets; }
+    public void setSubnets(String subnetsAsString) {
+        if (subnetsAsString == null || subnetsAsString.trim().isEmpty()) {
+            this.subnets = new LinkedList<>();
+            return;
+        }
+        this.subnets = Arrays.stream(subnetsAsString.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(addressStr -> {
+                    WireGuardVpnNetwork net = new WireGuardVpnNetwork(new IPMaskedAddress(addressStr));
+                    return net;
+                })
+                .collect(Collectors.toList());
+    }
+
+    public void setSubnetsAsString(String subnetsAsString) { this.subnetsAsString = subnetsAsString; }
+    public String getSubnetsAsString() {
+        if (subnetsAsString != null) return subnetsAsString;
+        if (subnets == null) {
+            return "";
+        }
+        return subnets.stream()
+                .map(wg -> wg.getAddress().toString())
+                .collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public String toJSONString() {
+        JSONObject jO = new JSONObject(this);
+        return jO.toString();
+    }
+
+}

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
@@ -19,7 +19,7 @@ import com.untangle.uvm.app.IPMaskedAddress;
 @SuppressWarnings("serial")
 public class WireGuardVpnSettings implements Serializable, JSONString
 {
-    private Integer version = 5;
+    private Integer version = 6;
 
     private Integer keepaliveInterval = 25;
     private Integer listenPort = 51820;
@@ -31,6 +31,7 @@ public class WireGuardVpnSettings implements Serializable, JSONString
     private InetAddress dnsServer;
     private String dnsSearchDomain = "";
     private List<WireGuardVpnNetwork> networks;
+    private List<WireGuardVpnNetworkProfile> networkProfiles;
     private boolean autoAddressAssignment = true;
 
     private List<WireGuardVpnTunnel> tunnels;
@@ -67,6 +68,9 @@ public class WireGuardVpnSettings implements Serializable, JSONString
 
     public List<WireGuardVpnNetwork> getNetworks() { return networks; }
     public void setNetworks( List<WireGuardVpnNetwork> newValue ) { this.networks = newValue; }
+
+    public List<WireGuardVpnNetworkProfile> getNetworkProfiles() { return networkProfiles; }
+    public void setNetworkProfiles(List<WireGuardVpnNetworkProfile> networkProfiles) { this.networkProfiles = networkProfiles; }
 
     public boolean getAutoAddressAssignment() { return autoAddressAssignment; }
     public void setAutoAddressAssignment( boolean newValue ) { this.autoAddressAssignment = newValue; }

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnTunnel.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnTunnel.java
@@ -6,7 +6,6 @@ package com.untangle.app.wireguard_vpn;
 
 import java.io.Serializable;
 import java.util.LinkedList;
-import java.util.List;
 
 import org.json.JSONObject;
 import org.json.JSONString;
@@ -38,6 +37,7 @@ public class WireGuardVpnTunnel implements Serializable, JSONString
     private Boolean pingUnreachableEvents = false;
     // Only required for dynamic endpoints
     private Boolean assignDnsServer = false;
+    private LinkedList<String> routedNetworks = null;
 
     public Boolean getEnabled() { return enabled; }
     public void setEnabled( Boolean newValue ) { this.enabled = newValue; }
@@ -87,6 +87,9 @@ public class WireGuardVpnTunnel implements Serializable, JSONString
 
     public Boolean getAssignDnsServer() { return assignDnsServer; }
     public void setAssignDnsServer(Boolean assignDnsServer) { this.assignDnsServer = assignDnsServer; }
+
+    public LinkedList<String> getRoutedNetworks() { return routedNetworks; }
+    public void setRoutedNetworks(LinkedList<String> routedNetworks) { this.routedNetworks = routedNetworks; }
 
     public String toJSONString()
     {

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnTunnel.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnTunnel.java
@@ -5,13 +5,12 @@
 package com.untangle.app.wireguard_vpn;
 
 import java.io.Serializable;
-import java.util.LinkedList;
 
 import org.json.JSONObject;
 import org.json.JSONString;
 
 import java.net.InetAddress;
-import com.untangle.uvm.app.IPMaskedAddress;
+import java.util.List;
 
 /**
  * Settings for the WireGuardVpn app.
@@ -37,7 +36,9 @@ public class WireGuardVpnTunnel implements Serializable, JSONString
     private Boolean pingUnreachableEvents = false;
     // Only required for dynamic endpoints
     private Boolean assignDnsServer = false;
-    private LinkedList<String> routedNetworks = null;
+    // Routed Network Profiles
+    private List<String> routedNetworkProfiles = null;
+    private String routedNetworks = "";
 
     public Boolean getEnabled() { return enabled; }
     public void setEnabled( Boolean newValue ) { this.enabled = newValue; }
@@ -88,8 +89,11 @@ public class WireGuardVpnTunnel implements Serializable, JSONString
     public Boolean getAssignDnsServer() { return assignDnsServer; }
     public void setAssignDnsServer(Boolean assignDnsServer) { this.assignDnsServer = assignDnsServer; }
 
-    public LinkedList<String> getRoutedNetworks() { return routedNetworks; }
-    public void setRoutedNetworks(LinkedList<String> routedNetworks) { this.routedNetworks = routedNetworks; }
+    public List<String> getRoutedNetworkProfiles() { return routedNetworkProfiles; }
+    public void setRoutedNetworkProfiles(List<String> routedNetworkProfiles) { this.routedNetworkProfiles = routedNetworkProfiles; }
+
+    public String getRoutedNetworks() { return routedNetworks; }
+    public void setRoutedNetworks(String routedNetworks) { this.routedNetworks = routedNetworks; }
 
     public String toJSONString()
     {


### PR DESCRIPTION
Support for Wireguard VPN Local Networks Profile:

**Changes:**
1. Status Page: - Remove **Local Service Information** clipboard from the page. As Local networks will be different for each tunnel.
![Screenshot from 2025-04-16 23-12-22](https://github.com/user-attachments/assets/927b7199-a25e-45eb-a689-a6d5b5673752)


2. Settings Page: - 
  - Changed **Local Networks** field to **Local Network Profiles**
        This field will contain Network Profiles with multiple comma separated Local Networks in CIDR format.
        First profile will always be `Full Tunnel - 0.0.0.0/0`. It will be non editable and non deletable.
        Second profile will be `Default` profile. For fresh install default profile will have all local LAN networks from networks settings. On upgrade old local networks will be added to Default profile.
        User will be able to Add/Edit/Delete the network profiles.
  - Validations: 
        Profile Name: Duplicate profile names won't be allowed. User will have to change the default profile name after new profile addition
        Network Addresses: Comma separated networks in the CIDR format will be valid. Conflicting addresses won't be allowed in same profile. 0.0.0.0/0 will be invalid address except for Full Tunnel Profile. On Profile Name change users will need to reconfigure their tunnels using the edited profile.
        ![Screenshot from 2025-04-17 01-27-50](https://github.com/user-attachments/assets/d06897cf-46ba-4cd3-9cfc-b2734ce37338)
        
        
3. Tunnels Page - Tunnel Editor Window:
  - Added a `checkboxgroup` filed **Routed Network Profiles**
        User will be able to select multiple Local Network Profiles defined on settings page as Routed Network Profiles for a tunnel. Using these profile names, distinct networks will be set as Routed Networks for that particular tunnel. These routed networks will be set as allowedIps for remote config of that tunnel.
        On upgrade for already defined tunnels default profile will be selected as Routed Network Profile.
        ![Screenshot from 2025-04-17 01-36-20](https://github.com/user-attachments/assets/70353e84-45e4-4360-a977-7ebcd91d447f)

Local functional testing has been done for above mentioned changes using virtual box environment