### PR TITLE
ngfw-15338: Allow 31 Subnet

### DIFF
--- a/uvm/js/common/util/Util.js
+++ b/uvm/js/common/util/Util.js
@@ -987,6 +987,17 @@ Ext.define('Ung.util.Util', {
     },
 
     /**
+     * From the specified IP address and netmask, validate the ip.
+     * @param {*} ip
+     * @param {*} prefix
+     */
+    isNetworkOrBroadcast: function(ip, prefix) {
+        if (prefix === 31) return false;
+        var netmask = Util.getV4NetmaskMap()[prefix];
+        return ip === Util.getNetwork(ip, netmask) || ip === Util.getBroadcast(ip, netmask);
+    },
+
+    /**
      * Increment the passed IP
      * @param  string ip      IP address to increment.
      * @param  int inc        Number to increment by.

--- a/uvm/servlets/admin/config/network/Interface.js
+++ b/uvm/servlets/admin/config/network/Interface.js
@@ -438,10 +438,9 @@ Ext.define('Ung.config.network.Interface', {
                     validator: function(value) {
                         // Validation for not allowing network and broadcast address of selected netmask
                         try {
-                            var staticPrefix = this.up('window').down('#intfcNetmask').getValue(),
-                                intfcNetMask = Util.getV4NetmaskMap()[staticPrefix];
-                            if(value == Util.getNetwork(value, intfcNetMask) || value == Util.getBroadcast(value, intfcNetMask)) {
-                                return Ext.String.format('Address cannot be a network or broadcast address with netmask {0}.'.t(), intfcNetMask);
+                            var staticPrefix = this.up('window').down('#intfcNetmask').getValue();
+                            if (Util.isNetworkOrBroadcast(value, staticPrefix)) {
+                                return Ext.String.format('Address cannot be a network or broadcast address with netmask {0}.'.t(), Util.getV4NetmaskMap()[staticPrefix]);
                             }
                         } catch(er) {
                             console.log(er);
@@ -630,17 +629,16 @@ Ext.define('Ung.config.network.Interface', {
                             // Validation for not allowing network and broadcast address of selected netmask                           
                             try {
                                 var selection = this.up("ungrid").getSelectionModel().getSelection()[0],
-                                    staticPrefix = selection ? selection.get('staticPrefix') : 24,
-                                    aliasNetMask = Util.getV4NetmaskMap()[staticPrefix];
-                                if(value == Util.getNetwork(value, aliasNetMask) || value == Util.getBroadcast(value, aliasNetMask)) {
-                                    return Ext.String.format('Address cannot be a network or broadcast address with netmask {0}'.t(), aliasNetMask);
-                                }
+                                    staticPrefix = selection ? selection.get('staticPrefix') : 24;
+                            if (Util.isNetworkOrBroadcast(value, staticPrefix)) {
+                                return Ext.String.format('Address cannot be a network or broadcast address with netmask {0}.'.t(), Util.getV4NetmaskMap()[staticPrefix]);
+                            }
                             } catch(err) {
                                 console.log(err);
                             }
                             // Validation for not allowing duplicate IP Addresses
                             if(this.dirty) {
-                                // Check if current value is eqaul to original value
+                                // Check if current value is equal to original value
                                 if(this.value === this.originalValue) return true;
 
                                 var aliasStore = this.up('grid').getStore(),


### PR DESCRIPTION
This PR updates IP address validation logic to allow /31 subnets.
According to [RFC 3021](https://datatracker.ietf.org/doc/html/rfc3021), both IPs in a /31 subnet are usable, eliminating the need for traditional broadcast and network address validation.

**Changes:**

Skipped broadcast and network address checks for /31 subnets
Ensured both IPs in /31 are considered valid for static configuration
**Testing:**

- Navigate to Config → Network.
- Click Add VLAN.
- Enter the required details.
- For the static IPv4 address, use a subnet of /31.
- Set the DHCP range according to the given /31 IP address.
- Verify that both IPs in the /31 subnet are accepted and no UI validation errors are shown.

**Functional Testing:**

- Set up a point-to-point link using a /31 subnet between two devices or interfaces.
- Ensure both endpoints can communicate with each other successfully, validating proper handling of /31 subnet behavior.