### PR TITLE
ngfw-15619 Modified 300-wireguard

### DIFF
--- a/wireguard-vpn/hier/etc/untangle/post-network-hook.d/300-wireguard
+++ b/wireguard-vpn/hier/etc/untangle/post-network-hook.d/300-wireguard
@@ -17,10 +17,22 @@ if [ -f /etc/wireguard/wg0.conf ]; then
         echo "Missing status file: /var/lib/interface-status/interface-wg0-status.js"
     fi
 
-    ip rule add priority 221 lookup wireguard
-    wg-quick down /etc/wireguard/wg0.conf
+    # Add routing rule only if it doesn't already exist
+    if ! ip rule list | grep -q "221:.*lookup wireguard"; then
+        ip rule add priority 221 lookup wireguard || echo "Warning: Failed to add routing rule"
+    fi
+
+    # Force cleanup of any existing wg0 interface to prevent stale state
+    # This removes any orphaned IP addresses, routes, or partial interface state
+    if ip link show wg0 >/dev/null 2>&1; then
+        echo "Removing existing wg0 interface"
+        ip link del dev wg0 2>/dev/null || echo "Warning: Failed to delete wg0 interface"
+    fi
+
+    # Bring up WireGuard interface
     wg-quick up /etc/wireguard/wg0.conf
 else
-    ip rule del priority 221 lookup wireguard
-    ip link del dev wg0
+    # Clean up routing rule and interface when WireGuard is disabled
+    ip rule del priority 221 lookup wireguard 2>/dev/null || echo "Warning: Routing rule not found"
+    ip link del dev wg0 2>/dev/null || echo "Warning: wg0 interface not found"
 fi


### PR DESCRIPTION
**Problem**
WireGuard site-to-site tunnels fail in between active connection, requiring manual disable/enable cycles to restore functionality.

**Root Cause:**

- Race condition between WireGuard startup and DNS service initialization
- wg-quick down fails when DNS unavailable, leaving orphaned IP addresses
- Subsequent wg-quick up fails with RTNETLINK answers: File exists error
- Concurrent script executions create duplicate interfaces

**Impact:** Production customer devices affected

**Solution**
Modified `/etc/untangle/post-network-hook.d/300-wireguard`:

1. Replaced DNS-dependent cleanup with direct interface deletion
    Removed: wg-quick down /etc/wireguard/wg0.conf
    Added: ip link del dev wg0 (no DNS dependency)
2. Added conditional routing rule check to prevent duplicate rule errors
3. Improved error handling with warnings instead of silent failures

**Testing**
- Verified on production device (uid 7620-2f5e-9697-eb52)
- Eliminates RTNETLINK answers: File exists errors
- Eliminates wg-quick: 'wg0' already exists errors
- Tunnels establish automatically on boot without manual intervention
- No regressions in normal operation (manual stop/start, settings changes)