### PR TITLE
 ngfw-15106 : Openvpn site-to-site connection Inline Import Implementation

### DIFF
--- a/openvpn/hier/usr/share/untangle/bin/openvpn-import-config
+++ b/openvpn/hier/usr/share/untangle/bin/openvpn-import-config
@@ -1,76 +1,104 @@
-#! /bin/bash
+#!/bin/bash
 
-# 
-# This script imports a config file containing the necessary configuration to connect to a remote server
-# It stores the files in settings, OpenVpnManager will later copy them into place
+#
+# This script imports a config file containing the necessary configuration to connect to a remote server.
+# It stores the files in settings; OpenVpnManager will later copy them into place.
 #
 
-filename="${1}"
-destination=`mktemp || -3`
+set -euo pipefail
 
-cleanup()
-{
-    if [ ! -z ${TMPDIR} ] ; then
-        rm -rf ${TMPDIR};  
+filename="${1:-}"
+TMPDIR=""
+
+cleanup() {
+    if [[ -n "${TMPDIR}" && -d "${TMPDIR}" ]]; then
+        rm -rf "${TMPDIR}"
     fi
-    exit -1
+    exit 1
 }
 
-if [ ! -f "${filename}" ]; then
+if [[ -z "${filename}" || ! -f "${filename}" ]]; then
     echo "Unable to find the file: ${filename}"
-    exit -1
+    exit 1
 fi
 
-TMPDIR=`mktemp -d || exit -3`
+ext="${filename##*.}"
 
-unzip -q ${filename} -d ${TMPDIR} || { rm -rf ${TMPDIR};  exit -1 ; }
+case "$ext" in
+    zip)
+        TMPDIR=$(mktemp -d) || exit 3
 
-CONFNAME="`ls ${TMPDIR}/untangle-vpn/*.conf`"
+        if ! unzip -q "${filename}" -d "${TMPDIR}"; then
+            cleanup
+        fi
 
-if [ -z "$CONFNAME" ] ; then
-    echo "Missing conf file"
-    exit -1
-fi
+        CONF_FILE_PATH=$(find "${TMPDIR}/untangle-vpn" -name "*.conf" | head -n 1)
 
-SITENAME="`basename $CONFNAME | sed -e 's/.conf//'`"
+        if [[ -z "${CONF_FILE_PATH}" || ! -f "${CONF_FILE_PATH}" ]]; then
+            echo "Missing conf file"
+            cleanup
+        fi
 
-# echo sitename to stdout
-# This is important because the java code launching this script
-# will use this to determine the site name. Do not remove.
-echo "SiteName: ${SITENAME}" 
+        SITENAME=$(basename "${CONF_FILE_PATH}" .conf)
 
-if [ -z "$SITENAME" ] ; then
-    echo "Missing site name"
-    exit -1
-fi
+        # Output site name (required by Java code)
+        echo "SiteName: ${SITENAME}"
 
-## Copy in the necessary files
-mkdir -p @PREFIX@/usr/share/untangle/settings/openvpn/remote-servers/
-mkdir -p @PREFIX@/usr/share/untangle/settings/openvpn/remote-servers/keys/
+        if [[ -z "${SITENAME}" ]]; then
+            echo "Missing site name"
+            cleanup
+        fi
 
-CONF_FILE="@PREFIX@/usr/share/untangle/settings/openvpn/remote-servers/${SITENAME}.conf"
+        CONF_DIR="@PREFIX@/usr/share/untangle/settings/openvpn/remote-servers"
+        KEYS_DIR="${CONF_DIR}/keys"
+        CONF_FILE="${CONF_DIR}/${SITENAME}.conf"
 
-cp ${TMPDIR}/untangle-vpn/*.conf ${CONF_FILE}
+        mkdir -p "${CONF_DIR}" "${KEYS_DIR}"
 
-if [ $? != 0 ] ; then
-    echo "Copy failed"
-    cleanup
-fi
+        if ! cp "${CONF_FILE_PATH}" "${CONF_FILE}"; then
+            echo "Copy failed"
+            cleanup
+        fi
 
-if [ -d ${TMPDIR}/untangle-vpn/keys ] ; then
-    cp -r ${TMPDIR}/untangle-vpn/keys/* @PREFIX@/usr/share/untangle/settings/openvpn/remote-servers/keys/
-fi
+        if [[ -d "${TMPDIR}/untangle-vpn/keys" ]]; then
+            if ! cp -r "${TMPDIR}/untangle-vpn/keys/"* "${KEYS_DIR}/"; then
+                echo "Key Copy failed"
+                echo "${TMPDIR}"
+                cleanup
+            fi
+        fi
 
-if [ $? != 0 ] ; then
-    echo "Key Copy failed"
-    echo ${TMPDIR}
-    exit
-    cleanup
-fi
+        rm -rf "${TMPDIR}"
 
-## Cleanup
-rm -rf ${TMPDIR}
+        echo "New configuration imported: ${CONF_FILE}"
+        ;;
 
-echo "New configuration imported: ${CONF_FILE}"
+    ovpn)
+        SITENAME=$(basename "${filename}" .ovpn | sed -E 's/[ ()]//g; s/-[0-9]+$//')
 
-true
+        # Output site name (required by Java code)
+        echo "SiteName: ${SITENAME}"
+
+        if [[ -z "${SITENAME}" ]]; then
+            echo "Missing site name"
+            exit 1
+        fi
+
+        CONF_DIR="@PREFIX@/usr/share/untangle/settings/openvpn/remote-servers"
+        CONF_FILE="${CONF_DIR}/${SITENAME}.conf"
+
+        mkdir -p "${CONF_DIR}"
+
+        if ! cp "${filename}" "${CONF_FILE}"; then
+            echo "Failed to copy .ovpn file"
+            exit 1
+        fi
+
+        echo "Inline .ovpn configuration imported: ${CONF_FILE}"
+        ;;
+
+    *)
+        echo "Unsupported file format: .${ext}"
+        exit 2
+        ;;
+esac

--- a/openvpn/servlets/openvpn/src/com/untangle/app/openvpn/servlet/UploadConfig.java
+++ b/openvpn/servlets/openvpn/src/com/untangle/app/openvpn/servlet/UploadConfig.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 import com.untangle.uvm.UvmContextFactory;
+import com.untangle.uvm.util.Constants;
 import com.untangle.app.openvpn.OpenVpnAppImpl;
 
 /**
@@ -40,6 +41,8 @@ import com.untangle.app.openvpn.OpenVpnAppImpl;
 public class UploadConfig extends HttpServlet
 {
     private static ServletFileUpload SERVLET_FILE_UPLOAD;
+    private final static  String ZIP_EXTENSION = ".zip";
+    private final static  String OVPN_EXTENSION = ".ovpn";
 
     private final Logger logger = LogManager.getLogger(this.getClass());
 
@@ -120,7 +123,7 @@ public class UploadConfig extends HttpServlet
         if (StringUtils.isNotBlank(fileName)){
             int dotIndex = fileName.lastIndexOf('.');
             if (dotIndex > 0 && dotIndex < fileName.length() - 1) {
-                finalName = fileName.substring(0, dotIndex)+"-";
+                finalName = fileName.substring(0, dotIndex) + Constants.HYPHEN;
                 extension = fileName.substring(dotIndex);
             } else {
                 logger.warn("Please upload file with valid extention.");
@@ -132,12 +135,12 @@ public class UploadConfig extends HttpServlet
         File temp = null;
         OutputStream outputStream = null;
         try {
-            if(".zip".equals(extension))
-                temp = File.createTempFile("openvpn-newconfig-", ".zip");
-            else if(".ovpn".equals(extension))
+            if(ZIP_EXTENSION.equals(extension))
+                temp = File.createTempFile(finalName, extension);
+            else if(OVPN_EXTENSION.equals(extension))
                 temp = File.createTempFile(finalName, extension);
             else 
-                temp = File.createTempFile("invalidFile-", extension);
+                temp = File.createTempFile(finalName, extension);
             temp.deleteOnExit();
             outputStream = new FileOutputStream(temp);
 

--- a/openvpn/servlets/openvpn/src/com/untangle/app/openvpn/servlet/UploadConfig.java
+++ b/openvpn/servlets/openvpn/src/com/untangle/app/openvpn/servlet/UploadConfig.java
@@ -136,6 +136,8 @@ public class UploadConfig extends HttpServlet
                 temp = File.createTempFile("openvpn-newconfig-", ".zip");
             else if(".ovpn".equals(extension))
                 temp = File.createTempFile(finalName, extension);
+            else 
+                temp = File.createTempFile("invalidFile-", extension);
             temp.deleteOnExit();
             outputStream = new FileOutputStream(temp);
 

--- a/openvpn/servlets/openvpn/src/com/untangle/app/openvpn/servlet/UploadConfig.java
+++ b/openvpn/servlets/openvpn/src/com/untangle/app/openvpn/servlet/UploadConfig.java
@@ -12,6 +12,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -103,10 +104,11 @@ public class UploadConfig extends HttpServlet
         }
 
         InputStream inputStream = null;
-
+        String fileName = null, finalName =null,extension = null;
         for (FileItem item : items) {
             if (!"uploadConfigFileName".equals(item.getFieldName())) continue;
             inputStream = item.getInputStream();
+            fileName = item.getName();
             break;
         }
 
@@ -115,12 +117,25 @@ public class UploadConfig extends HttpServlet
             writer.write("{ \"success\" : false, \"code\" : \"client error\", \"type\" : 4 }");
             return;
         }
+        if (StringUtils.isNotBlank(fileName)){
+            int dotIndex = fileName.lastIndexOf('.');
+            if (dotIndex > 0 && dotIndex < fileName.length() - 1) {
+                finalName = fileName.substring(0, dotIndex)+"-";
+                extension = fileName.substring(dotIndex);
+            } else {
+                logger.warn("Please upload file with valid extention.");
+                return;
+            }
+        }
 
         /* Write out the file. */
         File temp = null;
         OutputStream outputStream = null;
         try {
-            temp = File.createTempFile("openvpn-newconfig-", ".zip");
+            if(".zip".equals(extension))
+                temp = File.createTempFile("openvpn-newconfig-", ".zip");
+            else if(".ovpn".equals(extension))
+                temp = File.createTempFile(finalName, extension);
             temp.deleteOnExit();
             outputStream = new FileOutputStream(temp);
 

--- a/uvm/api/com/untangle/uvm/util/Constants.java
+++ b/uvm/api/com/untangle/uvm/util/Constants.java
@@ -19,6 +19,7 @@ public class Constants {
 
     // Symbols
     public static final String DOT = ".";
+    public static final String HYPHEN = "-";
     public static final String UNDERSCORE = "_";
     public static final String SPACE = " ";
     public static final String COMMA_STRING = ",";


### PR DESCRIPTION
This PR contains the implementation logic to support openvpn site-to-site inline configuration.

During grooming for [NGFW-13265](https://awakesecurity.atlassian.net/browse/NGFW-13265), we aligned on continuing support for .zip, .ovpn, and .onc file downloads in the release that introduces inline import support.
As per that discussion, we will:

- Retain .zip download and upload support in version 17.5
- Will have .ovpn  download and upload support for all upcoming versions
- Will have .onc download support

Also write basic unit test case to cover site-to-site tunnle creation through inline config file. 
![localUTResultOfZipandInlineConf](https://github.com/user-attachments/assets/a01e5c70-6ca8-42f8-86b7-8bef22c2ff7d)
![localUTRunForOpenvpn](https://github.com/user-attachments/assets/51ca20cd-6613-4fd3-b4a0-e696d4624e94)
**NOTE : Skipping new added test for ATS servers for now as inline file needs to be place on test server.**

[NGFW-13265]: https://awakesecurity.atlassian.net/browse/NGFW-13265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ