### PR TITLE
NGFW-15225: OpenVPN : Updated remoteServer attribute and configuration logic as per vue migration

### DIFF
--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnRemoteServer.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnRemoteServer.java
@@ -18,6 +18,7 @@ public class OpenVpnRemoteServer implements java.io.Serializable, org.json.JSONS
     private boolean authUserPass = false;
     private String authUsername;
     private String authPassword;
+    private OpenVpnConfFile openvpnConfFile;
     private String remoteServerEncryptedPassword;
 
     public OpenVpnRemoteServer()
@@ -44,11 +45,45 @@ public class OpenVpnRemoteServer implements java.io.Serializable, org.json.JSONS
     public String getRemoteServerEncryptedPassword() { return this.remoteServerEncryptedPassword; }
     public void setRemoteServerEncryptedPassword( String newValue ) { this.remoteServerEncryptedPassword = newValue; }
 
+    public OpenVpnConfFile getOpenvpnConfFile() { return openvpnConfFile; }
+    public void setOpenvpnConfFile(OpenVpnConfFile openvpnConfFile) { this.openvpnConfFile = openvpnConfFile; }
+
 // THIS IS FOR ECLIPSE - @formatter:on
 
     public String toJSONString()
     {
         org.json.JSONObject jO = new org.json.JSONObject(this);
         return jO.toString();
+    }
+
+    /**
+     * Represents an OpenVPN configuration file with its encoded contents and encoding format.
+     * 
+     * <p>This class is typically used to hold the contents of an OpenVPN configuration file
+     * encoded in a specific format (e.g., Base64). It can be deserialized from a JSON structure
+     * where the configuration content and encoding method are provided.</p>
+     */
+    public static class OpenVpnConfFile {
+        private String contents;
+        private String encoding = "base64";
+
+        public OpenVpnConfFile() {
+        }
+
+        public String getContents() {
+            return contents;
+        }
+
+        public void setContents(String contents) {
+            this.contents = contents;
+        }
+
+        public String getEncoding() {
+            return encoding;
+        }
+
+        public void setEncoding(String encoding) {
+            this.encoding = encoding;
+        }
     }
 }

--- a/uvm/api/com/untangle/uvm/util/Constants.java
+++ b/uvm/api/com/untangle/uvm/util/Constants.java
@@ -50,6 +50,9 @@ public class Constants {
     // Escape sequence
     public static final String NEW_LINE = "\n";
 
+    //encoding Key
+    public static final String BASE64 = "Base64";
+
     // Empty string
     public static final String EMPTY_STRING = "\" \"";
 }


### PR DESCRIPTION
Currently, client configuration is handled by the uploadConfig servlet. However, with the migration to Vue, we are moving away from relying on the servlet and file object input.

Now, the configuration payload for the client will be received in the following format:


> 
> {
>   "enabled": true,
>   "name": "",
>   "authUserPass": false,
>   "authUsername": "",
>   "authPassword": "",
>   "openvpnConfFile": {
>     "contents": "",
>     "encoding": "base64"
>   }
> }

This means we will receive the OpenVPN configuration file as a base64-encoded string along with its encoding format. We need to decode the contents based on the provided encoding and use the resulting data to configure the client.


DEMO VIDEO: showcasing before and after behaviour of openvpn client configuration
[Screencast from 10-07-25 03:45:46 PM IST.webm](https://github.com/user-attachments/assets/c27ef494-c646-4fc2-9923-bfe4606b3c14)

[Screencast from 10-07-25 03:34:33 PM IST.webm](https://github.com/user-attachments/assets/6bd5764e-2347-4647-83e5-3c30d47114a3)
