### PR TITLE
NGFW-15268 Fixed kiosk factory reset option

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-textui.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-textui.py
@@ -1508,7 +1508,7 @@ class FactoryDefaults(Form):
 
         uvm = UvmContext()
         try:
-            uvm.execute("nohup /usr/share/untangle/bin/ut-factory-defaults")
+            uvm.context.configManager().doFactoryReset()
         except:
             pass
         uvm = None


### PR DESCRIPTION
- Factory reset option in kiosk was indeed doing the factory reset, but since `forced-reboot` option was not provided to the factory reset script, we were seeing the python error.
 - Rather than replicating the same factory reset logic, we are now calling the factory reset API method.

https://github.com/user-attachments/assets/b07a09bf-7000-4089-aef9-fd5c6b7fe298


