### PR TITLE
NGFW-15341 Reset dbRetention counter config when their opposite is set

### DIFF
--- a/reports/js/MainController.js
+++ b/reports/js/MainController.js
@@ -110,6 +110,15 @@ Ext.define('Ung.apps.reports.MainController', {
 
         v.setLoading(true);
 
+         if (vm.get('dbRetentionInDays')) {
+            // We will be setting daily retention. Zero-out hourly retention so that it isn't set later.
+            vm.set('settings.dbRetentionHourly', 0);
+         } else {
+            // using hourly retention instead of daily
+            // We will be setting hourly retention. Zero-out daily retention so that it isn't set later.
+            vm.set('settings.dbRetention', 0);
+         }
+
         Rpc.asyncData(v.appManager, 'setSettings', vm.get('settings'))
         .then(function(result){
             if(Util.isDestroyed(v, vm)){

--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -649,6 +649,16 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
             settings.setVersion(6);
         }
 
+        /*
+         * NGFW-15341: when getDbRetentionHourly is set along with the dbRetention, then hourly was taking precedence.
+         * Ideally when hourly value is set then days value should be set to 0.
+         */
+        if ( settings.getVersion() == null || settings.getVersion() < 7 ) {
+            // if dbRetentionHourly was changed from its default value 0, reset the days value to 0.
+            if (settings.getDbRetentionHourly() > 0) settings.setDbRetention(0);
+            settings.setVersion(7);
+        }
+
         /* sync settings to disk if necessary */
         File settingsFile = new File( settingsFileName );
         if (settingsFile.lastModified() > CRON_FILE.lastModified()){
@@ -802,7 +812,7 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
     private ReportsSettings defaultSettings()
     {
         ReportsSettings settings = new ReportsSettings();
-        settings.setVersion( 6 );
+        settings.setVersion(7);
         settings.setEmailTemplates( defaultEmailTemplates() );
         settings.setReportsUsers( defaultReportsUsers( null ) );
 

--- a/reports/src/com/untangle/app/reports/ReportsSettings.java
+++ b/reports/src/com/untangle/app/reports/ReportsSettings.java
@@ -17,7 +17,7 @@ import com.untangle.uvm.event.AlertRule;
 @SuppressWarnings("serial")
 public class ReportsSettings implements Serializable, JSONString
 {
-    private Integer version = 2;
+    private Integer version = 7;
     
     private Integer dbRetention = 7; // days
     private Integer dbRetentionHourly = 0;


### PR DESCRIPTION
- On frontend, under Reports -> Data, when dbRetentionHourly is set then dbRetention (Days) is reset to 0, and when dbRetention is set the dbRetentionHourly is reset to 0. Issue was occurred after this change https://github.com/untangle/ngfw_src/pull/494/files#diff-c54bc8a123da4fe0d0605502f49d5a761f78b9b5b5371b8c2b95d6e0c67b51c3, derived the same logic here. 
- This also fixes the issue when Hourly value is set, then after save settings, the radio button selection was selecting Days.
- Since on existing boxes both days and hourly values would be present, during upgrade, if hourly value is set, then we would reset the days value to 0.