### PR TITLE
ngfw-15560 get apps views v2 API added

### DIFF
--- a/uvm/api/com/untangle/uvm/app/AppManager.java
+++ b/uvm/api/com/untangle/uvm/app/AppManager.java
@@ -189,6 +189,21 @@ public interface AppManager
     AppsView[] getAppsViews();
 
     /**
+     * Get the view of the apps (v2 format) when the specified policy/rack is displayed
+     *
+     * @param policyId policy.
+     * @return visible apps for this policy.
+     */
+    AppsView getAppsViewV2( Integer policyId );
+
+    /**
+     * Get the appsview for all policies in v2 format
+     *
+     * @return visible apps for every policy.
+     */
+    AppsView[] getAppsViewsV2();
+
+    /**
      * Shutdown any running apps that have an invalid license
      */
     void shutdownAppsWithInvalidLicense();

--- a/uvm/impl/com/untangle/uvm/AppManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/AppManagerImpl.java
@@ -994,6 +994,25 @@ public class AppManagerImpl implements AppManager
     }
 
     /**
+     * Get the view of the apps (v2 format) when the specified policy/rack is displayed
+     *
+     * @param policyId policy.
+     * @return visible apps for this policy.
+     */
+    public AppsView getAppsViewV2( Integer policyId ) {
+        return this.getAppsView( policyId );
+    }
+
+    /**
+     * Get an array of the AppsView for all policies (V2 API)
+     * 
+     * @return The array of AppsView objects
+     */
+    public AppsView[] getAppsViewsV2() {
+        return this.getAppsViews();
+    }
+
+    /**
      * Returns true is apps are being loaded
      * 
      * @return a boolean value


### PR DESCRIPTION
Added `getAppsViewV2(Integer policyId)` and `getAppsViewsV2` API's in `AppManager` to get the app views details for each poliicy. These API's will be required for Vue UI Apps View Implementation.