### PR TITLE
ngfw-15201 qosEnabled Flag added in interfaceSettings

### DIFF
--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -116,7 +116,8 @@ public class InterfaceSettings implements Serializable, JSONString
     private InetAddress dhcpRelayAddress; /* DHCP relay server IP address */
 
     private Boolean raEnabled; /* are IPv6 router advertisements available? */
-    
+
+    private boolean qosEnabled;         /* QOS enabled status for WAN interfaces */
     private Integer downloadBandwidthKbps; /* Download Bandwidth available on this WAN interface (for QoS) */
     private Integer uploadBandwidthKbps; /* Upload Bandwidth available on this WAN interface (for QoS) */
 
@@ -314,6 +315,9 @@ public class InterfaceSettings implements Serializable, JSONString
 
     public Boolean getRaEnabled() { return this.raEnabled; }
     public void setRaEnabled( Boolean newValue ) { this.raEnabled = newValue; }
+
+    public boolean isQosEnabled() { return qosEnabled; }
+    public void setQosEnabled(boolean qosEnabled) { this.qosEnabled = qosEnabled; }
 
     public Integer getDownloadBandwidthKbps() { return this.downloadBandwidthKbps; }
     public void setDownloadBandwidthKbps( Integer newValue ) { this.downloadBandwidthKbps = newValue; }
@@ -560,6 +564,7 @@ public class InterfaceSettings implements Serializable, JSONString
         intfSettingsGen.setDhcpRelayAddress(this.dhcpRelayAddress);
         intfSettingsGen.setRouterAdvertisements(this.raEnabled);
 
+        intfSettingsGen.setQosEnabled(this.qosEnabled);
         intfSettingsGen.setDownloadKbps(this.downloadBandwidthKbps);
         intfSettingsGen.setUploadKbps(this.uploadBandwidthKbps);
 

--- a/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
@@ -99,6 +99,7 @@ public class InterfaceSettingsGeneric implements Serializable, JSONString {
 
     private Boolean routerAdvertisements;       /* are IPv6 router advertisements available? */
 
+    private boolean qosEnabled;         /* QOS enabled status for WAN interfaces */
     private Integer downloadKbps;       /* Download Bandwidth available on this WAN interface (for QoS) */
     private Integer uploadKbps;         /* Upload Bandwidth available on this WAN interface (for QoS) */
 
@@ -272,6 +273,9 @@ public class InterfaceSettingsGeneric implements Serializable, JSONString {
     public Boolean getRouterAdvertisements() { return routerAdvertisements; }
     public void setRouterAdvertisements(Boolean routerAdvertisements) { this.routerAdvertisements = routerAdvertisements; }
 
+    public boolean isQosEnabled() { return qosEnabled; }
+    public void setQosEnabled(boolean qosEnabled) { this.qosEnabled = qosEnabled; }
+
     public Integer getDownloadKbps() { return downloadKbps; }
     public void setDownloadKbps(Integer downloadKbps) { this.downloadKbps = downloadKbps; }
 
@@ -388,8 +392,9 @@ public class InterfaceSettingsGeneric implements Serializable, JSONString {
 
         intfSettings.setRaEnabled(this.routerAdvertisements);
 
-        intfSettings.setDownloadBandwidthKbps(this.downloadKbps);
-        intfSettings.setUploadBandwidthKbps(this.uploadKbps);
+        intfSettings.setQosEnabled(this.qosEnabled);
+        intfSettings.setDownloadBandwidthKbps(this.qosEnabled ? this.downloadKbps : 0);
+        intfSettings.setUploadBandwidthKbps(this.qosEnabled ? this.uploadKbps : 0);
 
         intfSettings.setVrrpEnabled(this.vrrpEnabled);
         intfSettings.setVrrpId(this.vrrpId);

--- a/uvm/api/com/untangle/uvm/network/generic/NetworkSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/NetworkSettingsGeneric.java
@@ -54,6 +54,7 @@ public class NetworkSettingsGeneric implements Serializable, JSONString {
         Map<Integer, InterfaceSettings> interfaceMap = existingInterfaces.stream()
             .collect(Collectors.toMap(InterfaceSettings::getInterfaceId, Function.identity()));
 
+        boolean qosEnabled = false;
         for (InterfaceSettingsGeneric intfSettingsGen : this.interfaces) {
             InterfaceSettings matchingIntf = interfaceMap.get(intfSettingsGen.getInterfaceId());
 
@@ -64,6 +65,16 @@ public class NetworkSettingsGeneric implements Serializable, JSONString {
 
             // Transform data from generic to original InterfaceSettings
             intfSettingsGen.transformGenericToInterfaceSettings(matchingIntf);
+
+            // Track if any WAN interface has QoS enabled
+            if (intfSettingsGen.isWan() && intfSettingsGen.isQosEnabled()) {
+                qosEnabled = true;
+            }
+        }
+
+        // QOS Settings
+        if(networkSettings.getQosSettings() != null) {
+            networkSettings.getQosSettings().setQosEnabled(qosEnabled);
         }
 
         // Write other transformations below

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -112,7 +112,7 @@ public class NetworkManagerImpl implements NetworkManager
      * The current network settings
      */
     private NetworkSettings networkSettings;
-    private Integer currentVersion = 11;
+    private Integer currentVersion = 12;
 
     /**
      * This array holds the current interface Settings indexed by the interface ID.
@@ -3319,7 +3319,18 @@ public class NetworkManagerImpl implements NetworkManager
      */
     private void convertSettings()
     {
-        // For 17.1, peform "free" conversion to set the new dhcpMaxLeases setting to its default value
+        // For 17.5 Vue Migration Changes
+        // If QOS is enabled and interface have non zero band width set qosEnabled true for that interface
+        if(this.networkSettings.getQosSettings() != null && this.networkSettings.getQosSettings().getQosEnabled()) {
+            for(InterfaceSettings intfSettings: this.networkSettings.getInterfaces()) {
+                if(intfSettings.getIsWan()) {
+                    boolean qosEnabled = intfSettings.getDownloadBandwidthKbps() != null && intfSettings.getDownloadBandwidthKbps() != 0
+                            && intfSettings.getUploadBandwidthKbps() != null && intfSettings.getUploadBandwidthKbps() != 0;
+                    intfSettings.setQosEnabled(qosEnabled);
+                }
+            }
+        }
+        // Set new version
         this.networkSettings.setVersion( currentVersion );
         this.setNetworkSettings( this.networkSettings, false );
     }


### PR DESCRIPTION
- Currently, the `QoS Enabled` field is configured at the individual interface level within `vuntangle` Components. However, in the NGFW Backend, QoS Enabled is a global setting under `NetworkSettings` (common to all WAN interfaces).

To handle above problem
1. Added interface level QOS field for v1 and v2 model
2. Bandwidth will be set to payload values only if qosEnabled for that interface. else zero
3. Settings `networkSettings.qosSettings.qosEnabled = true` if any of the wan interface is QOS enabled. else `false`
4. Handled Upgrade Scenario. 