### PR TITLE
Ngfw 15107 Resolving google directory with its folderId

### DIFF
--- a/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupSettings.java
+++ b/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupSettings.java
@@ -17,6 +17,7 @@ public class ConfigurationBackupSettings implements Serializable, JSONString
     private int minuteInHour;
     private boolean googleDriveEnabled = true;
     private String  googleDriveDirectory = "Configuration Backups";
+    private String googleDriveDirectoryId;
     
     public ConfigurationBackupSettings() { }
 
@@ -31,7 +32,15 @@ public class ConfigurationBackupSettings implements Serializable, JSONString
 
     public String getGoogleDriveDirectory() { return googleDriveDirectory; }
     public void setGoogleDriveDirectory( String newValue ) { this.googleDriveDirectory = newValue; }
-    
+
+    public String getGoogleDriveDirectoryId() {
+        return googleDriveDirectoryId;
+    }
+
+    public void setGoogleDriveDirectoryId(String googleDriveDirectoryId) {
+        this.googleDriveDirectoryId = googleDriveDirectoryId;
+    }
+
     /**
      * Convert settings to JSON string.
      *

--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -197,6 +197,9 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
                 }
             }
         }
+
+        // // Set google drive folderId
+        setGoogleDriveDirectoryFolderId(newSettings);
         
         /**
          * Save the settings
@@ -649,6 +652,15 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
             settings.setVersion(6);
         }
 
+        /**
+         * Set google directory folderId
+         */
+        if (settings.getVersion() == null || settings.getVersion() < 7) {
+            setGoogleDriveDirectoryFolderId(settings);
+            settings.setVersion(7);
+            setSettings(settings, false);
+        }
+
         /* sync settings to disk if necessary */
         File settingsFile = new File( settingsFileName );
         if (settingsFile.lastModified() > CRON_FILE.lastModified()){
@@ -657,6 +669,17 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
 
         if(settingsFile.lastModified() > HOURLY_CRON_FILE.lastModified()) {
             writeHourlyCron();
+        }
+    }
+
+    /**
+     * Set app's google drive folderId (must call setSettings after this method call)
+     * @param settings
+     */
+    private void setGoogleDriveDirectoryFolderId(ReportsSettings settings) {
+        if (getGoogleManager().isGoogleDriveConnected()) {
+            String appDirectoryId = getGoogleManager().getAppSpecificGoogleDriveFolderId(settings.getGoogleDriveDirectory());
+            settings.setGoogleDriveDirectoryId(appDirectoryId);
         }
     }
 

--- a/reports/src/com/untangle/app/reports/ReportsSettings.java
+++ b/reports/src/com/untangle/app/reports/ReportsSettings.java
@@ -44,6 +44,7 @@ public class ReportsSettings implements Serializable, JSONString
     private boolean googleDriveUploadData = false;
     private boolean googleDriveUploadCsv = false;
     private String  googleDriveDirectory = "Reports Backups";
+    private String  googleDriveDirectoryId;
     
     public ReportsSettings() { }
 
@@ -112,6 +113,14 @@ public class ReportsSettings implements Serializable, JSONString
     
     public String getGoogleDriveDirectory() { return googleDriveDirectory; }
     public void setGoogleDriveDirectory( String newValue ) { this.googleDriveDirectory = newValue; }
+
+    public String getGoogleDriveDirectoryId() {
+        return googleDriveDirectoryId;
+    }
+
+    public void setGoogleDriveDirectoryId(String googleDriveDirectoryId) {
+        this.googleDriveDirectoryId = googleDriveDirectoryId;
+    }
 
     /**
      * @deprecated

--- a/uvm/api/com/untangle/uvm/GoogleManager.java
+++ b/uvm/api/com/untangle/uvm/GoogleManager.java
@@ -3,8 +3,6 @@
  */
 package com.untangle.uvm;
 
-import org.json.JSONObject;
-
 /**
  * Describe interface <code>GoogleManager</code> here.
  */
@@ -17,6 +15,8 @@ public interface GoogleManager
     public boolean isGoogleDriveConnected();
 
     String getAppSpecificGoogleDrivePath(String appDirectory);
+
+    String getAppSpecificGoogleDriveFolderId(String appDirectory);
 
     public String getAuthorizationUrl(String windowProtocol, String windowLocation );
 

--- a/uvm/api/com/untangle/uvm/GoogleSettings.java
+++ b/uvm/api/com/untangle/uvm/GoogleSettings.java
@@ -20,6 +20,8 @@ public class GoogleSettings implements java.io.Serializable, JSONString
 
     private String googleDriveRootDirectory;
 
+    private String googleDriveRootDirectoryId;
+
     private String encryptedDriveAccessToken = null;
 
     private String encryptedDriveRefreshToken = null;
@@ -93,6 +95,22 @@ public class GoogleSettings implements java.io.Serializable, JSONString
     }
 
     /**
+     * Get fileId of root directory
+     * @return
+     */
+    public String getGoogleDriveRootDirectoryId() {
+        return googleDriveRootDirectoryId;
+    }
+
+    /**
+     * Set fileId of root directory
+     * @return
+     */
+    public void setGoogleDriveRootDirectoryId(String googleDriveRootDirectoryId) {
+        this.googleDriveRootDirectoryId = googleDriveRootDirectoryId;
+    }
+
+    /**
      * Get settings version.
      *
      * @return
@@ -135,6 +153,7 @@ public class GoogleSettings implements java.io.Serializable, JSONString
     public void clear() {
         this.driveRefreshToken = null;
         this.googleDriveRootDirectory = null;
+        this.googleDriveRootDirectoryId = null;
         this.encryptedDriveAccessToken = null;
         this.encryptedDriveRefreshToken = null;
         this.accessTokenExpiresIn = null;

--- a/uvm/impl/com/untangle/uvm/UriManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/UriManagerImpl.java
@@ -346,6 +346,10 @@ public class UriManagerImpl implements UriManager
         uriTranslation.setUri("https://www.googleapis.com/oauth2/v3/tokeninfo");
         uriTranslations.add(uriTranslation);
 
+        uriTranslation = new UriTranslation();
+        uriTranslation.setUri("https://www.googleapis.com/drive/v3/files");
+        uriTranslations.add(uriTranslation);
+
         return uriTranslations;
     }
 

--- a/uvm/servlets/admin/config/administration/MainController.js
+++ b/uvm/servlets/admin/config/administration/MainController.js
@@ -1044,6 +1044,7 @@ Ext.define('Ung.config.administration.MainController', {
     openIframe: function(messageData) {
         var me = this,
             fileName = null,
+            fileId = null,
             vm = me.getViewModel(),
             iframe,
         iframeWindow = Ext.create('Ext.window.Window', {
@@ -1107,6 +1108,7 @@ Ext.define('Ung.config.administration.MainController', {
                             break;
                         case 'fileSelected':
                             fileName = event.data.fileName;
+                            fileId = event.data.fileId;
                             resolve();
                             break;
                         case 'cancel':
@@ -1118,6 +1120,9 @@ Ext.define('Ung.config.administration.MainController', {
         }).then(function() {
             if(fileName) {
                 vm.set('googleSettings.googleDriveRootDirectory', fileName);
+            }
+            if(fileId) {
+                vm.set('googleSettings.googleDriveRootDirectoryId', fileId);
             }
             if(iframeWindow) {
                 iframeWindow.close();


### PR DESCRIPTION
- Folder selection from Google tab using Picker now also gets the folderId of the selected folder.
- Added methods to, resolve the folderId of the input directory under a specified parent folder. Creates the folder if not present (controlled by `createFolder` flag).
- During upgrades, google manager sets the folderId of the root folder (selected from Picker) only if folder name is available and drive is configured.
- For Reports and Configuration Apps, upgrades set folderId of the respective app folder names. Looks for folder under root directory set in google settings.
- App setSettings fetches the folderId of the input folder name.