### PR TITLE
ngfw-15134 - Fixed threat-prevention : test_551_https_with_sni_packet_split

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_syslog.py
@@ -1,5 +1,6 @@
 import copy
 import pytest
+import subprocess
 
 from tests.common import NGFWTestCase
 import tests.global_functions as global_functions
@@ -23,6 +24,17 @@ class SysLogTests(NGFWTestCase):
     def module_name():
         return "syslog"
     
+    def checkSyslogStatus(self):
+        # Check rsyslog service status and reset if failed
+        status_output = subprocess.run(
+            ["systemctl", "is-failed", "rsyslog"],
+            capture_output=True,
+            text=True
+        )
+
+        if status_output.returncode == 0 and status_output.stdout.strip() == "failed":
+            subprocess.run(["systemctl", "reset-failed", "rsyslog"])
+
     def test_050_disable_syslog(self):
         syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
@@ -36,7 +48,8 @@ class SysLogTests(NGFWTestCase):
           pass
         global_functions.uvmContext.eventManager().setSettings(orig_settings)
 
-    def test_050_enable_syslog(self):
+    def test_051_enable_syslog(self):
+        self.checkSyslogStatus()
         #covering scenario of setup where default syslog is enabled and configured
         syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
@@ -66,7 +79,8 @@ class SysLogTests(NGFWTestCase):
         assert (syslogUpdatedSettings['syslogRules']['list'][0]['syslogServers']['list'][0] == 2)
         global_functions.uvmContext.eventManager().setSettings(orig_settings)
 
-    def test_050_enable_syslog_withouthostnameset(self):
+    def test_052_enable_syslog_withouthostnameset(self):
+        self.checkSyslogStatus()
         #covering scenario of setup where default syslog is enabled and sysloghost not set configured
         syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
@@ -82,7 +96,8 @@ class SysLogTests(NGFWTestCase):
         global_functions.uvmContext.eventManager().setSettings(orig_settings)
 
 
-    def test_050_multiple_syslogservers(self):
+    def test_053_multiple_syslogservers(self):
+        self.checkSyslogStatus()
         initial_logservers = 0
         syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)
@@ -100,7 +115,8 @@ class SysLogTests(NGFWTestCase):
         global_functions.uvmContext.eventManager().setSettings(orig_settings)
 
 
-    def test_050_delete_syslogservers(self):
+    def test_054_delete_syslogservers(self):
+        self.checkSyslogStatus()
         initial_logservers = 0
         syslogSettings = global_functions.uvmContext.eventManager().getSettings()
         orig_settings = copy.deepcopy(syslogSettings)


### PR DESCRIPTION
Calling the syslog setSettings method caused the rsyslog status to change to 'failed' because a restart was triggered before the first execution completed. As a result, no logs were generated afterward. The issue was fixed by checking the rsyslog status and restarting the service if it was in a failed state. This issue occurs only in test cases, as multiple setSettings calls are made in rapid succession without any delay between them.

**BEFORE :**
![ngfw-15134-BEFORE](https://github.com/user-attachments/assets/7b4d5488-4d04-47bc-81bc-1b501dc1f01a)

**AFTER:**
![ngfw-15134-AFTER](https://github.com/user-attachments/assets/4fd269da-dfa6-4e01-9cf6-8ea8457b2502)
