### PR TITLE
NGFW-15092: UI changes for Webfilter Global Pass/Block Sites

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -898,6 +898,46 @@ Ext.define('Ung.util.Util', {
         return ((ipInteger & netmaskInteger) == (networkInteger & netmaskInteger) );
     },
 
+    /**
+     * Define the styling for global entries. 
+     *
+     * @param record  The grid record to evaluate.
+     * @return Style to apply on global fields.
+     */
+    getGlobalRowClass: function(record) {
+        if (record.phantom === false && record.dirty && !record.get('markedForNew') && record.get('markedForDelete')) {
+            return 'mark-delete';
+        }
+        if (record.get('isGlobal') === true) {
+            return 'row-global-locked';
+        }
+    },
+
+    /**
+     * Determines whether the global checkbox for a given grid record should be clickable.
+     *
+     * @param column  checkBox global column
+     * @param rowIndex index of global field
+     * @return boolean  Returns false if the 'isGlobal' field is true (i.e., the record is global and should not be edited).
+     *                  Returns true if 'isGlobal' is false or not set (i.e., the checkbox can be clicked).
+     */
+    canToggleGlobalCheckbox: function (column, rowIndex) {
+        var grid = column.up('grid');
+        var store = column.getGridStore ? column.getGridStore() : grid.getStore();
+        var record = store.getAt(rowIndex);
+        if (!record) return true;
+    
+        var modified = record.modified || {};
+        var originalValue = modified.hasOwnProperty('isGlobal') ? !record.get('isGlobal') : record.get('isGlobal');
+        var canToggleIsGlobal = !(originalValue === true && !modified.hasOwnProperty('isGlobal'));
+        if (!canToggleIsGlobal && !record.get('markedForNew')) {
+            Ext.MessageBox.alert('Info', '<strong> Global Field </strong> cannot be edited!');
+            return false;
+        } else {
+            return true;
+        }
+    },
+
     isIPInRange: function (ip, network, netmask) {
         // Split the IP address into octets
         var nextPoolOctets = ip.split('.');

--- a/uvm/servlets/admin/sass/base.scss
+++ b/uvm/servlets/admin/sass/base.scss
@@ -1067,3 +1067,8 @@ a.view-reports {
         color: #999;
     }
 }
+
+.x-grid-row.row-global-locked {
+    background-color:  #e4e0e0 !important;
+    color: #333 !important;
+}

--- a/web-filter/js/Main.js
+++ b/web-filter/js/Main.js
@@ -21,6 +21,9 @@ Ext.define('Ung.apps.webfilter.Main', {
             passedUrls:    { data: '{settings.passedUrls.list}' },
             passedClients: { data: '{settings.passedClients.list}' },
             filterRules:   { data: '{settings.filterRules.list}' }
+        },
+        data: {
+            isAddAction: false 
         }
     },
 

--- a/web-filter/js/MainController.js
+++ b/web-filter/js/MainController.js
@@ -217,6 +217,39 @@ Ext.define('Ung.apps.webfilter.MainController', {
 
 });
 
+Ext.define('Ung.apps.webfilter.cmp.BlockSitesController', {
+    extend: 'Ung.cmp.GridController',
+    alias: 'controller.blocksites',
+
+    addRecord: function () {
+        var vm = this.getViewModel();
+        if (vm) vm.set('isAddAction', true);
+        this.callParent(arguments);
+    },
+    editRecord: function () {
+        var vm = this.getViewModel();
+        if (vm) vm.set('isAddAction', false);
+        this.callParent(arguments); 
+    }
+});
+
+Ext.define('Ung.apps.webfilter.cmp.PassSitesController', {
+    extend: 'Ung.cmp.GridController',
+    alias: 'controller.passsites',
+
+    addRecord: function () {
+        var vm = this.getViewModel();
+        if (vm) vm.set('isAddAction', true);
+        this.callParent(arguments);
+    },
+    editRecord: function () {
+        var vm = this.getViewModel();
+        if (vm) vm.set('isAddAction', false);
+        this.callParent(arguments); 
+    }
+});
+
+
 Ext.define('Ung.apps.webfilter.cmp.SearchTermsGridController', {
     extend: 'Ung.cmp.GridController',
     alias: 'controller.unwebfiltersearchtermsgrid',

--- a/web-filter/js/view/BlockSites.js
+++ b/web-filter/js/view/BlockSites.js
@@ -3,6 +3,7 @@ Ext.define('Ung.apps.webfilter.view.BlockSites', {
     alias:  'widget.app-web-filter-blocksites',
     itemId: 'block-sites',
     title:  'Block Sites'.t(),
+    controller: 'blocksites',
     withValidation: false,
     dockedItems: [{
         xtype: 'toolbar',
@@ -38,6 +39,10 @@ Ext.define('Ung.apps.webfilter.view.BlockSites', {
 
     bind: '{blockedUrls}',
 
+    viewConfig: {
+        getRowClass : Ung.util.Util.getGlobalRowClass
+    },
+    
     columns: [{
         header: 'Site'.t(),
         width: Renderer.uriWidth,
@@ -59,7 +64,10 @@ Ext.define('Ung.apps.webfilter.view.BlockSites', {
         width: Renderer.booleanWidth,
         header: 'Global'.t(),
         dataIndex: 'isGlobal',
-        resizable: false,
+        resizable: false, 
+        listeners: {
+            beforecheckchange: Ung.util.Util.canToggleGlobalCheckbox
+        },
     }, {
         xtype: 'checkcolumn',
         width: Renderer.booleanWidth,
@@ -90,8 +98,11 @@ Ext.define('Ung.apps.webfilter.view.BlockSites', {
         fieldLabel: 'Block'.t()
     }, {
         xtype: 'checkbox',
-        bind: '{record.isGlobal}',
-        fieldLabel: 'Global'.t()
+        bind: {
+            value: '{record.isGlobal}',
+            hidden: '{!isAddAction}'
+        },    
+        fieldLabel: 'Global'.t(),
     },  {
         xtype: 'checkbox',
         bind: '{record.flagged}',

--- a/web-filter/js/view/PassSites.js
+++ b/web-filter/js/view/PassSites.js
@@ -4,6 +4,7 @@ Ext.define('Ung.apps.webfilter.view.PassSites', {
     itemId: 'pass-sites',
     title: 'Pass Sites'.t(),
     withValidation: false,
+    controller: 'passsites',
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',
@@ -25,6 +26,10 @@ Ext.define('Ung.apps.webfilter.view.PassSites', {
     emptyText: 'No Pass Sites defined'.t(),
 
     importValidationJavaClass: true,
+
+    viewConfig: {
+        getRowClass : Ung.util.Util.getGlobalRowClass
+    },
 
     listProperty: 'settings.passedUrls.list',
     emptyRow: {
@@ -58,7 +63,10 @@ Ext.define('Ung.apps.webfilter.view.PassSites', {
         width: Renderer.booleanWidth,
         header: 'Global'.t(),
         dataIndex: 'isGlobal',
-        resizable: false
+        resizable: false,
+        listeners: {
+            beforecheckchange: Ung.util.Util.canToggleGlobalCheckbox
+        },
     }, {
         header: 'Description'.t(),
         width: Renderer.messageWidth,
@@ -82,8 +90,11 @@ Ext.define('Ung.apps.webfilter.view.PassSites', {
         fieldLabel: 'Pass'.t()
     }, {
         xtype: 'checkbox',
-        bind: '{record.isGlobal}',
-        fieldLabel: 'Global'.t()
+        bind: {
+            value: '{record.isGlobal}',
+            hidden: '{!isAddAction}'
+        }, 
+        fieldLabel: 'Global'.t(),
     }, {
         xtype: 'textarea',
         bind: '{record.description}',


### PR DESCRIPTION
As will be as below:
- Once a site is saved as Global, the user will not be able to modify the Global field and Global record will be highlighted.

>![Screenshot from 2025-04-23 19-36-38](https://github.com/user-attachments/assets/8c4e972e-82e3-4dd0-af08-86940fb82337)



- The Global checkbox will be visible only in the editor fields during the Add operation.
> **PassSIte:**
> ![Screenshot from 2025-04-23 18-39-42](https://github.com/user-attachments/assets/352784dd-1500-4804-9489-27fc0d6d8623)
> **BlockSite:**
> ![image](https://github.com/user-attachments/assets/a54c9c9d-1997-48d0-93d6-d2c1d6bf3cb0)

- For edit operation editorField, global field is not visible.

> **PassSite:**
> ![Screenshot from 2025-04-23 18-42-58](https://github.com/user-attachments/assets/d4935009-767c-49ed-86fe-67d030dd1312)
> **BlockSite:**
> ![Screenshot from 2025-04-23 18-42-18](https://github.com/user-attachments/assets/c5a5ecf1-b39a-4b18-b910-60d0a810630a)
> 

- While try to disable the global field, user will get below info.

> ![Screenshot from 2025-04-23 18-45-04](https://github.com/user-attachments/assets/c31318c2-528f-4bee-a9a6-282dbb740f33)


- Users can promote a non-global entry to global using the checkbox directly from the grid.
**PassSite:**
![Screenshot from 2025-04-23 18-46-00](https://github.com/user-attachments/assets/586c47a7-9323-4941-af4b-17e085f9acd1)
**BlockSite**
![Screenshot from 2025-04-23 18-49-37](https://github.com/user-attachments/assets/9452a57d-de77-4e2f-9c13-c944dbc7c8e5)
