### PR TITLE
ngfw-15094 Added filters for wireguard tunnels grid

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -1161,6 +1161,9 @@ Ext.define('Ung.util.Util', {
         components.forEach(function(component) {
             var store = component.getStore();
             var listId = component.listProperty;
+            // Clear any filters applied on store
+            var filters = store.getFilters().clone();
+            store.clearFilter(true);
             if(listId == null){
                 return;
             }
@@ -1211,6 +1214,10 @@ Ext.define('Ung.util.Util', {
                 });
             });
             viewModel.set(listId, values);
+            // restore filters after data is processed
+            filters.each( function(filter){
+                store.addFilter(filter);
+            });
         });
         return changes;
     },

--- a/wireguard-vpn/js/view/Tunnels.js
+++ b/wireguard-vpn/js/view/Tunnels.js
@@ -26,7 +26,11 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',
-        items: ['@add', '->', '@import', '@export']
+        items: ['@add', '-', { xtype: 'ungridfilter', store: 'tunnels' }, '->', '@import', '@export']
+    }],
+    plugins: [ 'gridfilters', {
+        ptype: 'cellediting',
+        clicksToEdit: 1
     }],
 
     recordActions: ['edit', 'copy', 'delete'],
@@ -82,6 +86,7 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
         width: Renderer.messageWidth,
         flex: 1,
         dataIndex: 'description',
+        filter: Renderer.stringFilter
     }, {
         header: 'Remote Public Key'.t(),
         width: 290,
@@ -98,27 +103,32 @@ Ext.define('Ung.apps.wireguard-vpn.cmp.TunnelsGrid', {
             validator: function(value) {
                 return peerIpAddrValidator(value, 'peerAddress', this, 'app-wireguard-vpn-server-tunnels-grid');
             }
-        }
+        },
+        filter: Renderer.stringFilter
     }, {
         header: 'Remote Networks'.t(),
         width: Renderer.messageWidth,
         flex: 1,
-        dataIndex: 'networks'
+        dataIndex: 'networks',
+        filter: Renderer.stringFilter
     }, {
         header: 'Remote Endpoint'.t(),
         width: Renderer.messageWidth,
         dataIndex: 'endpointDynamic',
-        renderer: Ung.apps['wireguard-vpn'].Main.dynamicEndpointRenderer
+        renderer: Ung.apps['wireguard-vpn'].Main.dynamicEndpointRenderer,
+        filter: Renderer.booleanFilter
     }, {
         header: 'Hostname'.t(),
         width: Renderer.messageWidth,
         dataIndex: 'endpointHostname',
-        renderer: Ung.apps['wireguard-vpn'].Main.dynamicEndpointRenderer
+        renderer: Ung.apps['wireguard-vpn'].Main.dynamicEndpointRenderer,
+        filter: Renderer.stringFilter
     }, {
         header: 'Port'.t(),
         width: Renderer.portWidth,
         dataIndex: 'endpointPort',
-        renderer: Ung.apps['wireguard-vpn'].Main.dynamicEndpointRenderer
+        renderer: Ung.apps['wireguard-vpn'].Main.dynamicEndpointRenderer,
+        filter: Renderer.numericFilter
     }, {
         xtype: 'actioncolumn',
         header: 'Remote Client'.t(),


### PR DESCRIPTION
**Changes:** 1. Added filter search for Wireguard VPN Tunnels Grid.
Added column filter for `Description, Remote Peer Address, Remote Networks, Remote Endpoints, Hostname and Port`.

![Screenshot from 2025-05-28 18-14-54](https://github.com/user-attachments/assets/6163502f-7530-4d88-97c3-01c8b0b98035)


![Screenshot from 2025-05-28 18-15-40](https://github.com/user-attachments/assets/21ded7c2-c219-4fe9-b55b-a544f81f2700)
