### PR TITLE
Ngfw -15103/15120 :  ATS tests to verify Web-Filter Global Block/Pass URL site support

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/common.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/common.py
@@ -135,9 +135,6 @@ class NGFWTestCase(TestCase):
             uvmContext.appManager().destroy( app.getAppSettings()["id"] )
         cls.apps.clear()
 
-        if cls._app:
-            cls.final_extra_tear_down()
-
         if not cls.do_not_remove_app:
             name = cls.module_name()
             if cls._app or uvmContext.appManager().isInstantiated(name):


### PR DESCRIPTION
Added test cases specific to the web-filter Global block/pass sites rule:

1 - Verify addition and removal of Global block/pass sites. 
> test_202_url_filtering_global_vs_instance_specific_rules_reflection

2- Verify that a global block rule applies only when a corresponding per-instance pass rule is NOT present.
> test_203_url_filtering_respects_pass_and_block_rules_per_ip

3- Verify that a globally flagged (not blocked) URL logs a flagged event only for the instance which does NOT have an explicit pass rule. The instance with a local pass rule for the same URL should NOT log a flagged event.
> test_204_flagged_logs_only_without_pass

4- Verifies that during concurrent setSettings calls across multiple web filter instances, the global settings persist correctly and the last completed update is reflected.
> test_205_global_settings_consistency_under_concurrent_updates

5- Verifies that when Policy Manager routes traffic to a policy that does not have the Web Filter app enabled, the global block rule is not enforced. The traffic bypasses the Web Filter entirely and is not blocked for that specific policy instance,even if a global block rule exists. 
> test_206_global_block_rule_ignored_when_web_filter_disabled_in_policy

6- Verify that the Untangle system backup includes the `globalSettings.js` file from Web Filter configuration.
> test_207_backup_includes_global_settings_file


**Before Change:** 

> ![beforeChange](https://github.com/user-attachments/assets/2a6981c0-be88-48c5-8036-f6cd8452eef2)


**After Change:**

> ![AfterChange](https://github.com/user-attachments/assets/742267fa-a4a7-4b53-875c-45e96cfdd20e)

> ![Screenshot from 2025-05-02 15-12-07](https://github.com/user-attachments/assets/fc09c4e1-277d-4f9d-8585-04f57a6354fd)
