### PR TITLE
ngfw-15261 clone original settings to transform

### DIFF
--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -613,7 +613,7 @@ public class InterfaceSettings implements Serializable, JSONString
      * @return InterfaceSettingsGeneric.V6ConfigType
      */
     private InterfaceSettingsGeneric.V6ConfigType transformV6ConfigTypeEnum(V6ConfigType v6ConfigType) {
-        return  (this.v6ConfigType == v6ConfigType.AUTO) ? InterfaceSettingsGeneric.V6ConfigType.SLAAC
+        return  (this.v6ConfigType == V6ConfigType.AUTO) ? InterfaceSettingsGeneric.V6ConfigType.SLAAC
                 : InterfaceSettingsGeneric.V6ConfigType.valueOf(this.v6ConfigType.name());
     }
 

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -5,53 +5,53 @@ package com.untangle.uvm;
 
 import com.untangle.uvm.app.IPMaskedAddress;
 import com.untangle.uvm.app.RuleCondition;
-import com.untangle.uvm.network.NetworkSettings;
-import com.untangle.uvm.network.InterfaceSettings;
-import com.untangle.uvm.network.InterfaceStatus;
-import com.untangle.uvm.network.DeviceStatus;
-import com.untangle.uvm.network.DeviceSettings;
 import com.untangle.uvm.network.BypassRule;
 import com.untangle.uvm.network.BypassRuleCondition;
-import com.untangle.uvm.network.StaticRoute;
-import com.untangle.uvm.network.NatRule;
-import com.untangle.uvm.network.NatRuleCondition;
-import com.untangle.uvm.network.PortForwardRule;
-import com.untangle.uvm.network.PortForwardRuleCondition;
-import com.untangle.uvm.network.FilterRule;
-import com.untangle.uvm.network.FilterRuleCondition;
-import com.untangle.uvm.network.QosSettings;
-import com.untangle.uvm.network.QosRule;
-import com.untangle.uvm.network.QosRuleCondition;
-import com.untangle.uvm.network.QosPriority;
-import com.untangle.uvm.network.DnsSettings;
-import com.untangle.uvm.network.DhcpStaticEntry;
-import com.untangle.uvm.network.DhcpRelay;
-import com.untangle.uvm.network.UpnpSettings;
+import com.untangle.uvm.network.DeviceSettings;
+import com.untangle.uvm.network.DeviceStatus;
 import com.untangle.uvm.network.DeviceStatus.ConnectedStatus;
 import com.untangle.uvm.network.DeviceStatus.DuplexStatus;
-import com.untangle.uvm.network.InterfaceSettings.ConfigType;
-import com.untangle.uvm.network.InterfaceSettings.V4ConfigType;
-import com.untangle.uvm.network.InterfaceSettings.V6ConfigType;
-import com.untangle.uvm.network.generic.InterfaceSettingsGeneric;
-import com.untangle.uvm.network.generic.InterfaceStatusGeneric;
-import com.untangle.uvm.network.generic.NetworkSettingsGeneric;
-import com.untangle.uvm.network.UpnpRule;
-import com.untangle.uvm.network.UpnpRuleCondition;
-import com.untangle.uvm.network.NetflowSettings;
-import com.untangle.uvm.network.DynamicRoutingSettings;
+import com.untangle.uvm.network.DhcpRelay;
+import com.untangle.uvm.network.DhcpStaticEntry;
+import com.untangle.uvm.network.DnsSettings;
 import com.untangle.uvm.network.DynamicRouteBgpNeighbor;
 import com.untangle.uvm.network.DynamicRouteNetwork;
 import com.untangle.uvm.network.DynamicRouteOspfArea;
 import com.untangle.uvm.network.DynamicRouteOspfInterface;
+import com.untangle.uvm.network.DynamicRoutingSettings;
+import com.untangle.uvm.network.FilterRule;
+import com.untangle.uvm.network.FilterRuleCondition;
+import com.untangle.uvm.network.InterfaceSettings;
+import com.untangle.uvm.network.InterfaceSettings.ConfigType;
+import com.untangle.uvm.network.InterfaceSettings.V4ConfigType;
+import com.untangle.uvm.network.InterfaceSettings.V6ConfigType;
+import com.untangle.uvm.network.InterfaceStatus;
+import com.untangle.uvm.network.NatRule;
+import com.untangle.uvm.network.NatRuleCondition;
+import com.untangle.uvm.network.NetflowSettings;
+import com.untangle.uvm.network.NetworkSettings;
+import com.untangle.uvm.network.PortForwardRule;
+import com.untangle.uvm.network.PortForwardRuleCondition;
+import com.untangle.uvm.network.QosPriority;
+import com.untangle.uvm.network.QosRule;
+import com.untangle.uvm.network.QosRuleCondition;
+import com.untangle.uvm.network.QosSettings;
+import com.untangle.uvm.network.StaticRoute;
+import com.untangle.uvm.network.UpnpRule;
+import com.untangle.uvm.network.UpnpRuleCondition;
+import com.untangle.uvm.network.UpnpSettings;
+import com.untangle.uvm.network.generic.InterfaceSettingsGeneric;
+import com.untangle.uvm.network.generic.InterfaceStatusGeneric;
+import com.untangle.uvm.network.generic.NetworkSettingsGeneric;
 import com.untangle.uvm.servlet.DownloadHandler;
 import com.untangle.uvm.util.ObjectMatcher;
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jabsorb.serializer.UnmarshallException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -63,18 +63,18 @@ import java.net.InetAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.Iterator;
 
 /**
  * The Network Manager handles all the network configuration
@@ -257,8 +257,10 @@ public class NetworkManagerImpl implements NetworkManager
      */
     public void setNetworkSettingsV2( NetworkSettingsGeneric newSettings )
     {
-        newSettings.transformGenericToNetworkSettings(this.networkSettings);
-        setNetworkSettings( this.networkSettings, true );
+        // Deep clone current Network Settings to transform in New Network Settings
+        NetworkSettings clonedNetworkSettings = SerializationUtils.clone(this.networkSettings);
+        newSettings.transformGenericToNetworkSettings(clonedNetworkSettings);
+        setNetworkSettings( clonedNetworkSettings, true );
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -4,56 +4,46 @@
 
 package com.untangle.uvm;
 
+import com.untangle.uvm.app.DayOfWeekMatcher;
+import com.untangle.uvm.generic.SystemSettingsGeneric;
+import com.untangle.uvm.network.NetworkSettings;
+import com.untangle.uvm.servlet.DownloadHandler;
+import com.untangle.uvm.util.Constants;
+import com.untangle.uvm.util.FileDirectoryMetadata;
+import com.untangle.uvm.util.IOUtil;
+import org.apache.commons.lang3.SerializationUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FilenameFilter;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
-import java.io.FileOutputStream;
+import java.io.FilenameFilter;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Scanner;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Scanner;
 import java.util.Set;
-import java.util.HashSet;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.TimeZone;
-import java.util.zip.*;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import com.untangle.uvm.generic.SystemSettingsGeneric;
-import com.untangle.uvm.network.NetworkSettings;
-import org.apache.commons.lang3.StringUtils;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
-import com.untangle.uvm.UvmContextFactory;
-import com.untangle.uvm.SettingsManager;
-import com.untangle.uvm.SystemManager;
-import com.untangle.uvm.SystemSettings;
-import com.untangle.uvm.SnmpSettings;
-import com.untangle.uvm.ExecManagerResultReader;
-import com.untangle.uvm.app.DayOfWeekMatcher;
-import com.untangle.uvm.event.AdminLoginEvent;
-import com.untangle.uvm.servlet.DownloadHandler;
-import com.untangle.uvm.util.Constants;
-import com.untangle.uvm.util.FileDirectoryMetadata;
-import com.untangle.uvm.util.IOUtil;
-import com.untangle.uvm.util.StringUtil;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  * The Manager for system-related settings
@@ -285,16 +275,20 @@ public class SystemManagerImpl implements SystemManager
      * @param systemSettingsGeneric SystemSettingsGeneric
      */
     public void setSystemSettingsV2(final SystemSettingsGeneric systemSettingsGeneric) {
-        // Get current network settings
+        // Get current network settings and clone it.
         NetworkSettings networkSettings = UvmContextFactory.context().networkManager().getNetworkSettings();
+        NetworkSettings clonedNetworkSettings = SerializationUtils.clone(networkSettings);
 
-        // update hostname and web services fields with value coming from postData
-        systemSettingsGeneric.transformGenericToLegacySettings(this.settings, networkSettings);
+        // Deep clone current System Settings to transform in New System Settings
+        SystemSettings clonedSystemSettings = SerializationUtils.clone(this.settings);
+
+        // update network (Hostname|Services) and system settings with value coming from postData
+        systemSettingsGeneric.transformGenericToLegacySettings(clonedSystemSettings, networkSettings);
 
         // Set Network Settings with updated values.
-        UvmContextFactory.context().networkManager().setNetworkSettings(networkSettings);
+        UvmContextFactory.context().networkManager().setNetworkSettings(clonedNetworkSettings);
 
-        // TODO Set SystemSettings when those fields will be transformed in future
+        // TODO Set SystemSettings (clonedSystemSettings) when those fields will be transformed in future
     }
 
     /**

--- a/uvm/servlets/admin/app/view/main/IframePanel.js
+++ b/uvm/servlets/admin/app/view/main/IframePanel.js
@@ -14,7 +14,6 @@ Ext.define('Ung.view.main.IframePanel', {
         this.callParent(arguments);
 
         this.on('afterrender', function (panel) {
-            console.log("Iframe Panel Loaded");
             var iframe = document.createElement('iframe');
 
             iframe.src = panel.iframeUrl || '';


### PR DESCRIPTION
In set settings v2 API's we were directly modifying the manager class settings object. 
In case of sanity failure this would cause issue of data mismatch in `network.js` and JVM object.
To handle this we need to clone original object apply transformations on cloned object and then pass it in set settings as new settings.

Other Changes:
1. Refactored Imports 
2. Using `V6ConfigType` for static variable instead of class variable `v6ConfigType`
3. Removed unnecessary console.log

