### PR TITLE
NGFW-13908: Show logging of WIFI activity in UI

### DIFF
--- a/uvm/api/com/untangle/uvm/NetworkManager.java
+++ b/uvm/api/com/untangle/uvm/NetworkManager.java
@@ -84,6 +84,8 @@ public interface NetworkManager
 
     boolean getInterfacesOverloadedFlag();
 
+    String getLogFile(String device);
+
     ConcurrentMap<String, String> lookupMacVendorList(List<String> macAddressList);
 
     public static enum StatusCommands {

--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -124,6 +124,7 @@ public class InterfaceSettings implements Serializable, JSONString
     public static enum WirelessMode { AP, CLIENT };
     private WirelessMode wirelessMode = WirelessMode.AP;
     private String wirelessPassword = null;
+    private int wirelessLoglevel = 2;
     private Integer wirelessChannel = null;
     private Integer wirelessVisibility = 0;
     private String wirelessCountryCode = "";
@@ -345,6 +346,9 @@ public class InterfaceSettings implements Serializable, JSONString
 
     public String getWirelessCountryCode() { return this.wirelessCountryCode; }
     public void setWirelessCountryCode( String newValue ) { this.wirelessCountryCode = newValue; }
+
+    public int getWirelessLogLevel() { return this.wirelessLoglevel; }
+    public void setWirelessLogLevel( int newValue ) { this.wirelessLoglevel = newValue; }
 
     /**
      * Interface alias.

--- a/uvm/hier/etc/rsyslog.d/hostapd.conf
+++ b/uvm/hier/etc/rsyslog.d/hostapd.conf
@@ -1,0 +1,6 @@
+#The lines below cause wpa_suppliant logs to go to /var/log/hostapd.log.
+$FileCreateMode 0644
+
+$outchannel oc_hostapd.log,/var/log/hostapd.log,524288000,/usr/share/untangle-system-config/syslog-maxsize-rotate.sh /var/log/hostapd.log
+:syslogtag, startswith, "hostapd":omfile:$oc_hostapd.log
+& stop

--- a/uvm/hier/usr/share/untangle/bin/hostapd-logfile
+++ b/uvm/hier/usr/share/untangle/bin/hostapd-logfile
@@ -1,0 +1,23 @@
+#!/bin/dash
+
+LOGFILE=/var/log/hostapd.log
+device_name=$1
+
+if [ ! -e "$LOGFILE" ]; then
+    echo "hostapd not running"
+    exit 0
+fi
+
+if [ ! -s "$LOGFILE" ]; then
+    echo "The hostapd log file is empty"
+    exit 0
+fi
+
+# Grab hostapd output from the log file
+if [ -n "$device_name" ]; then
+    tail -n 1024 "$LOGFILE" | grep "$device_name" | /usr/bin/tac
+else
+    tail -n 1024 "$LOGFILE" | /usr/bin/tac
+fi
+
+exit 0

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -90,6 +90,7 @@ public class NetworkManagerImpl implements NetworkManager
     private static String NETSPACE_STATIC_ADDRESS = "static-address";
     private static String NETSPACE_STATIC_ALIAS = "static-alias";
     private static String NETSPACE_DYNAMIC_ADDRESS = "dynamic-address";
+    private final static String GET_LOGFILE_SCRIPT = System.getProperty("uvm.home") + "/bin/hostapd-logfile";
 
     // creating a cache for the lookedup mac addresses and vendors
     private static ConcurrentMap<String,String> cachedMacAddrVendorList = new ConcurrentHashMap<>();
@@ -3117,6 +3118,18 @@ public class NetworkManagerImpl implements NetworkManager
         // For 17.1, peform "free" conversion to set the new dhcpMaxLeases setting to its default value
         this.networkSettings.setVersion( currentVersion );
         this.setNetworkSettings( this.networkSettings, false );
+    }
+
+    /**
+     * Gets the contents of the hostapd log file
+     * @param device - the device name to filter the logs
+     *
+     * @return The contents of the IPsec log file
+     */
+    public String getLogFile(String device)
+    {
+        logger.debug("hostapd.log getLogFile()");
+        return UvmContextFactory.context().execManager().execOutput(String.format("%s %s", GET_LOGFILE_SCRIPT, device));
     }
 
     /**

--- a/uvm/servlets/admin/app/model/Interface.js
+++ b/uvm/servlets/admin/app/model/Interface.js
@@ -78,6 +78,7 @@ Ext.define ('Ung.model.Interface', {
         { name: 'wirelessEncryption', type: 'auto', defaultValue: null },
         { name: 'wirelessPassword', type: 'string', defaultValue: '' },
         { name: 'wirelessSsid', type: 'string', defaultValue: '' },
+        { name: 'wirelessLogLevel', type: 'number', defaultValue: 2 },
 
         // status fields
         { name: 'v4Address', type: 'string', defaultValue: null },


### PR DESCRIPTION
Added backend support for fetching wifi logs. the api will call the script and fetch the logs similar to ipsec.
Presently logs were going to daemon.log, have added a rsyslog configuration file to send those logs to /var/log/hostapd
![Screenshot from 2025-06-04 19-36-38](https://github.com/user-attachments/assets/1b6fb172-9307-4f0d-b8cc-373f93262346)


Added support for managing log levels as well from hostapd documentation
hostapd event logger configuration#
Two output method: syslog and stdout (only usable if not forking to# background).## Module bitfield (ORed bitfield of modules that will be logged;
-1 = all modules
bit 0 (1) = IEEE 802.11
bit 1 (2) = IEEE 802.1X
bit 2 (4) = RADIUS
bit 3 (8) = WPA
bit 4 (16) = driver interface# bit 6 (64) = MLME

Levels (minimum value for logged events):
0 = verbose debugging
1 = debugging
2 = informational messages#
3 = notification
4 = warning

these are default values
logger_syslog=-1
logger_syslog_level=2

Dependant PR
https://github.com/untangle/sync-settings/pulls