### PR TITLE
ngfw-13480 : Added validation to restrict public address in peer address

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -938,6 +938,44 @@ Ext.define('Ung.util.Util', {
         }
     },
 
+    /**
+     * Checks whether a given CIDR block belongs to a private IP address space.
+     *
+     * Private IP ranges (as defined in RFC 1918) include:
+     * - 10.0.0.0/8
+     * - 172.16.0.0/12
+     * - 192.168.0.0/16
+     *
+     * @param {string} cidr - The CIDR notation string (e.g., "192.168.1.0/24") to validate.
+     * @returns {boolean} - Returns true if the CIDR is within a private IP range; false otherwise.
+     *
+     * @example
+     * isPrivateCIDR("192.168.1.0/24"); // true
+     * isPrivateCIDR("8.8.8.0/24");     // false
+     */
+    isPrivateCIDR: function(cidr) {
+        try {
+            var parts = cidr.split('/');
+            var ip = parts[0].split('.');
+            if (ip.length !== 4) return false;
+    
+            for (var i = 0; i < ip.length; i++) {
+                var num = parseInt(ip[i], 10);
+                if (isNaN(num) || num < 0 || num > 255) return false;
+                ip[i] = num; // Convert to integer for next checks
+            }
+    
+            if (ip[0] === 10) return true;
+            if (ip[0] === 172 && ip[1] >= 16 && ip[1] <= 31) return true;
+            if (ip[0] === 192 && ip[1] === 168) return true;
+    
+            return false; // Not private
+        } catch (e) {
+            return false;
+        }
+    },
+    
+
     isIPInRange: function (ip, network, netmask) {
         // Split the IP address into octets
         var nextPoolOctets = ip.split('.');

--- a/wireguard-vpn/js/view/Settings.js
+++ b/wireguard-vpn/js/view/Settings.js
@@ -280,6 +280,11 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                             if(!isValidVtypeField){
                                 return true;
                             }
+
+                            // Ensure the network is in a private IP range
+                            if (!Util.isPrivateCIDR(value)) {
+                                return "Only private IP ranges are allowed (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)";
+                            }
                             var localNetworkStoreFn = this.up('#settings').down('#localNetworkGrid').getStore();
 
                             var localNetworkStore = [];
@@ -288,13 +293,13 @@ Ext.define('Ung.apps.wireguard-vpn.view.Settings', {
                                 if(profile.get("subnetsAsString")){
                                     var subnets = profile.get("subnetsAsString").split(',');
                                     for (var i = 0; i < subnets.length; i++) {
-                                        subnet = subnets[i].trim();
-                                        if(localNetworkStore.indexOf(subnet) === -1) 
+                                        var subnet = subnets[i].trim();
+                                        if (subnet !== "0.0.0.0/0" && localNetworkStore.indexOf(subnet) === -1) {
                                             localNetworkStore.push(subnet);
+                                        }
                                     }
                                 }
                             });
-
                             return Util.findIpPoolConflict(value, localNetworkStore, this, true);
 
                         } catch(err) {


### PR DESCRIPTION
**ISSUE:** Wireguard VPN server Peer IP address pool Network space is manually able assign as the Public network space.

**FIXED:** Added validation so peer IP address Pool network space should only allow Private IP network range.

- **Network space should be in valid CIDR format**
![Screenshot from 2025-05-20 11-51-12](https://github.com/user-attachments/assets/f3ecd0e0-3d7c-4084-bd5b-2343d5afa987)
-  **Network space with conflicting network should give any error**
![Screenshot from 2025-05-20 11-51-05](https://github.com/user-attachments/assets/eda82204-610b-4ca3-8556-c42838f66044)
- **Public network should give error**
![Screenshot from 2025-05-20 11-50-23](https://github.com/user-attachments/assets/836022b5-79cb-4f41-9bd5-2d35fd5ffc27)
- **Valid network space should not give any error**
![Screenshot from 2025-05-20 11-51-20](https://github.com/user-attachments/assets/8879b0ea-3d01-4aef-8176-279d3ea806d4)
