### PR TITLE
ngfw-15293 transformation for static routes

### DIFF
--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -550,8 +550,8 @@ public class InterfaceSettings implements Serializable, JSONString
         intfSettingsGen.setV6StaticDNS1(this.v6StaticDns1);
         intfSettingsGen.setV6StaticDNS2(this.v6StaticDns2);
 
-        intfSettingsGen.setDhcpEnabled(null != this.dhcpEnabled && this.dhcpEnabled && this.dhcpType == DhcpType.SERVER);
-        intfSettingsGen.setDhcpRelayEnabled(null != this.dhcpEnabled && this.dhcpEnabled && this.dhcpType == DhcpType.RELAY);
+        intfSettingsGen.setDhcpEnabled(this.dhcpType == DhcpType.SERVER);
+        intfSettingsGen.setDhcpRelayEnabled(this.dhcpType == DhcpType.RELAY);
 
         intfSettingsGen.setDhcpRangeStart(this.dhcpRangeStart);
         intfSettingsGen.setDhcpRangeEnd(this.dhcpRangeEnd);

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -279,6 +279,10 @@ public class NetworkSettings implements Serializable, JSONString
         }
         netSettingsGen.setVirtualInterfaces(virtualInterfacesGen);
 
+        // Transform Static Routes
+        if(this.getStaticRoutes() != null)
+            netSettingsGen.setStaticRoutes(StaticRoute.transformStaticRoutesToGeneric(this.getStaticRoutes()));
+
         // Write other transformtions below
 
         return netSettingsGen;

--- a/uvm/api/com/untangle/uvm/network/StaticRoute.java
+++ b/uvm/api/com/untangle/uvm/network/StaticRoute.java
@@ -5,8 +5,11 @@ package com.untangle.uvm.network;
 
 import java.io.Serializable;
 import java.net.InetAddress;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.regex.Pattern;
 
+import com.untangle.uvm.network.generic.StaticRouteGeneric;
 import org.json.JSONObject;
 import org.json.JSONString;
 import org.apache.logging.log4j.Logger;
@@ -83,6 +86,22 @@ public class StaticRoute implements JSONString, Serializable
         }
         
     }
-    
+
+    /**
+     * Transforms Static Routes List to Static Routes Generic List for vue UI
+     * @param staticRoutes List<StaticRoute>
+     * @return LinkedList<StaticRouteGeneric>
+     */
+    public static LinkedList<StaticRouteGeneric> transformStaticRoutesToGeneric(List<StaticRoute> staticRoutes) {
+        LinkedList<StaticRouteGeneric> staticRouteGenList = new LinkedList<>();
+        for (StaticRoute staticRoute : staticRoutes) {
+            int prefix = staticRoute.getPrefix() != null ? staticRoute.getPrefix() : 24;
+            String network = new IPMaskedAddress(staticRoute.getNetwork(), prefix).toString();
+            StaticRouteGeneric staticRouteGeneric = new StaticRouteGeneric(staticRoute.getRuleId(), staticRoute.getDescription(), network, staticRoute.getNextHop());
+
+            staticRouteGenList.add(staticRouteGeneric);
+        }
+        return staticRouteGenList;
+    }
 }
 

--- a/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
@@ -379,7 +379,6 @@ public class InterfaceSettingsGeneric implements Serializable, JSONString {
         intfSettings.setV6StaticDns1(this.v6StaticDNS1);
         intfSettings.setV6StaticDns2(this.v6StaticDNS2);
 
-        intfSettings.setDhcpEnabled(this.dhcpEnabled || this.dhcpRelayEnabled);
         intfSettings.setDhcpType(resolveDhcpType(this));
         intfSettings.setDhcpRangeStart(this.dhcpRangeStart);
         intfSettings.setDhcpRangeEnd(this.dhcpRangeEnd);

--- a/uvm/api/com/untangle/uvm/network/generic/NetworkSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/NetworkSettingsGeneric.java
@@ -35,6 +35,7 @@ public class NetworkSettingsGeneric implements Serializable, JSONString {
     private LinkedList<InterfaceSettingsGeneric> virtualInterfaces = null;
     private LinkedList<RuleGeneric> port_forward_rules = null;
     private LinkedList<RuleGeneric> nat_rules = null;
+    private LinkedList<StaticRouteGeneric> staticRoutes = null;
 
     public NetworkSettingsGeneric() {
         super();
@@ -50,6 +51,9 @@ public class NetworkSettingsGeneric implements Serializable, JSONString {
     public void setPort_forward_rules(LinkedList<RuleGeneric> port_forward_rules) { this.port_forward_rules = port_forward_rules; }
     public LinkedList<RuleGeneric> getNat_rules() { return nat_rules; }
     public void setNat_rules(LinkedList<RuleGeneric> nat_rules) { this.nat_rules = nat_rules; }
+
+    public LinkedList<StaticRouteGeneric> getStaticRoutes() { return staticRoutes; }
+    public void setStaticRoutes(LinkedList<StaticRouteGeneric> staticRoutes) { this.staticRoutes = staticRoutes; }
 
     /**
      * Populates the provided {@link NetworkSettings} instance with data from this
@@ -107,6 +111,10 @@ public class NetworkSettingsGeneric implements Serializable, JSONString {
         // Transform NAT Rules
         if (this.nat_rules != null)
             networkSettings.setNatRules(transformGenericToLegacyNatRules(networkSettings.getNatRules()));
+
+        // Transform Static Routes
+        if (this.staticRoutes != null)
+            networkSettings.setStaticRoutes(StaticRouteGeneric.transformGenericToStaticRoutes(this.staticRoutes, networkSettings.getStaticRoutes()));
 
         // Write other transformations below
         

--- a/uvm/api/com/untangle/uvm/network/generic/StaticRouteGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/StaticRouteGeneric.java
@@ -1,0 +1,93 @@
+/**
+ * $Id$
+ */
+package com.untangle.uvm.network.generic;
+
+import com.untangle.uvm.app.IPMaskedAddress;
+import com.untangle.uvm.network.StaticRoute;
+import org.json.JSONObject;
+import org.json.JSONString;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Generic represesntation of @{StaticRoute}
+ */
+@SuppressWarnings("serial")
+public class StaticRouteGeneric implements JSONString, Serializable {
+
+    private Integer ruleId;
+    private String description;
+    private String network;
+    private String nextHop;
+
+    public StaticRouteGeneric() {}
+
+    public StaticRouteGeneric(Integer ruleId, String description, String network, String nextHop) {
+        this.ruleId = ruleId;
+        this.description = description;
+        this.network = network;
+        this.nextHop = nextHop;
+    }
+
+    public Integer getRuleId() { return ruleId; }
+    public void setRuleId(Integer ruleId) { this.ruleId = ruleId; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getNetwork() { return network; }
+    public void setNetwork(String network) { this.network = network; }
+    public String getNextHop() { return nextHop; }
+    public void setNextHop(String nextHop) { this.nextHop = nextHop; }
+
+    public String toJSONString() {
+        JSONObject jO = new JSONObject(this);
+        return jO.toString();
+    }
+
+    /**
+     * Transforms Static Routes Generic List to Static Routes List for vue UI set API
+     * @param staticRouteGenList LinkedList<StaticRouteGeneric>
+     * @param legacyStaticRoutes List<StaticRoute>
+     * @return List<StaticRoute>
+     */
+    public static List<StaticRoute> transformGenericToStaticRoutes(LinkedList<StaticRouteGeneric> staticRouteGenList, List<StaticRoute> legacyStaticRoutes) {
+        if (legacyStaticRoutes == null)
+            legacyStaticRoutes = new LinkedList<>();
+
+        // CLEANUP: Remove deleted routes first
+        Set<Integer> incomingIds = staticRouteGenList.stream()
+                .map(StaticRouteGeneric::getRuleId)
+                .collect(Collectors.toSet());
+        legacyStaticRoutes.removeIf(route -> !incomingIds.contains(route.getRuleId()));
+
+        // Build a map for quick lookup by ruleId
+        Map<Integer, StaticRoute> routesMap = legacyStaticRoutes.stream()
+                .collect(Collectors.toMap(StaticRoute::getRuleId, Function.identity()));
+
+        List<StaticRoute> staticRoutes = new LinkedList<>();
+        for (StaticRouteGeneric staticRouteGeneric : staticRouteGenList) {
+            StaticRoute staticRoute = routesMap.get(staticRouteGeneric.getRuleId());
+
+            if (staticRoute == null)
+                staticRoute = new StaticRoute();
+
+            staticRoute.setRuleId(staticRouteGeneric.getRuleId());
+            staticRoute.setDescription(staticRouteGeneric.getDescription());
+            if (staticRouteGeneric.getNetwork() != null) {
+                IPMaskedAddress ipMaskedAddress = new IPMaskedAddress(staticRouteGeneric.getNetwork());
+                staticRoute.setNetwork(ipMaskedAddress.getAddress());
+                staticRoute.setPrefix(ipMaskedAddress.getPrefixLength());
+            }
+            staticRoute.setNextHop(staticRouteGeneric.getNextHop());
+
+            staticRoutes.add(staticRoute);
+        }
+        return staticRoutes;
+    }
+}


### PR DESCRIPTION
- Added transformation logic for Static Routes in `getNetworkSettingsV2` and `setNetworkSettingsV2` API's
- Removed v1 model `dhcpEnabled` (redundant) field mapping logic