### PR TITLE
ngfw-15347: Added v2 calls for getter/setter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -322,7 +322,7 @@ Description: Tunnel VPN
 
 Package: untangle-app-dynamic-blocklists
 Architecture: all
-Depends: ${misc:Depends}, untangle-vm, openvpn, python3
+Depends: ${misc:Depends}, untangle-vm, python3
 Description: Dynamic Blocklists
  The Dynamic Blocklists VPN application.
  

--- a/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockList.java
+++ b/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockList.java
@@ -27,6 +27,8 @@ public class DynamicBlockList implements Serializable, JSONString {
     private long count;
     private long lastUpdated;
 
+    public DynamicBlockList() { }
+
     public String getId() { return id; }
     public void setId(String id) { this.id = id; }
 

--- a/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsManager.java
+++ b/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsManager.java
@@ -36,9 +36,9 @@ public class DynamicBlockListsManager {
      * Start the dbl setup
      */
     protected void start() {
+        this.app.start();
         logger.info("Staring the Dynamic Blocklist Setup Process");
-        ExecManagerResult result = UvmContextFactory.context().execManager().exec(DBL_SETUP_SCRIPT);
-        configure();
+        ExecManagerResult result = UvmContextFactory.context().execManager().exec(DBL_SETUP_SCRIPT); 
         logger.info("DBL setup script result: {}", result.getOutput());
     }
 
@@ -46,6 +46,7 @@ public class DynamicBlockListsManager {
      * Stop the filter chain
      */
     protected void stop() {
+        this.app.stop();
         logger.info("Staring the Dynamic Blocklist Cleanup Process");
         ExecManagerResult result = UvmContextFactory.context().execManager().exec(DBL_CLEAN_UP_SCRIPT );
         logger.info("DBL cleanup script result: {}", result.getOutput());

--- a/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsSettings.java
+++ b/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsSettings.java
@@ -19,14 +19,19 @@ import org.json.JSONString;
 public class DynamicBlockListsSettings implements Serializable, JSONString
 {
     private Integer version = 1;
-    private List<DynamicBlockList> dynamicBlockList = new LinkedList<>();
+    private Boolean enabled = false;
+    private LinkedList<DynamicBlockList> configurations = new LinkedList<DynamicBlockList>();
+    public DynamicBlockListsSettings() { }
 
     public Integer getVersion() { return version; }
     public void setVersion(Integer version) { this.version = version; }
 
-    public List<DynamicBlockList> getDynamicBlockList() { return dynamicBlockList; }
-    public void setDynamicBlockList(List<DynamicBlockList> dynamicBlockList) { this.dynamicBlockList = dynamicBlockList; }
- 
+    public LinkedList<DynamicBlockList> getConfigurations() { return configurations; }
+    public void setConfigurations(LinkedList<DynamicBlockList> configurations) { this.configurations = configurations; }
+    
+    public Boolean getEnabled() { return enabled; } 
+    public void setEnabled(Boolean enabled) { this.enabled = enabled; }
+
     public String toJSONString()
     {
         JSONObject jO = new JSONObject(this);


### PR DESCRIPTION
**Description of Changes for Dynamic Blocklists Application**


- Added handling of dynamic blocklist settings with new getter/setter methods required for Vue(getDynamicBlockListsSettingsV2 and setDynamicBlockListSettingsV2).
- Added logic to start or stop the DynamicBlockListsManager based on the enabled state in the settings.
- handling lifecycle management with setteing method instead of preStart, postStart, and preStop methods to control the dynamic blocklist manager.
- Introduced a method to reset settings to defaults (onResetDefaultsV2), ensuring the manager stops when resetting.
- Updated settings model to include an enabled flag.
