### PR TITLE
ngfw-15261 created get and set SystemSettingsV2 API's

### DIFF
--- a/uvm/api/com/untangle/uvm/SystemSettings.java
+++ b/uvm/api/com/untangle/uvm/SystemSettings.java
@@ -5,6 +5,8 @@ package com.untangle.uvm;
 
 import java.io.Serializable;
 
+import com.untangle.uvm.generic.SystemSettingsGeneric;
+import com.untangle.uvm.network.NetworkSettings;
 import org.json.JSONObject;
 import org.json.JSONString;
 
@@ -213,4 +215,35 @@ public class SystemSettings implements Serializable, JSONString
     public void setThresholdTemperature( Double newValue ) { this.thresholdTemperature = newValue; }
     public Double getThresholdTemperature() { return this.thresholdTemperature; }
 
+    /**
+     * Transforms a {@link SystemSettings} and {@link NetworkSettings} object
+     * into its generic counterpart {@link SystemSettingsGeneric},
+     * @param networkSettings {@link NetworkSettings} object to populate hostname and services fields
+     * @return a new {@link SystemSettingsGeneric} instance containing the generic representation of systemSettings for vue UI
+     */
+    public SystemSettingsGeneric transformLegacyToGenericSettings(NetworkSettings networkSettings) {
+        SystemSettingsGeneric systemSettingsGeneric = new SystemSettingsGeneric();
+        if (networkSettings != null) {
+            // Local Services Settings
+            systemSettingsGeneric.setHttpPort(networkSettings.getHttpPort());
+            systemSettingsGeneric.setHttpsPort(networkSettings.getHttpsPort());
+
+            // Hostname Settings
+            systemSettingsGeneric.setHostName(networkSettings.getHostName());
+            systemSettingsGeneric.setDomainName(networkSettings.getDomainName());
+
+            systemSettingsGeneric.setDynamicDnsServiceEnabled(networkSettings.getDynamicDnsServiceEnabled());
+            systemSettingsGeneric.setDynamicDnsServiceUsername(networkSettings.getDynamicDnsServiceUsername());
+            systemSettingsGeneric.setDynamicDnsServiceName(networkSettings.getDynamicDnsServiceName());
+            systemSettingsGeneric.setDynamicDnsServiceHostnames(networkSettings.getDynamicDnsServiceHostnames());
+            systemSettingsGeneric.setDynamicDnsServicePassword(networkSettings.getDynamicDnsServicePassword());
+            systemSettingsGeneric.setDynamicDnsServiceZone(networkSettings.getDynamicDnsServiceZone());
+            systemSettingsGeneric.setDynamicDnsServiceWan(networkSettings.getDynamicDnsServiceWan());
+
+            systemSettingsGeneric.setPublicUrlAddress(networkSettings.getPublicUrlAddress());
+            systemSettingsGeneric.setPublicUrlMethod(networkSettings.getPublicUrlMethod());
+            systemSettingsGeneric.setPublicUrlPort(networkSettings.getPublicUrlPort());
+        }
+        return systemSettingsGeneric;
+    }
 }

--- a/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
@@ -1,0 +1,113 @@
+/**
+ * $Id$
+ */
+package com.untangle.uvm.generic;
+
+import com.untangle.uvm.SystemSettings;
+import com.untangle.uvm.network.NetworkSettings;
+import org.json.JSONObject;
+import org.json.JSONString;
+
+import java.io.Serializable;
+
+/**
+ * Generic (v2) System Settings.
+ */
+@SuppressWarnings("serial")
+public class SystemSettingsGeneric implements Serializable, JSONString {
+
+    /**
+     * These are required for Web Admin Ports
+     */
+    private int httpPort  = 80;
+    private int httpsPort = 443;
+
+    /**
+     * These are required for Hostname Settings
+     */
+    private String hostName;
+    private String domainName;
+
+    private boolean dynamicDnsServiceEnabled = false;
+    private String  dynamicDnsServiceName = null;
+    private String  dynamicDnsServiceUsername = null;
+    private String  dynamicDnsServicePassword = null;
+    private String  dynamicDnsServiceZone = null;
+    private String  dynamicDnsServiceHostnames = null;
+    private String  dynamicDnsServiceWan = "Default";
+
+    private String  publicUrlMethod;
+    private String  publicUrlAddress;
+    private Integer publicUrlPort;
+
+    /**
+     * These are required for Web Admin Ports
+     */
+    public int getHttpPort() { return httpPort; }
+    public void setHttpPort(int httpPort) { this.httpPort = httpPort; }
+    public int getHttpsPort() { return httpsPort; }
+    public void setHttpsPort(int httpsPort) { this.httpsPort = httpsPort; }
+
+    /**
+     * These are required for Hostname Settings
+     */
+    public String getHostName() { return hostName; }
+    public void setHostName(String hostName) { this.hostName = hostName; }
+    public String getDomainName() { return domainName; }
+    public void setDomainName(String domainName) { this.domainName = domainName; }
+    public boolean isDynamicDnsServiceEnabled() { return dynamicDnsServiceEnabled; }
+    public void setDynamicDnsServiceEnabled(boolean dynamicDnsServiceEnabled) { this.dynamicDnsServiceEnabled = dynamicDnsServiceEnabled; }
+    public String getDynamicDnsServiceName() { return dynamicDnsServiceName; }
+    public void setDynamicDnsServiceName(String dynamicDnsServiceName) { this.dynamicDnsServiceName = dynamicDnsServiceName; }
+    public String getDynamicDnsServiceUsername() { return dynamicDnsServiceUsername; }
+    public void setDynamicDnsServiceUsername(String dynamicDnsServiceUsername) { this.dynamicDnsServiceUsername = dynamicDnsServiceUsername; }
+    public String getDynamicDnsServicePassword() { return dynamicDnsServicePassword; }
+    public void setDynamicDnsServicePassword(String dynamicDnsServicePassword) { this.dynamicDnsServicePassword = dynamicDnsServicePassword; }
+    public String getDynamicDnsServiceZone() { return dynamicDnsServiceZone; }
+    public void setDynamicDnsServiceZone(String dynamicDnsServiceZone) { this.dynamicDnsServiceZone = dynamicDnsServiceZone; }
+    public String getDynamicDnsServiceHostnames() { return dynamicDnsServiceHostnames; }
+    public void setDynamicDnsServiceHostnames(String dynamicDnsServiceHostnames) { this.dynamicDnsServiceHostnames = dynamicDnsServiceHostnames; }
+    public String getDynamicDnsServiceWan() { return dynamicDnsServiceWan; }
+    public void setDynamicDnsServiceWan(String dynamicDnsServiceWan) { this.dynamicDnsServiceWan = dynamicDnsServiceWan; }
+    public String getPublicUrlMethod() { return publicUrlMethod; }
+    public void setPublicUrlMethod(String publicUrlMethod) { this.publicUrlMethod = publicUrlMethod; }
+    public String getPublicUrlAddress() { return publicUrlAddress; }
+    public void setPublicUrlAddress(String publicUrlAddress) { this.publicUrlAddress = publicUrlAddress; }
+    public Integer getPublicUrlPort() { return publicUrlPort; }
+    public void setPublicUrlPort(Integer publicUrlPort) { this.publicUrlPort = publicUrlPort; }
+
+    public String toJSONString() {
+        JSONObject jO = new JSONObject(this);
+        return jO.toString();
+    }
+
+    /**
+     * Populates the provided {@link SystemSettings} and {@link NetworkSettings} instance with data from this
+     * {@link SystemSettingsGeneric} instance.
+     * @param systemSettings the target {@link SystemSettings} object to be updated.
+     * @param networkSettings the target {@link NetworkSettings} object to be updated.
+     */
+    public void transformGenericToLegacySettings(SystemSettings systemSettings, NetworkSettings networkSettings) {
+        if(networkSettings != null) {
+            // Local Services Settings
+            networkSettings.setHttpPort(this.getHttpPort());
+            networkSettings.setHttpsPort(this.getHttpsPort());
+
+            // Hostname Settings
+            networkSettings.setHostName(this.hostName);
+            networkSettings.setDomainName(this.domainName);
+
+            networkSettings.setDynamicDnsServiceEnabled(this.dynamicDnsServiceEnabled);
+            networkSettings.setDynamicDnsServiceUsername(this.dynamicDnsServiceUsername);
+            networkSettings.setDynamicDnsServiceZone(this.dynamicDnsServiceZone);
+            networkSettings.setDynamicDnsServiceName(this.dynamicDnsServiceName);
+            networkSettings.setDynamicDnsServiceHostnames(this.dynamicDnsServiceHostnames);
+            networkSettings.setDynamicDnsServicePassword(this.dynamicDnsServicePassword);
+            networkSettings.setDynamicDnsServiceWan(this.dynamicDnsServiceWan);
+
+            networkSettings.setPublicUrlAddress(this.publicUrlAddress);
+            networkSettings.setPublicUrlMethod(this.publicUrlMethod);
+            networkSettings.setPublicUrlPort(this.publicUrlPort);
+        }
+    }
+}

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -33,6 +33,9 @@ import java.util.zip.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.untangle.uvm.generic.SystemSettingsGeneric;
+import com.untangle.uvm.network.NetworkSettings;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.logging.log4j.Logger;
@@ -264,6 +267,34 @@ public class SystemManagerImpl implements SystemManager
     */
     public void setSettings(final SystemSettings newSettings) {
         setSettings(newSettings, false);
+    }
+
+    /**
+     * Get SystemSettingsGeneric for Vue UI
+     * @return SystemSettingsGeneric
+     */
+    public SystemSettingsGeneric getSystemSettingsV2() {
+        // Get current network settings
+        NetworkSettings networkSettings = UvmContextFactory.context().networkManager().getNetworkSettings();
+        // transform the systemSettings and networkSettings to systemSettingsGeneric
+        return this.settings.transformLegacyToGenericSettings(networkSettings);
+    }
+
+    /**
+     * Sets the SystemSettings and NetworkSettings (Hostname/Services)
+     * @param systemSettingsGeneric SystemSettingsGeneric
+     */
+    public void setSystemSettingsV2(final SystemSettingsGeneric systemSettingsGeneric) {
+        // Get current network settings
+        NetworkSettings networkSettings = UvmContextFactory.context().networkManager().getNetworkSettings();
+
+        // update hostname and web services fields with value coming from postData
+        systemSettingsGeneric.transformGenericToLegacySettings(this.settings, networkSettings);
+
+        // Set Network Settings with updated values.
+        UvmContextFactory.context().networkManager().setNetworkSettings(networkSettings);
+
+        // TODO Set SystemSettings when those fields will be transformed in future
     }
 
     /**


### PR DESCRIPTION
We have Hostname and Services tab settings in the ExtJs at `Config -> Network`.
In Vue UI those settings will be shown at `System -> Settings` Page.

To achieve above change implemented below solution.

1. Created `SystemSettingsGeneric` POJO for Vue v2 API's 
2. Created `getSystemSettingsV2` and `setSystemSettingsV2` API's for data transformation.
These API's use Network Settings to get and persist data in back-end for Hostname and Services Settings.