### PR TITLE
ngfw-15338 : Allow /31 subnets for ipv4 static addresses 

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -947,7 +947,17 @@ Ext.define('Ung.util.Util', {
         return Util.isIPInRange(nextPoolAddr, network, netMask)? nextPoolAddr : '';
     },
 
-    
+    /**  Helper function to convert netmask string to prefix length
+     * @param {*} netmask
+     */
+    netmaskToPrefix: function(netmask) {
+        var binaryStr = netmask.split('.')
+            .map(function(octet) {
+                return ("00000000" + parseInt(octet, 10).toString(2)).slice(-8);
+            })
+            .join('');
+        return binaryStr.split('1').length - 1;
+    },
 
     /**
      * From the specified IP address and netmask, return the network.

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -440,8 +440,12 @@ Ext.define('Ung.config.network.Interface', {
                         try {
                             var staticPrefix = this.up('window').down('#intfcNetmask').getValue(),
                                 intfcNetMask = Util.getV4NetmaskMap()[staticPrefix];
-                            if(value == Util.getNetwork(value, intfcNetMask) || value == Util.getBroadcast(value, intfcNetMask)) {
-                                return Ext.String.format('Address cannot be a network or broadcast address with netmask {0}.'.t(), intfcNetMask);
+                            var prefixLength = Util.netmaskToPrefix(intfcNetMask);
+                            // Allow /31 subnets – no need for broadcast and network address validation, as both IPs are usable.
+                            if (prefixLength !== 31) {
+                                if(value == Util.getNetwork(value, intfcNetMask) || value == Util.getBroadcast(value, intfcNetMask)) {
+                                    return Ext.String.format('Address cannot be a network or broadcast address with netmask {0}.'.t(), intfcNetMask);
+                                }
                             }
                         } catch(er) {
                             console.log(er);
@@ -632,8 +636,11 @@ Ext.define('Ung.config.network.Interface', {
                                 var selection = this.up("ungrid").getSelectionModel().getSelection()[0],
                                     staticPrefix = selection ? selection.get('staticPrefix') : 24,
                                     aliasNetMask = Util.getV4NetmaskMap()[staticPrefix];
-                                if(value == Util.getNetwork(value, aliasNetMask) || value == Util.getBroadcast(value, aliasNetMask)) {
-                                    return Ext.String.format('Address cannot be a network or broadcast address with netmask {0}'.t(), aliasNetMask);
+                                var prefixLength = Util.netmaskToPrefix(intfcNetMask);
+                                if (prefixLength !== 31) {
+                                    if(value == Util.getNetwork(value, aliasNetMask) || value == Util.getBroadcast(value, aliasNetMask)) {
+                                        return Ext.String.format('Address cannot be a network or broadcast address with netmask {0}'.t(), aliasNetMask);
+                                    }
                                 }
                             } catch(err) {
                                 console.log(err);


### PR DESCRIPTION
**Description:**

This PR updates IP address validation logic to allow /31 subnets.
According to [RFC 3021](https://datatracker.ietf.org/doc/html/rfc3021), both IPs in a /31 subnet are usable, eliminating the need for traditional broadcast and network address validation.

**Changes:**
- Skipped broadcast and network address checks for /31 subnets
- Ensured both IPs in /31 are considered valid for static configuration

**Testing:**

- Navigate to Config → Network.
- Click Add VLAN.
- Enter the required details.
- For the static IPv4 address, use a subnet of /31.
- Set the DHCP range according to the given /31 IP address.
- Verify that both IPs in the /31 subnet are accepted and no UI validation errors are shown.

**Functional Testing:**

- Set up a point-to-point link using a /31 subnet between two devices or interfaces.
- Ensure both endpoints can communicate with each other successfully, validating proper handling of /31 subnet behavior.
