### PR TITLE
ngfw-15211 enabled, wan and duplex field changes

### DIFF
--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -498,6 +498,7 @@ public class InterfaceSettings implements Serializable, JSONString
     public InterfaceSettingsGeneric transformInterfaceSettingsToGeneric() {
         InterfaceSettingsGeneric intfSettingsGen = new InterfaceSettingsGeneric();
 
+        intfSettingsGen.setEnabled(true);
         intfSettingsGen.setInterfaceId(this.interfaceId);
         intfSettingsGen.setName(this.name);
         intfSettingsGen.setDevice(this.symbolicDev);

--- a/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
@@ -29,6 +29,8 @@ import com.untangle.uvm.network.InterfaceSettings.WirelessMode;
 @SuppressWarnings("serial")
 public class InterfaceSettingsGeneric implements Serializable, JSONString {
 
+    private boolean enabled;        /* enabled/disabled status of interface */
+
     private int interfaceId;        /* the ID of the physical interface (1-254) */
     private String name;            /* human name: ie External, Internal, Wireless */
 
@@ -109,6 +111,8 @@ public class InterfaceSettingsGeneric implements Serializable, JSONString {
     private boolean hidden;
     private String wirelessCountryCode = "";
 
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
 
     public int getInterfaceId() { return interfaceId; }
     public void setInterfaceId(int interfaceId) { this.interfaceId = interfaceId; }

--- a/uvm/api/com/untangle/uvm/network/generic/InterfaceStatusGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/InterfaceStatusGeneric.java
@@ -23,8 +23,9 @@ public class InterfaceStatusGeneric implements Serializable, JSONString {
 
     private boolean connected;
     private boolean offline;
+    private boolean wan;
 
-    private DuplexStatus ethDuplex;
+    private String ethDuplex;
     private int ethSpeed;
 
     private List<String> ip4Addr = new LinkedList<>();
@@ -60,8 +61,11 @@ public class InterfaceStatusGeneric implements Serializable, JSONString {
     public boolean isOffline() { return offline; }
     public void setOffline(boolean offline) { this.offline = offline; }
 
-    public DuplexStatus getEthDuplex() { return ethDuplex; }
-    public void setEthDuplex(DuplexStatus ethDuplex) { this.ethDuplex = ethDuplex; }
+    public boolean isWan() { return wan; }
+    public void setWan(boolean wan) { this.wan = wan; }
+
+    public String getEthDuplex() { return ethDuplex; }
+    public void setEthDuplex(String ethDuplex) { this.ethDuplex = ethDuplex; }
 
     public int getEthSpeed() { return ethSpeed; }
     public void setEthSpeed(int ethSpeed) { this.ethSpeed = ethSpeed; }

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -28,6 +28,7 @@ import com.untangle.uvm.network.DhcpStaticEntry;
 import com.untangle.uvm.network.DhcpRelay;
 import com.untangle.uvm.network.UpnpSettings;
 import com.untangle.uvm.network.DeviceStatus.ConnectedStatus;
+import com.untangle.uvm.network.DeviceStatus.DuplexStatus;
 import com.untangle.uvm.network.InterfaceSettings.ConfigType;
 import com.untangle.uvm.network.InterfaceSettings.V4ConfigType;
 import com.untangle.uvm.network.InterfaceSettings.V6ConfigType;
@@ -609,6 +610,7 @@ public class NetworkManagerImpl implements NetworkManager
             InterfaceStatusGeneric status = new InterfaceStatusGeneric();
 
             status.setDevice(intf.getSymbolicDev());
+            status.setWan(intf.getIsWan());
             populateTransferStats(status, intf);
             populateMacVendor(status);
             populateIpAddresses(status, intf);
@@ -689,10 +691,16 @@ public class NetworkManagerImpl implements NetworkManager
         for (DeviceStatus ds : deviceStatusList) {
             if (ds.getDeviceName().equals(intf.getPhysicalDev())) {
                 boolean isConnected = ConnectedStatus.CONNECTED.equals(ds.getConnected());
+                DuplexStatus duplex = ds.getDuplex();
+
                 status.setConnected(isConnected);
                 status.setOffline(!isConnected);
-                status.setEthDuplex(ds.getDuplex());
                 status.setEthSpeed(ds.getMbit());
+
+                if (duplex == DuplexStatus.FULL_DUPLEX) status.setEthDuplex("full");
+                else if(duplex == DuplexStatus.HALF_DUPLEX) status.setEthDuplex("half");
+                else status.setEthDuplex(DuplexStatus.UNKNOWN.toString().toLowerCase());
+                
                 return;
             }
         }


### PR DESCRIPTION
As a part of vue migration we are creating new API's for vue Application.

Modified InterfaceSettingsGeneric and InterfaceStatusGeneric classes to match vuntangle conventions.

`vuntangle` needs **enabled** field in `interfaceSettings` object to populated Status (connected/disconnected, offline/online)
For now settings all interfaceSettings.enabled = true. With VPN changes the value will be mapped to respective enabled field.

interface status object should also contain **wan** field for same purpose.

**duplex** value should be either `full`, `half` if UNKNOWN settings it to 'unknown'.