### PR TITLE
Ngfw 15107 Google drive root directory is now optional

### DIFF
--- a/configuration-backup/js/view/GoogleConnector.js
+++ b/configuration-backup/js/view/GoogleConnector.js
@@ -18,15 +18,6 @@ Ext.define('Ung.apps.configurationbackup.view.GoogleConnector', {
                 style: { color: '{googleDriveIsConfigured ? "green" : "red"}'}
             }
         },{
-            xtype: 'component',
-            hidden: true,
-            margin: '0 0 0 10',
-            bind: {
-                hidden: '{rootDirectory}',
-                html: 'The Google Drive directory is not selected.'.t(),
-                style: { color: "red" }
-            }
-        },{
             xtype: "button",
             text: 'Configure Google Drive'.t(),
             iconCls: "fa fa-check-circle",
@@ -40,8 +31,8 @@ Ext.define('Ung.apps.configurationbackup.view.GoogleConnector', {
             hidden: true,
             disabled: true,
              bind: {
-                 hidden: '{googleDriveIsConfigured == false || !rootDirectory}',
-                 disabled: '{googleDriveIsConfigured == false || !rootDirectory}'
+                 hidden: '{googleDriveIsConfigured == false}',
+                 disabled: '{googleDriveIsConfigured == false}'
              },
             items: [{
                 xtype: "checkbox",
@@ -75,7 +66,9 @@ Ext.define('Ung.apps.configurationbackup.view.GoogleConnector', {
                     labelWidth: 150,
                     renderer: function() {
                         var rootDirectory = Rpc.directData('rpc.UvmContext.googleManager.getAppSpecificGoogleDrivePath', null);
-                        return Ext.String.format('<strong><span class="cond-val"> {0}</span></strong>', rootDirectory + " /");
+                        if (!rootDirectory || rootDirectory.trim() === '')
+                            return '';
+                        return Ext.String.format('<strong><span class="cond-val">{0}</span></strong>', rootDirectory + " /");
                     }
                 },{
                     xtype: 'textfield',

--- a/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
+++ b/configuration-backup/src/com/untangle/app/configuration_backup/ConfigurationBackupApp.java
@@ -331,7 +331,7 @@ public class ConfigurationBackupApp extends AppBase
         catch (GoogleDriveOperationFailedException e) {
             exitCode = e.getExitCode();
             output = e.getMessage();
-            logger.warn("Exception running backup",e);
+            logger.warn("Exception running backup", e);
         }
 
         if(exitCode != 0) {
@@ -339,9 +339,13 @@ public class ConfigurationBackupApp extends AppBase
 
             String reason = null;
             switch(exitCode) {
-            default:
-                reason = "Unknown error. Make sure your google drive is correctly configured. Error: " + output;
-            }
+                case 401:
+                    reason = "Either google account credentials have changed or drive connector no longer has access to google drive." +
+                            "Try reconfiguring the google drive." + output;
+                    break;
+                default:
+                    reason = "Unknown error. Make sure your google drive is correctly configured. Error: " + output;
+                }
             logger.warn("Backup failed: {}", reason);
             this.logEvent( new ConfigurationBackupEvent(false, reason, I18nUtil.marktr("Google Drive")) );
         }

--- a/reports/js/view/Data.js
+++ b/reports/js/view/Data.js
@@ -80,14 +80,6 @@ Ext.define('Ung.apps.reports.view.Data', {
                  style: { color: '{googleDriveConfigured ? "green" : "red"}'}
              }
          }, {
-            xtype: 'component',
-            hidden: true,
-            bind: {
-                hidden: '{rootDirectory}',
-                html: 'The Google Drive directory is not selected.'.t(),
-                style: { color: "red" }
-            }
-        }, {
              xtype: 'button',
              text: 'Configure Google Drive'.t(),
              margin: '10 0 15 0',
@@ -98,7 +90,7 @@ Ext.define('Ung.apps.reports.view.Data', {
              disabled: true,
              bind: {
                  value: '{settings.googleDriveUploadData}',
-                 disabled: '{!googleDriveConfigured || !rootDirectory}'
+                 disabled: '{!googleDriveConfigured}'
              },
              listeners: {
                  render: function(obj) {
@@ -111,7 +103,7 @@ Ext.define('Ung.apps.reports.view.Data', {
              disabled: true,
              bind: {
                  value: '{settings.googleDriveUploadCsv}',
-                 disabled: '{!googleDriveConfigured || !rootDirectory}'
+                 disabled: '{!googleDriveConfigured}'
              },
              listeners: {
                  render: function(obj) {
@@ -123,8 +115,8 @@ Ext.define('Ung.apps.reports.view.Data', {
             disabled: true,
             hidden: true,
             bind: {
-                disabled: '{!googleDriveConfigured || !rootDirectory}',
-                hidden: '{!googleDriveConfigured || !rootDirectory}'
+                disabled: '{!googleDriveConfigured}',
+                hidden: '{!googleDriveConfigured}'
             },
             layout: {
                 type: 'hbox'
@@ -136,7 +128,9 @@ Ext.define('Ung.apps.reports.view.Data', {
                 labelWidth: 150,
                 renderer: function() {
                     var rootDirectory = Rpc.directData('rpc.UvmContext.googleManager.getAppSpecificGoogleDrivePath', null);
-                    return Ext.String.format('<strong><span class="cond-val"> {0}</span></strong>', rootDirectory + " /");
+                    if (!rootDirectory || rootDirectory.trim() === '')
+                        return '';
+                    return Ext.String.format('<strong><span class="cond-val">{0}</span></strong>', rootDirectory + " /");
                 }
             },{
                 xtype: 'textfield',

--- a/uvm/api/com/untangle/uvm/util/Pulse.java
+++ b/uvm/api/com/untangle/uvm/util/Pulse.java
@@ -219,6 +219,15 @@ public class Pulse implements Runnable
     }
 
     /**
+     * Stops the running thread
+     */
+    public void stopIfRunning() {
+        if (this.getState() == PulseState.RUNNING) {
+            this.stop();
+        }
+    }
+
+    /**
      * Stop the thread, you can only start a pulse once and once it is stopped,
      * you can never restart it.
      */

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -19,6 +19,7 @@ import urllib3
 import fnmatch
 import base64
 
+from urllib.parse import urlparse, parse_qs
 from tests.common import NGFWTestCase
 import tests.global_functions as global_functions
 import runtests.test_registry as test_registry
@@ -1424,5 +1425,35 @@ class UvmTests(NGFWTestCase):
 
         # Set old settings
         global_functions.uvmContext.deviceTable().setDevicesSettings(oldDevicesSettings)
+
+    def test_320_google_drive_authorization_url(self):
+        """ Test to check if the google drive authorization URL contains valid google drive connector oauth2 credentials"""
+
+        creds_file = '/var/lib/google-drive/.gd/credentials.json'
+        auth_url = global_functions.uvmContext.googleManager().getAuthorizationUrl('http:', global_functions.get_lan_ip())
+
+        with open(creds_file, 'r') as f:
+            creds = json.load(f)
+        
+        expected = creds["web"]  # expected['client_id'], expected['redirect_uri']
+        
+        # Parse the URL
+        parsed = urlparse(auth_url)
+        query = parse_qs(parsed.query)
+
+        # Extract values from query parameters
+        client_id = query.get("client_id", [None])[0]
+        redirect_uri = query.get("redirect_uri", [None])[0]
+
+        result = True
+        if client_id != expected.get("client_id"):
+            result = False
+            print(f"Expected client_id: {expected.get('client_id')}, actual: {client_id}")
+
+        if redirect_uri != expected.get("redirect_uri"):
+            result = False
+            print(f"Expected redirect_uri: {expected.get('redirect_uri')}, actual: {redirect_uri}")
+
+        assert(result)
 
 test_registry.register_module("uvm", UvmTests)

--- a/uvm/servlets/admin/config/administration/view/Google.js
+++ b/uvm/servlets/admin/config/administration/view/Google.js
@@ -68,20 +68,24 @@ Ext.define('Ung.config.administration.view.Google', {
                 items: [{
                     xtype: "textfield",
                     margin: '10',
-                    readOnly: true,
-                    emptyText: "No Directory Selected".t(),
+                    emptyText: "No root directory entered".t(),
                     regex: /^[\w\. \/]+$/,
                     regexText: "The field can have only alphanumerics, spaces, or periods.".t(),
-                    fieldLabel: "Google Drive Directory".t(),
-                    labelWidth: 200,
+                    fieldLabel: "Optional Google Drive Root Directory".t(),
+                    labelWidth: 220,
                     bind: '{googleSettings.googleDriveRootDirectory}',
                     autoEl: {
                         tag: 'div',
-                        'data-qtip': "The destination directory in google drive.".t()
+                        'data-qtip': "Root directory in Google Drive where app directories will be created. If not set, app directories will be created at the top level.".t()
                     }
                 }, {
+                    xtype: 'component',
+                    html: 'Or',
+                    margin: '15',
+                    style: { fontSize: '12px', fontWeight: 500 }
+                }, {
                     xtype: 'button',
-                    text: 'Select Directory'.t(),
+                    text: 'Select Existing Directory'.t(),
                     itemId: 'selectDirButton',
                     margin: '10',
                     handler: 'handleSelectDirectory',


### PR DESCRIPTION
- Root google drive directory settings (Administration -> Google) is now optional.
![image](https://github.com/user-attachments/assets/bc34d4ac-e38d-4491-a06f-f182ec48a751)
- This root google drive directory can be manually entered as opposed to be only set via Select Directory option using Picker functionality.
- If set manually, user no need to create this root directory on their google drive. NGFW will create this directory.
- If not set manually, users can still select an existing directory from their drive as it is currently supported.
- Generating specific event for 401 token invalid error.
![image](https://github.com/user-attachments/assets/ded47d50-8e39-4be5-93f8-96e8d2db1548)
- If root google drive directory is kept empty then app specific directories (configuration backup and reports) will get created at root level on google drive.
- ATS test case to verify client_id and redirect_uri from credentials.json against the API that returns google authorization URL
