### PR TITLE
ngfw-15345: Fixed Timezone data discrepancy issue

### DIFF
--- a/uvm/api/com/untangle/uvm/SystemSettings.java
+++ b/uvm/api/com/untangle/uvm/SystemSettings.java
@@ -35,7 +35,6 @@ public class SystemSettings implements Serializable, JSONString
     private SnmpSettings snmpSettings;
 
     private String timeSource = "ntp";
-    private String timeZone = null;
 
     private int logRetention = 7;
     
@@ -134,12 +133,6 @@ public class SystemSettings implements Serializable, JSONString
     public void setAutoUpgradeMinute( int newValue) { this.autoUpgradeMinute = newValue; }
 
     /**
-     * Get the current timeZone
-     */
-    public String getTimeZone() { return timeZone; }
-    public void setTimeZone(String timeZone) { this.timeZone = timeZone; }
-
-    /**
      * Get the current settings version
      */
     public int getVersion() { return version; }
@@ -229,8 +222,9 @@ public class SystemSettings implements Serializable, JSONString
      * @return a new {@link SystemSettingsGeneric} instance containing the generic representation of systemSettings for vue UI
      */
     public SystemSettingsGeneric transformLegacyToGenericSettings(NetworkSettings networkSettings) {
+        UvmContext context =  UvmContextFactory.context();
         SystemSettingsGeneric systemSettingsGeneric = new SystemSettingsGeneric();
-        systemSettingsGeneric.setCCHidden(UvmContextFactory.context().isCCHidden());
+        systemSettingsGeneric.setCCHidden(context.isCCHidden());
 
         if (networkSettings != null) {
             // Local Services Settings
@@ -253,7 +247,7 @@ public class SystemSettings implements Serializable, JSONString
             systemSettingsGeneric.setPublicUrlMethod(networkSettings.getPublicUrlMethod());
             systemSettingsGeneric.setPublicUrlPort(networkSettings.getPublicUrlPort());
         }
-        systemSettingsGeneric.setTimeZone(new SystemSettingsGeneric.TimeZone(this.timeZone, StringUtils.EMPTY));
+        systemSettingsGeneric.setTimeZone(new SystemSettingsGeneric.TimeZone(context.systemManager().getTimeZone().getID(), StringUtils.EMPTY));
 
         systemSettingsGeneric.setCloudEnabled(this.getCloudEnabled());
         systemSettingsGeneric.setSupportEnabled(this.getSupportEnabled());

--- a/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
@@ -151,7 +151,6 @@ public class SystemSettingsGeneric implements Serializable, JSONString {
         }
 
         if (systemSettings != null) {
-            systemSettings.setTimeZone(this.timeZone.getDisplayName());
             systemSettings.setCloudEnabled(this.isCloudEnabled());
             systemSettings.setSupportEnabled(this.isSupportEnabled());
         }

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -50,7 +50,7 @@ import java.util.zip.ZipOutputStream;
  */
 public class SystemManagerImpl implements SystemManager
 {
-    private static final int SETTINGS_VERSION = 7;
+    private static final int SETTINGS_VERSION = 6;
     private static final String ZIP_FILE = "system_logs.zip";
     private static final String EOL = "\n";
     private static final String BLANK_LINE = EOL + EOL;
@@ -137,7 +137,6 @@ public class SystemManagerImpl implements SystemManager
                     this.settings.setLogRetention(7);
                 }
                 this.settings.setVersion(SETTINGS_VERSION);
-                this.settings.setTimeZone(getTimeZone().getID());
                 this.getSettings().setThresholdTemperature(105.0);
                 this.setSettings(this.settings, false);
             }
@@ -287,6 +286,9 @@ public class SystemManagerImpl implements SystemManager
 
         // update network (Hostname|Services) and system settings with value coming from postData
         systemSettingsGeneric.transformGenericToLegacySettings(clonedSystemSettings, clonedNetworkSettings);
+        
+        //Set TimeZone with updated values.
+        setTimeZone(TimeZone.getTimeZone(systemSettingsGeneric.getTimeZone().getDisplayName()));
 
         // Set Network Settings with updated values.
         UvmContextFactory.context().networkManager().setNetworkSettings(clonedNetworkSettings);
@@ -337,9 +339,6 @@ public class SystemManagerImpl implements SystemManager
             newSettings.setRadiusProxyPassword(null);
         }
         SettingsManager settingsManager = UvmContextFactory.context().settingsManager();
-        if(this.settings != null && !this.settings.getTimeZone().equals(newSettings.getTimeZone())){
-            setTimeZone(TimeZone.getTimeZone(newSettings.getTimeZone()));
-        }
         try {
             settingsManager.save(this.SettingsFileName, newSettings);
         } catch (SettingsManager.SettingsException e) {
@@ -1030,7 +1029,6 @@ can look deeper. - mahotz
         newSettings.setAutoUpgradeHour(23);
         newSettings.setAutoUpgradeMinute((new java.util.Random()).nextInt(60));
         newSettings.setAutoUpgradeDays(DayOfWeekMatcher.getAnyMatcher());
-        newSettings.setTimeZone(getTimeZone().getID());
         // pass the settings to the OEM override function and return the override settings
         SystemSettings overrideSettings = (SystemSettings)UvmContextFactory.context().oemManager().applyOemOverrides(newSettings);
         return overrideSettings;


### PR DESCRIPTION
During testing of the TimeZone Vue migration, a bug was identified where changing the timezone via ETM does not update the system.js settings properly. This occurs because the ETM directly calls the timedatectl command to set the timezone, bypassing the usual update mechanisms. As a result, there is a data discrepancy in the displayed timezone information. hence the UI shows outdated timezone data after changes through ETM.
Fixed the issue via refering single file /etc/timezone for timezone settings.