### PR TITLE
ngfw-15324: Implemented Transformation logic for system TimeSettings

### DIFF
--- a/uvm/api/com/untangle/uvm/SystemSettings.java
+++ b/uvm/api/com/untangle/uvm/SystemSettings.java
@@ -35,6 +35,7 @@ public class SystemSettings implements Serializable, JSONString
     private SnmpSettings snmpSettings;
 
     private String timeSource = "ntp";
+    private String timeZone = null;
 
     private int logRetention = 7;
     
@@ -131,6 +132,12 @@ public class SystemSettings implements Serializable, JSONString
      */
     public int getAutoUpgradeMinute() { return autoUpgradeMinute; }
     public void setAutoUpgradeMinute( int newValue) { this.autoUpgradeMinute = newValue; }
+    
+    /**
+     * Get the current timeZone
+     */
+    public String getTimeZone() { return timeZone; }
+    public void setTimeZone(String timeZone) { this.timeZone = timeZone; }
 
     /**
      * Get the current settings version
@@ -244,6 +251,7 @@ public class SystemSettings implements Serializable, JSONString
             systemSettingsGeneric.setPublicUrlMethod(networkSettings.getPublicUrlMethod());
             systemSettingsGeneric.setPublicUrlPort(networkSettings.getPublicUrlPort());
         }
+        systemSettingsGeneric.setTimeZone(new SystemSettingsGeneric.TimeZone(this.timeZone, StringUtils.EMPTY));
         return systemSettingsGeneric;
     }
 }

--- a/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
@@ -7,6 +7,7 @@ import com.untangle.uvm.SystemSettings;
 import com.untangle.uvm.network.NetworkSettings;
 import org.json.JSONObject;
 import org.json.JSONString;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 
@@ -39,6 +40,14 @@ public class SystemSettingsGeneric implements Serializable, JSONString {
     private String  publicUrlMethod;
     private String  publicUrlAddress;
     private Integer publicUrlPort;
+    private TimeZone timeZone = null;
+
+
+    /**
+     * These are required for TimeZone settings
+     */
+    public void setTimeZone(TimeZone timeZone) { this.timeZone = timeZone; }
+    public TimeZone getTimeZone() { return timeZone; }
 
     /**
      * These are required for Web Admin Ports
@@ -108,6 +117,40 @@ public class SystemSettingsGeneric implements Serializable, JSONString {
             networkSettings.setPublicUrlAddress(this.publicUrlAddress);
             networkSettings.setPublicUrlMethod(this.publicUrlMethod);
             networkSettings.setPublicUrlPort(this.publicUrlPort);
+        }if(systemSettings != null){
+            systemSettings.setTimeZone(this.timeZone.getDisplayName());
         }
     }
+    /**
+     * Represents the TimeZone data structure received from the Vue UI.
+     */
+        public static class TimeZone implements Serializable{
+        private String displayName= StringUtils.EMPTY;
+        private String value = StringUtils.EMPTY;
+
+        public TimeZone() {
+        }
+
+        public TimeZone(String displayName, String value) {
+            this.displayName = displayName;
+            this.value = value;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public void setDisplayName(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
 }

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -135,6 +135,7 @@ public class SystemManagerImpl implements SystemManager
             if (this.settings.getVersion() < SETTINGS_VERSION) {
                 this.settings.setVersion(SETTINGS_VERSION);
                 this.settings.setLogRetention(7);
+                this.settings.setTimeZone(getTimeZone().getID());
                 this.getSettings().setThresholdTemperature(105.0);
                 this.setSettings(this.settings, false);
             }
@@ -287,6 +288,7 @@ public class SystemManagerImpl implements SystemManager
 
         // Set Network Settings with updated values.
         UvmContextFactory.context().networkManager().setNetworkSettings(clonedNetworkSettings);
+        UvmContextFactory.context().systemManager().setSettings(clonedSystemSettings);
 
         // TODO Set SystemSettings (clonedSystemSettings) when those fields will be transformed in future
     }
@@ -333,6 +335,9 @@ public class SystemManagerImpl implements SystemManager
             newSettings.setRadiusProxyPassword(null);
         }
         SettingsManager settingsManager = UvmContextFactory.context().settingsManager();
+        if(!this.settings.getTimeZone().equals(newSettings.getTimeZone())){
+            setTimeZone(TimeZone.getTimeZone(newSettings.getTimeZone()));
+        }
         try {
             settingsManager.save(this.SettingsFileName, newSettings);
         } catch (SettingsManager.SettingsException e) {
@@ -1023,7 +1028,7 @@ can look deeper. - mahotz
         newSettings.setAutoUpgradeHour(23);
         newSettings.setAutoUpgradeMinute((new java.util.Random()).nextInt(60));
         newSettings.setAutoUpgradeDays(DayOfWeekMatcher.getAnyMatcher());
-
+        newSettings.setTimeZone(getTimeZone().getID());
         // pass the settings to the OEM override function and return the override settings
         SystemSettings overrideSettings = (SystemSettings)UvmContextFactory.context().oemManager().applyOemOverrides(newSettings);
         return overrideSettings;

--- a/uvm/servlets/admin/config/system/MainController.js
+++ b/uvm/servlets/admin/config/system/MainController.js
@@ -38,9 +38,6 @@ Ext.define('Ung.config.system.MainController', {
         var rpcSequence = [
             Rpc.asyncPromise('rpc.languageManager.getLanguageSettings'),
             Rpc.asyncPromise('rpc.systemManager.getSettings'),
-            Rpc.asyncPromise('rpc.systemManager.getDate'),
-            Rpc.asyncPromise('rpc.systemManager.getTimeZone'),
-            Rpc.asyncPromise('rpc.systemManager.getTimeZones'),
             Rpc.asyncPromise('rpc.systemManager.getLogDirectorySize'),
             Rpc.directPromise('rpc.isExpertMode'),
             Rpc.directPromise('rpc.UvmContext.isCCHidden')
@@ -49,9 +46,6 @@ Ext.define('Ung.config.system.MainController', {
         var dataNames = [
             'languageSettings',
             'systemSettings',
-            'time',
-            'timeZone',
-            'timeZonesList',
             'logDirectorySize',
             'isExpertMode',
             'isCCHidden'
@@ -80,13 +74,6 @@ Ext.define('Ung.config.system.MainController', {
                 return;
             }
 
-            var timeZones = [];
-            if (result[4]) {
-                eval(result[4]).forEach(function (tz) {
-                    timeZones.push({name: '(' + tz[1] + ') ' + tz[0], value: tz[0]});
-                });
-            }
-            vm.set('timeZonesList', timeZones);
 
             // Massage language to include the appropriate source.
             var languageSettings = result[0];
@@ -128,27 +115,6 @@ Ext.define('Ung.config.system.MainController', {
         });
     },
 
-    syncTime: function () {
-        Ext.MessageBox.confirm(
-            'Force Time Synchronization'.t(),
-            'Forced time synchronization can cause problems if the current date is far in the future.'.t() + '<br/>' +
-            'A reboot is suggested after time sychronization.'.t() + '<br/><br/>' +
-            'Continue?'.t(),
-            function(btn) {
-                if (btn === 'yes') {
-                    Ext.MessageBox.wait('Synchronizing time with the internet...'.t(), 'Please wait'.t());
-                    Rpc.asyncData('rpc.UvmContext.forceTimeSync')
-                    .then(function(result){
-                        Ext.MessageBox.hide();
-                        if (result !== 0) {
-                            Util.handleException('Time synchronization failed. Return code:'.t() + ' ' + result);
-                        } else {
-                            Util.successToast('Time was synchronized!');
-                        }
-                    });
-                }
-            });
-    },
 
     syncLanguage: function () {
         Ext.MessageBox.wait('Synchronizing languages with the internet...'.t(), 'Please wait'.t());
@@ -204,7 +170,6 @@ Ext.define('Ung.config.system.MainController', {
         var rpcSequence = [
             Rpc.asyncPromise('rpc.languageManager.setLanguageSettings', languageSettings),
             Rpc.asyncPromise('rpc.systemManager.setSettings', vm.get('systemSettings')),
-            Rpc.asyncPromise('rpc.systemManager.setTimeZone', vm.get('timeZone')),
         ];
 
         if(Rpc.directData('rpc.appManager.app', 'http')){

--- a/uvm/servlets/admin/config/system/MainModel.js
+++ b/uvm/servlets/admin/config/system/MainModel.js
@@ -7,28 +7,13 @@ Ext.define('Ung.config.system.MainModel', {
         title: 'System'.t(),
         iconName: 'system',
 
-        time: null,
         languageSettings: null,
         languagesList: null,
         systemSettings: null,
-        timeZone: null,
-        timeZonesList: null,
 
         shieldSettings: null
     },
     formulas: {
-        timeSource: function (get) {
-            return get('systemSettings.timeSource') === 'manual' ? 'Time was set manually'.t() : 'Time is automatically synchronized via NTP'.t();
-        },
-        manualDate: {
-            get: function (get) {
-                // to fix because rpc.systemManager.getDate() returns an invalid date string
-                return get('time') ? new Date(get('time').replace('EET', '(EET)')) : new Date();
-            },
-            set: function (val) {
-                return;
-            }
-        },
         // used for setting the date/time
         manualDateFormat: function (get) { return get('languageSettings.overrideTimestampFmt') || 'timestamp_fmt'.t(); },
 
@@ -64,10 +49,6 @@ Ext.define('Ung.config.system.MainModel', {
 
     },
     stores: {
-        timeZones: {
-            fields: ['name', 'value'],
-            data: '{timeZonesList}'
-        },
         languages: {
             fields: [
             'code',

--- a/uvm/servlets/admin/config/system/view/Regional.js
+++ b/uvm/servlets/admin/config/system/view/Regional.js
@@ -15,40 +15,6 @@ Ext.define('Ung.config.system.view.Regional', {
     },
 
     items: [{
-        title: 'Current Time'.t(),
-        hidden: true,
-        bind: {
-            hidden: '{!time}'
-        },
-        items: [{
-            xtype: 'component',
-            bind: '{timeSource}'
-        }, {
-            xtype: 'component',
-            margin: '10 0 0 0',
-            bind: '<i class="fa fa-clock-o"></i> <strong>{time}</strong>'
-        }]
-    }, {
-        title: 'Force Sync Time'.t(),
-        hidden: true,
-        bind: {
-            hidden: '{isExpertMode || systemSettings.timeSource === "manual" || !time}'
-        },
-        layout: {
-            type: 'hbox'
-        },
-        magin: 5,
-        items: [{
-            xtype: 'button',
-            margin: '0 10 0 0',
-            text: 'Synchronize Time'.t(),
-            iconCls: 'fa fa-refresh',
-            handler: 'syncTime'
-        }, {
-            xtype: 'displayfield',
-            value: 'Click to force instant time synchronization.'.t()
-        }]
-    }, {
         title: 'Time Settings'.t(),
         hidden: true,
         bind: {
@@ -104,33 +70,6 @@ Ext.define('Ung.config.system.view.Regional', {
                     hidden: '{systemSettings.timeSource !== "manual"}'
                 }
             }]
-        }]
-    }, {
-        title: 'Timezone'.t(),
-        hidden: true,
-        bind: {
-            hidden: '{!timeZonesList || !timeZone}'
-        },
-        items: [{
-            xtype: 'combo',
-            width: 350,
-            bind: {
-                store: '{timeZones}',
-                value: '{timeZone.ID}'
-            },
-            listeners: {
-                change: function (ck, newValue) {
-                    // warn if changing timezone but dont warn on initial render
-                    if (ck.initialized) {
-                        Ext.MessageBox.alert('Timezone changed'.t(),"A reboot is required after changing the timezone!".t());
-                    }
-                    ck.initialized = true;
-                }
-            },
-            displayField: 'name',
-            valueField: 'value',
-            editable: false,
-            queryMode: 'local'
         }]
     }, {
         title: 'Language'.t(),


### PR DESCRIPTION
**System TimeSetting Vue Migration - Summary of Changes:**

- Previously, the timeZone was managed via a specific method setTimeZone(), which saved the time settings in the /etc/TimeZone file.
- As per the Vue payload requirements, the timezone string attribute has now been added to settings.js. This new attribute is used to construct the timezone and set it using the existing setTimeZone() method.
- The current "Time" tab has been temporarily removed and will be implemented in a separate story under the dashboard, similar to the MFW UI.