### PR TITLE
NGFW-15107 Google drive oauth2 implementation using REST APIs

### DIFF
--- a/uvm/api/com/untangle/uvm/CloudApp.java
+++ b/uvm/api/com/untangle/uvm/CloudApp.java
@@ -48,6 +48,10 @@ public abstract class CloudApp implements java.io.Serializable, JSONString {
         this.clientSecret = clientSecret;
     }
 
+    public void decryptAndSetClientSecret(String encryptedClientSecret) {
+        this.clientSecret = PasswordUtil.getDecryptPassword(encryptedClientSecret);
+    }
+
     public String getScopes() {
         return scopes;
     }

--- a/uvm/api/com/untangle/uvm/GoogleCloudApp.java
+++ b/uvm/api/com/untangle/uvm/GoogleCloudApp.java
@@ -18,6 +18,10 @@ public class GoogleCloudApp extends CloudApp {
 
     private String relayServerUrl;
 
+    private String authUri;
+
+    private String tokenUri;
+
     /**
      * Default constructor
      */
@@ -26,20 +30,39 @@ public class GoogleCloudApp extends CloudApp {
     }
 
     /**
-     * Parameterized constructor
+     * Parameterized constructor (decrypts the encrypted params and initialize their plaintext counterparts)
      * @param appId
-     * @param apiKey
+     * @param encryptedApiKey
      * @param clientId
-     * @param clientSecret
+     * @param encryptedClientSecret
      * @param scopes
-     * @param redirectUrl
+     * @param redirectUri
      * @param relayServerUrl
      */
-    public GoogleCloudApp(String appId, String apiKey, String clientId, String clientSecret, String scopes, String redirectUrl, String relayServerUrl) {
-        super(clientId, clientSecret, scopes, redirectUrl);
+    public GoogleCloudApp(String appId, String encryptedApiKey, String clientId, String encryptedClientSecret, String scopes, String redirectUri, String relayServerUrl) {
+        super(clientId, PasswordUtil.getDecryptPassword(encryptedClientSecret), scopes, redirectUri);
         this.appId = appId;
-        this.apiKey = apiKey;
+        this.apiKey = PasswordUtil.getDecryptPassword(encryptedApiKey);
         this.relayServerUrl = relayServerUrl;
+    }
+
+
+    /**
+     * Parameterized constructor (decrypts the encrypted params and initialize their plaintext counterparts)
+     * @param appId
+     * @param encryptedApiKey
+     * @param clientId
+     * @param encryptedClientSecret
+     * @param scopes
+     * @param redirectUri
+     * @param relayServerUrl
+     * @param authUri
+     * @param tokenUri
+     */
+    public GoogleCloudApp(String appId, String encryptedApiKey, String clientId, String encryptedClientSecret, String scopes, String redirectUri, String relayServerUrl, String authUri, String tokenUri) {
+        this(appId, encryptedApiKey, clientId, encryptedClientSecret, scopes, redirectUri, relayServerUrl);
+        this.authUri = authUri;
+        this.tokenUri = tokenUri;
     }
 
     /**
@@ -75,6 +98,14 @@ public class GoogleCloudApp extends CloudApp {
     }
 
     /**
+     * Set apiKey by decrypting the param value
+     * @param encryptedApiKey
+     */
+    public void decryptAndSetApiKey(String encryptedApiKey) {
+        this.apiKey = PasswordUtil.getDecryptPassword(encryptedApiKey);
+    }
+
+    /**
      * Get relay server
      * @return
      */
@@ -88,5 +119,37 @@ public class GoogleCloudApp extends CloudApp {
      */
     public void setRelayServerUrl(String relayServerUrl) {
         this.relayServerUrl = relayServerUrl;
+    }
+
+    /**
+     * Get auth uri
+     * @return
+     */
+    public String getAuthUri() {
+        return authUri;
+    }
+
+    /**
+     * Set auth uri
+     * @param authUri
+     */
+    public void setAuthUri(String authUri) {
+        this.authUri = authUri;
+    }
+
+    /**
+     * get token uri
+     * @return
+     */
+    public String getTokenUri() {
+        return tokenUri;
+    }
+
+    /**
+     * set token uri
+     * @param tokenUri
+     */
+    public void setTokenUri(String tokenUri) {
+        this.tokenUri = tokenUri;
     }
 }

--- a/uvm/api/com/untangle/uvm/GoogleSettings.java
+++ b/uvm/api/com/untangle/uvm/GoogleSettings.java
@@ -9,13 +9,71 @@ import org.json.JSONString;
 /**
  * Settings for Google
  */
-@SuppressWarnings("serial")
+@SuppressWarnings({"deprecation", "serial"})
 public class GoogleSettings implements java.io.Serializable, JSONString
 {
+    private Integer version;
+
+    @Deprecated(forRemoval = true, since = "18")
     private String driveRefreshToken = null;
+
     private String googleDriveRootDirectory;
+
+    private String encryptedDriveAccessToken = null;
+
+    private String encryptedDriveRefreshToken = null;
+
+    private Integer accessTokenExpiresIn;
     
     public GoogleSettings() { }
+
+    /**
+     * Get encrypted access token
+     * @return
+     */
+    public String getEncryptedDriveAccessToken() {
+        return encryptedDriveAccessToken;
+    }
+
+    /**
+     * Set encrypted access token
+     * @param encryptedDriveAccessToken
+     */
+    public void setEncryptedDriveAccessToken(String encryptedDriveAccessToken) {
+        this.encryptedDriveAccessToken = encryptedDriveAccessToken;
+    }
+
+    /**
+     * Set token expiry (in seconds)
+     * @return
+     */
+    public Integer getAccessTokenExpiresIn() {
+        return accessTokenExpiresIn;
+    }
+
+    /**
+     * Get token expiry (in seconds)
+     * @param accessTokenExpiresIn
+     */
+    public void setAccessTokenExpiresIn(Integer accessTokenExpiresIn) {
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
+    }
+
+    /**
+     * Get encrypted refresh token
+     * @return
+     */
+    public String getEncryptedDriveRefreshToken() {
+        return encryptedDriveRefreshToken;
+    }
+
+    /**
+     * Set encrypted refresh token
+     * @param encryptedDriveRefreshToken
+     */
+    public void setEncryptedDriveRefreshToken(String encryptedDriveRefreshToken) {
+        this.encryptedDriveRefreshToken = encryptedDriveRefreshToken;
+    }
 
     public String getDriveRefreshToken() { return driveRefreshToken; }
     public void setDriveRefreshToken(String newValue) { this.driveRefreshToken = newValue; }
@@ -28,9 +86,35 @@ public class GoogleSettings implements java.io.Serializable, JSONString
         this.googleDriveRootDirectory = googleDriveRootDirectory;
     }
 
+    /**
+     * Get settings version.
+     *
+     * @return
+     *      Current settings version.
+     */
+    public Integer getVersion() { return this.version; }
+    /**
+     * Set setting settings.
+     *
+     * @param newValue
+     *      Set newversion.
+     */
+    public void setVersion( Integer newValue ) { this.version = newValue; }
+
     public String toJSONString()
     {
         JSONObject jO = new JSONObject(this);
         return jO.toString();
+    }
+
+    /**
+     * Clears the attributes
+     */
+    public void clear() {
+        this.driveRefreshToken = null;
+        this.googleDriveRootDirectory = null;
+        this.encryptedDriveAccessToken = null;
+        this.encryptedDriveRefreshToken = null;
+        this.accessTokenExpiresIn = null;
     }
 }

--- a/uvm/api/com/untangle/uvm/util/Constants.java
+++ b/uvm/api/com/untangle/uvm/util/Constants.java
@@ -24,6 +24,8 @@ public class Constants {
     public static final String COMMA_STRING = ",";
 
     public static final String EQUALS_TO = "=";
+    public static final String SLASH = "/";
+    public static final String DOUBLE_SLASH = "//";
 
     // Boolean
     public static final String FALSE = "False";

--- a/uvm/hier/usr/share/untangle/bin/ut-google-drive-helper.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-google-drive-helper.sh
@@ -9,22 +9,16 @@ get_json_value() {
   python3 -m simplejson.tool $2 | grep "$json_key" | awk '{print $2}' | sed 's/[",[:space:]]//g' | tr -d '\t' | tr -d '\n'
 }
 
-refreshToken()
-{
-    shift
-    get_json_value "refresh_token" "$1.gd/credentials.json"
-}
-
 appId()
 {
     shift
     get_json_value "app_id" "$1.gd/credentials.json"
 }
 
-apiKey()
+encryptedApiKey()
 {
     shift
-    get_json_value "api_key" "$1.gd/credentials.json"
+    get_json_value "encrypted_api_key" "$1.gd/credentials.json"
 }
 
 clientId()
@@ -33,10 +27,10 @@ clientId()
     get_json_value "client_id" "$1.gd/credentials.json"
 }
 
-clientSecret()
+encryptedClientSecret()
 {
     shift
-    get_json_value "client_secret" "$1.gd/credentials.json"
+    get_json_value "encrypted_client_secret" "$1.gd/credentials.json"
 }
 
 scopes()
@@ -45,10 +39,22 @@ scopes()
     get_json_value "scopes" "$1.gd/credentials.json"
 }
 
-redirectUrl()
+redirectUri()
 {
     shift
-    get_json_value "redirect_url" "$1.gd/credentials.json"
+    get_json_value "redirect_uri" "$1.gd/credentials.json"
+}
+
+authUri()
+{
+    shift
+    get_json_value "auth_uri" "$1.gd/credentials.json"
+}
+
+tokenUri()
+{
+    shift
+    get_json_value "token_uri" "$1.gd/credentials.json"
 }
 
 $1 "$@"

--- a/uvm/impl/com/untangle/uvm/UriManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/UriManagerImpl.java
@@ -342,6 +342,10 @@ public class UriManagerImpl implements UriManager
         uriTranslation.setUri("https://auth-relay.edge.arista.com");
         uriTranslations.add(uriTranslation);
 
+        uriTranslation = new UriTranslation();
+        uriTranslation.setUri("https://www.googleapis.com/oauth2/v3/tokeninfo");
+        uriTranslations.add(uriTranslation);
+
         return uriTranslations;
     }
 

--- a/uvm/servlets/admin/config/administration/MainController.js
+++ b/uvm/servlets/admin/config/administration/MainController.js
@@ -990,9 +990,9 @@ Ext.define('Ung.config.administration.MainController', {
 
                     v.down('[name=fieldsetDriveEnabled]').setVisible(isConnected);
                     v.down('[name=fieldsetDriveDisabled]').setVisible(!isConnected);
+                    vm.set({ googleSettings: googleSettings });
 
-                    if ( isConnected && googleSettings.driveRefreshToken != vm.get('googleSettings.driveRefreshToken')){
-                        vm.set({ googleSettings: googleSettings });
+                    if (isConnected){
                         me.refreshGoogleTask.stop();
                         return;
                     }


### PR DESCRIPTION
- `drive` cli package is no longer used. As a result, retrieving/refreshing access token, handling authorization and authentication has to be done by untangle-vm using google REST APIs.
- Migrate older google drive settings to newer version (v1) by also getting a new access token.
settings before upgrade
```
[root @ arista] ~ # cat /usr/share/untangle/settings/untangle-vm/google.js
{
    "driveRefreshToken": "<REFRESH_TOKEN>",
    "googleDriveRootDirectory": "New NGFW Backups",
    "javaClass": "com.untangle.uvm.GoogleSettings"
}
```
after upgrade, (same refresh token is retained in encrypted form, retrieved new access token, stored in encrypted form, and kept directory selection as is.
```
{
    "accessTokenExpiresIn": 3599,
    "encryptedDriveAccessToken": "5/6qk8A1IFD/lOZOBgxqnsFm/jYupph32QT6JMBCAKwSI9uSbpblV+PdHxLrnsdLBnbioyNSXEZAXdq4Sg9RhjhmQk2Ti36yJQgimUjYwjgzUDrubitj4ABe1nZABH0JlC9pMvz0D+MU9X/Kt/in2Bq0OB450kgfPW23+lU7phZyXVL8UFGlRoDbjkPd7aKDgL+Z9RrlhtIWed8BAS5JADno5HN56XyHwxNTUBogG2LfInLVx/9GbY7/1vfNTSkkkfTD1aUWZ4P/oDS0hZeqZ+4XvZ94w7p1O+c+Omn/vuMkpWUfmPPEQvowGAsx12HH:JcJcDDJ5zHijFyqR:HiHwmFSVFveBV8Qf+kQ1dg==",
    "encryptedDriveRefreshToken": "apvdXVBmqpxxbT/OjBqKwJBrTxGcnJW3H8M9SxxRYDCPBdnfyWyORyHfsFfN90+Gt8CcI08aZHz8FPGF385sFKWNJNblH4oPGFHsnOiTMgxZNKnu5uPWzkipdS/RyTdEsIkkegrAd/AB7z2MDVMqRhHAyGEPcdk=:3GWsGH8KRiosumE6:n8KKZYDvRxImjU1y/6CrLw==",
    "googleDriveRootDirectory": "New NGFW Backups",
    "javaClass": "com.untangle.uvm.GoogleSettings",
    "version": 1
}

```
- Since credentials.json now only holds drive connector app details, we no need to remove this file as opposed in older implementation during disconnectDrive and setSettings.
- Fresh drive configuration's authorization and authentication is also done using REST APIs.