### PR TITLE
Ngfw 15333 reports protocol filter issue

### DIFF
--- a/uvm/js/common/util/_Map.js
+++ b/uvm/js/common/util/_Map.js
@@ -228,8 +228,8 @@ Ext.define('Ung.util.Map', {
             fld: { type: 'string' }
         },
         elapsed_time: {
-            col: { text: 'Elapsed'.t(), filter: Rndr.filters.numeric, width: 160 }, // converter
-            fld: { type: 'integer', convert: Converter.timestamp }
+            col: { text: 'Elapsed'.t(), width: 160 }, // converter
+            fld: { type: 'string' }
         },
         end_time: {
             col: { text: 'End Time'.t(), filter: Rndr.filters.date, renderer: Renderer.timestampUnixRenderer, width: 160 }, // converter
@@ -424,7 +424,7 @@ Ext.define('Ung.util.Map', {
             fld: { type: 'string', sortType: 'asIp' }
         },
         protocol: {
-            col: { text: 'Protocol'.t(), filter: Rndr.filters.numeric, width: 80 },
+            col: { text: 'Protocol'.t(), width: 80 },
             fld: { type: 'integer', convert: Converter.protocol }
         },
         protocol_name: {

--- a/uvm/js/common/util/_Map.js
+++ b/uvm/js/common/util/_Map.js
@@ -228,7 +228,7 @@ Ext.define('Ung.util.Map', {
             fld: { type: 'string' }
         },
         elapsed_time: {
-            col: { text: 'Elapsed'.t(), width: 160 }, // converter
+            col: { text: 'Elapsed'.t(), width: 160 },
             fld: { type: 'string' }
         },
         end_time: {


### PR DESCRIPTION
**Changes:**

1. Changed **Protocol** column filter type to default (string filter). As field display value is of type string, numeric filter won't work.

<img width="1848" height="1047" alt="Screenshot from 2025-09-22 13-49-15" src="https://github.com/user-attachments/assets/e5b9e71c-3302-45d9-937a-3bdf4f2d88fc" />

-----------------------------------------------------------
2. Changed **Elapsed** field type to string as we get string value. Removed unnecessary converter (timestamp to date. Time Elapsed can't be expressed as Date value). Assigning default filter (string filter).

<img width="1848" height="1047" alt="Screenshot from 2025-09-22 13-03-27" src="https://github.com/user-attachments/assets/8133c1f1-d179-4d15-98fe-8dcba08174e3" />
