### PR TITLE
NGWF-15206 Setting marshalling mode before calling jabsorb library

### DIFF
--- a/buildtools/jars.rb
+++ b/buildtools/jars.rb
@@ -36,8 +36,8 @@ class Jars
     const_set(:Log4j, [ Jars.downloadTarget('apache-log4j-2.23.1/log4j-api-2.23.1.jar'),
                         Jars.downloadTarget('apache-log4j-2.23.1/log4j-core-2.23.1.jar') ])
     const_set(:JavaMailApi, [ Jars.downloadTarget('javamail-1.3.3_01/lib/mailapi.jar') ])
-    const_set(:Jabsorb, [ Jars.downloadTarget('jabsorb-1.2.4-src/jabsorb-1.2.4/jabsorb-1.2.4.jar')])
-    const_set(:Json, [ Jars.downloadTarget('jabsorb-1.2.4-src/jabsorb-1.2.4/json.jar')])
+    const_set(:Jabsorb, [ Jars.downloadTarget('jabsorb-1.2.5-src/jabsorb-1.2.5/jabsorb-1.2.5.jar')])
+    const_set(:Json, [ Jars.downloadTarget('jabsorb-1.2.5-src/jabsorb-1.2.5/json.jar')])
     const_set(:GetText, [ Jars.downloadTarget('gettext-commons-0.9.1/gettext-commons-0.9.1.jar') ])
     const_set(:JakartaActivation, [ Jars.downloadTarget('jakarta.activation-1.2.1/jakarta.activation-1.2.1.jar') ])
     const_set(:JavaTransaction, [ Jars.downloadTarget('jta-1.1/jta-1.1.jar') ])

--- a/downloads/Makefile
+++ b/downloads/Makefile
@@ -29,7 +29,7 @@ tarballs_gz=apache-ant-1.6.5.tar.gz \
 
 tarballs_bz2=
 
-zips=javamail-1_3_3_01.zip jabsorb-1.2.4-src.zip \
+zips=javamail-1_3_3_01.zip jabsorb-1.2.5-src.zip \
 	jradius-client-1.0.0-release.zip apache-taglibs-standard-1.2.5.zip \
 	selenium-java-3.141.59.zip geoip2-2.17.0-with-dependencies.zip
 

--- a/uvm/api/com/untangle/uvm/util/ObjectMatcher.java
+++ b/uvm/api/com/untangle/uvm/util/ObjectMatcher.java
@@ -3,6 +3,8 @@
  */
 package com.untangle.uvm.util;
 
+import org.jabsorb.serializer.MarshallingMode;
+import org.jabsorb.serializer.MarshallingModeContext;
 import org.jabsorb.serializer.SerializerState;
 import org.jabsorb.serializer.UnmarshallException;
 import org.json.JSONArray;
@@ -26,12 +28,18 @@ public class ObjectMatcher {
     @SuppressWarnings("unchecked")
     public static <T> T parseJson(String json, Class<T> clazz) throws JSONException, UnmarshallException {
         try {
+            // MarshallingMode.STANDARD_REST is only applicable for v2 API calls,
+            // rest of the backend serialization should still be done by MarshallingMode.JABSORB
+            MarshallingModeContext.push(MarshallingMode.JABSORB);
+
             SerializerState state = new SerializerState();
             Object jsonObject = new JSONObject(json);
             UvmContextFactory.context().getSerializer().tryUnmarshall(state, clazz, jsonObject);
             return (T) UvmContextFactory.context().getSerializer().fromJSON(json);
         } catch (UnmarshallException e) {
             throw new UnmarshallException("Failed to parse JSON " + e.getMessage());
+        } finally {
+            MarshallingModeContext.pop();
         }
     }
 
@@ -50,12 +58,17 @@ public class ObjectMatcher {
         }
 
         try {
+            // MarshallingMode.STANDARD_REST is only applicable for v2 API calls,
+            // rest of the backend serialization should still be done by MarshallingMode.JABSORB
+            MarshallingModeContext.push(MarshallingMode.JABSORB);
             SerializerState state = new SerializerState();
             Object jsonObject = new JSONArray(json);
             UvmContextFactory.context().getSerializer().tryUnmarshall(state, arrayClazz, jsonObject);
             return (T[]) UvmContextFactory.context().getSerializer().fromJSON(json);
         }catch (UnmarshallException e) {
             throw new UnmarshallException("Failed to parse JSON " + e.getMessage());
+        } finally {
+            MarshallingModeContext.pop();
         }
     }
 }

--- a/uvm/impl/com/untangle/uvm/SessionMonitorImpl.java
+++ b/uvm/impl/com/untangle/uvm/SessionMonitorImpl.java
@@ -28,6 +28,8 @@ import com.untangle.uvm.app.App;
 import com.untangle.uvm.app.SessionTuple;
 import com.untangle.uvm.vnet.AppSession;
 import com.untangle.uvm.app.SessionEvent;
+import org.jabsorb.serializer.MarshallingMode;
+import org.jabsorb.serializer.MarshallingModeContext;
 
 /**
  * SessionMonitor is a utility class that provides some convenient
@@ -359,12 +361,17 @@ public class SessionMonitorImpl implements SessionMonitor
 
         try {
             String output = SessionMonitorImpl.execManager.execOutput(execStr);
+
+            // Expect command output to be serialized as per jabsorb style
+            MarshallingModeContext.push(MarshallingMode.JABSORB);
             List<SessionMonitorEntry> entryList = (List<SessionMonitorEntry>) ((UvmContextImpl)UvmContextFactory.context()).getSerializer().fromJSON(output);
             return entryList;
 
         } catch (org.jabsorb.serializer.UnmarshallException exc) {
             logger.error("Unable to read jnettop - invalid JSON",exc);
             return null;
+        } finally {
+            MarshallingModeContext.pop();
         }
     }
 


### PR DESCRIPTION
We need to set marhsalling mode inorder for jabsorb to decide which mode of marshalling has to be used to serialize objects.
For ngfw_src, except for the API requests, we need to ensure rest of the serialization like reading of settings file or command output has to be done with JABSORB mode since we are not changing the structure of these.

Setting of marshalling mode for APIs has to be handled from jabsorb library.