### PR TITLE
ngfw-15214 Added logs to know the eventwriter thread state

### DIFF
--- a/reports/src/com/untangle/app/reports/EventWriterImpl.java
+++ b/reports/src/com/untangle/app/reports/EventWriterImpl.java
@@ -19,6 +19,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.io.File;
+import java.lang.Thread.State;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -344,13 +345,21 @@ public class EventWriterImpl implements Runnable
     public void logEvent(LogEvent event)
     {
         if ( this.thread == null ) {
+            logger.warn("Event Writer Thread is null returning without writing logs");
             return;
+        }
+        // Logs to check if thread is working fine #NGFW-15214
+        State threadState = this.thread.getState();
+        if( threadState != State.RUNNABLE && threadState != State.TIMED_WAITING ) {
+            logger.warn("Thread State: {}", threadState);
+            logger.warn("InputQueue Size: {}", inputQueue.size());
         }
         if ( this.overloadedFlag || this.diskFullFlag ) {
             if ( System.currentTimeMillis() - this.lastLoggedWarningTime > 10000 ) {
                 if (this.overloadedFlag) { logger.warn("Event Writer overloaded, discarding event"); }
                 this.lastLoggedWarningTime = System.currentTimeMillis();
             }
+            logger.warn("Override flag: {}, Disk Full flag: {}", this.overloadedFlag, this.diskFullFlag);
             return;
         }
         

--- a/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
+++ b/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
@@ -1210,6 +1210,7 @@ public class ReportsManagerImpl implements ReportsManager
         try {
             //Need to stop EventWriter thread to avoid DB write failures
             if (app.getEventWriter() != null) {
+                logger.info("Stopping EventWriter thread to avoid DB write failures");
                 app.getEventWriter().stop();
             }
             String pgCleanupCmd = "/usr/share/untangle/bin/reports-reinitialize-database.sh";
@@ -1222,6 +1223,7 @@ public class ReportsManagerImpl implements ReportsManager
             UvmContextFactory.context().execManager().execOutput(pgCleanupCmd);
             UvmContextFactory.context().execManager().execResult(pgStartCmd);
             pgStatus = UvmContextFactory.context().execManager().execResult(pgStatusCmd);
+            logger.info("Postgress Status Response {}", pgStatus);
             if (pgStatus == 0) {
                 UvmContextFactory.context().execManager().execOutput(generateReportTablesCmd);
                 String username = null;
@@ -1237,6 +1239,7 @@ public class ReportsManagerImpl implements ReportsManager
                     OperationsEvent event = new OperationsEvent(DELETE_ALL_REPORTS, username, hostname);
                     //Start EventWriter after successful completion of DELETE_ALL_REPORTS data
                     if (app.getEventWriter() != null) {
+                        logger.info("Starting EventWriter after successful completion of DELETE_ALL_REPORTS data");
                         app.getEventWriter().start(app);
                         //Added additional wait, EventWriter yet to be ready
                         try {
@@ -1245,6 +1248,8 @@ public class ReportsManagerImpl implements ReportsManager
                             logger.warn("Interrupted during wait....");
                         }
                         UvmContextFactory.context().logEvent(event);
+                    } else{
+                        logger.info("EventWriter is null");
                     }
                     } else {
                         logger.info("Operation event generation failed, EventWriter not ready, Restart is required ");


### PR DESCRIPTION
On one of the prod box the reports app was failing after few days of restart.
v17.3.1

Added new logs giving us info about writer thread state and input queue length along with other logs at suspicious code.