### PR TITLE
Ngfw 15261 create getinterfaceStatusV2

### DIFF
--- a/uvm/api/com/untangle/uvm/app/DayOfWeekMatcher.java
+++ b/uvm/api/com/untangle/uvm/app/DayOfWeekMatcher.java
@@ -4,6 +4,7 @@
 
 package com.untangle.uvm.app;
 
+import java.io.Serializable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -20,7 +21,8 @@ import org.apache.logging.log4j.LogManager;
  * 
  * DayOfWeekMatcher it is case insensitive
  */
-public class DayOfWeekMatcher
+@SuppressWarnings("serial")
+public class DayOfWeekMatcher implements Serializable
 {
     private static final String MARKER_ANY = "any";
     private static final String MARKER_ALL = "all";

--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -366,7 +366,7 @@ public class InterfaceSettings implements Serializable, JSONString
     /**
      * Interface alias.
      */
-    public static class InterfaceAlias
+    public static class InterfaceAlias implements Serializable
     {
         private InetAddress staticAddress; /* the address  of this interface if configured static, or dhcp override */ 
         private Integer     staticPrefix; /* the netmask of this interface if configured static, or dhcp override */
@@ -511,7 +511,7 @@ public class InterfaceSettings implements Serializable, JSONString
         intfSettingsGen.setSystemDev(this.systemDev);
         intfSettingsGen.setSymbolicDev(this.symbolicDev);
         intfSettingsGen.setImqDev(this.imqDev);
-        intfSettingsGen.setDevice(this.isVlanInterface ? this.systemDev : this.physicalDev);
+        intfSettingsGen.setDevice(resolveDeviceName());
         intfSettingsGen.setWan(this.isWan);
         intfSettingsGen.setType(resolveGenericType());
         intfSettingsGen.setVlanId(this.vlanTag);
@@ -615,6 +615,13 @@ public class InterfaceSettings implements Serializable, JSONString
     private InterfaceSettingsGeneric.V6ConfigType transformV6ConfigTypeEnum(V6ConfigType v6ConfigType) {
         return  (this.v6ConfigType == V6ConfigType.AUTO) ? InterfaceSettingsGeneric.V6ConfigType.SLAAC
                 : InterfaceSettingsGeneric.V6ConfigType.valueOf(this.v6ConfigType.name());
+    }
+
+    /**
+     * Helper: Resolve device name (vlan vs physical)
+     */
+    public String resolveDeviceName() {
+        return this.isVlanInterface ? this.systemDev : this.physicalDev;
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -283,7 +283,7 @@ public class SystemManagerImpl implements SystemManager
         SystemSettings clonedSystemSettings = SerializationUtils.clone(this.settings);
 
         // update network (Hostname|Services) and system settings with value coming from postData
-        systemSettingsGeneric.transformGenericToLegacySettings(clonedSystemSettings, networkSettings);
+        systemSettingsGeneric.transformGenericToLegacySettings(clonedSystemSettings, clonedNetworkSettings);
 
         // Set Network Settings with updated values.
         UvmContextFactory.context().networkManager().setNetworkSettings(clonedNetworkSettings);


### PR DESCRIPTION
- Added interface specific `getinterfaceStatusV2` API which accepts device as param and returns status response. 
This API is needed on interface edit page. Unnecessarily we had to fetch all intf status and hence, increased response time.

- For `SerializationUtils.clone` we need all nested objects to implement `java.io.Serializable`. Added same for `DayOfWeekMatcher` and `InterfaceAlias` classes.
- Changed `networkSettings` reference with `clonedNetworkSettings` reference for transformation method in `setSystemSettingsV2`