### PR TITLE
NGFW-15677 Using @SafeCheck for IPSec data attributes

### DIFF
--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnNetwork.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnNetwork.java
@@ -9,6 +9,8 @@ import java.io.Serializable;
 import org.json.JSONObject;
 import org.json.JSONString;
 
+import com.untangle.uvm.util.SafeCheck;
+
 /**
  * This class is used to hold the settings for GRE networks. Yes, it probably
  * should have been called IpsecGreNetwork, but changing it now would require
@@ -24,9 +26,13 @@ public class IpsecVpnNetwork implements JSONString, Serializable
 {
     private int id;
     private boolean active;
+    @SafeCheck
     private String description;
+    @SafeCheck
     private String localAddress;
+    @SafeCheck
     private String remoteAddress;
+    @SafeCheck
     private String remoteNetworks;
     private int ttl = 64;
     private int mtu = 1476;

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnPingTimer.java
@@ -5,6 +5,7 @@
 package com.untangle.app.ipsec_vpn;
 
 import java.util.LinkedList;
+import java.util.List;
 import java.util.TimerTask;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -107,9 +108,9 @@ public class IpsecVpnPingTimer extends TimerTask
             tunnel = configList.get(x);
 
             // ignore disabled tunnels and those with no ping target configured
-            if (tunnel.getActive() == false) continue;
+            if (!tunnel.getActive()) continue;
             if (tunnel.getPingAddress() == null) continue;
-            if (tunnel.getPingAddress().length() == 0) continue;
+            if (tunnel.getPingAddress().isEmpty()) continue;
             if (tunnel.getRight().equals("%any")) continue;
 
             String leftAddress = app.getManager().resolveLeftAddress(tunnel.getLeft());
@@ -118,14 +119,14 @@ public class IpsecVpnPingTimer extends TimerTask
             watcher = watchTable.get(tunnel.getDescription());
 
             if (watcher == null) {
-                logger.debug("Creating new ping table entry for " + tunnel.getDescription());
+                logger.debug("Creating new ping table entry for {}", tunnel.getDescription());
                 watcher = new TunnelWatcher(tunnel.getDescription(), tunnel.getId());
                 lastLeftConnectAddressTable.put(tunnel.getDescription(), leftAddress);
                 watchTable.put(tunnel.getDescription(), watcher);
             }
 
             else {
-                logger.debug("Found existing ping table entry for " + tunnel.getDescription());
+                logger.debug("Found existing ping table entry for {}", tunnel.getDescription());
             }
 
             // update the cycle mark for the current tunnel
@@ -152,7 +153,8 @@ public class IpsecVpnPingTimer extends TimerTask
                     watcher.failCounter = 0;
                     IpsecVpnEvent event = new IpsecVpnEvent(leftAddress, tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.CONNECT);
                     app.logEvent(event);
-                    logger.debug("logEvent(ipsec_vpn_events) " + event.toSummaryString());
+                    if (logger.isDebugEnabled())
+                        logger.debug("logEvent(ipsec_vpn_events) {}", event.toSummaryString());
                 }
 
                 // continue the tunnel loop
@@ -171,7 +173,8 @@ public class IpsecVpnPingTimer extends TimerTask
                 watcher.activeFlag = false;
                 IpsecVpnEvent event = new IpsecVpnEvent(leftAddress, tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.DISCONNECT);
                 app.logEvent(event);
-                logger.debug("logEvent(ipsec_vpn_events) " + event.toSummaryString());
+                if (logger.isDebugEnabled())
+                    logger.debug("logEvent(ipsec_vpn_events) {}", event.toSummaryString());
             }
 
             // increment the ping fail counter for the tunnel
@@ -181,16 +184,17 @@ public class IpsecVpnPingTimer extends TimerTask
             if (watcher.failCounter < PING_FAIL_THRESHOLD) continue;
 
             // fail threshold reached so log event and bring tunnel down and back up
-            logger.warn("Attempting restart for inactive tunnel " + watcher.controlName);
+            logger.warn("Attempting restart for inactive tunnel {}", watcher.controlName);
 
             IpsecVpnEvent event = new IpsecVpnEvent(leftAddress, tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.RESTART);
             app.logEvent(event);
-            logger.debug("logEvent(ipsec_vpn_events) " + event.toSummaryString());
+            if (logger.isDebugEnabled())
+                logger.debug("logEvent(ipsec_vpn_events) {}", event.toSummaryString());
 
-            IpsecVpnApp.execManager().exec("ipsec down " + watcher.controlName);
+            IpsecVpnApp.execManager().execCommand("/sbin/ipsec", List.of("down", watcher.controlName));
 
             // run the up command in the background as it can block if the other side is unreachable
-            IpsecVpnApp.execManager().exec("nohup ipsec up " + watcher.controlName );
+            IpsecVpnApp.execManager().execCommand("/sbin/ipsec", List.of("up", watcher.controlName));
         }
 
         Iterator<String> ksi = watchTable.keySet().iterator();
@@ -203,7 +207,7 @@ public class IpsecVpnPingTimer extends TimerTask
             // it means we didn't find an enabled IPsec tunnel so we remove the entry
             // using the iterator remove function since the Java docs say it's safe
             if (watcher.cycleMark != cycleCounter) {
-                logger.debug("Removing stale ping table entry for " + watcher.tunnelName);
+                logger.debug("Removing stale ping table entry for {}", watcher.tunnelName);
                 ksi.remove();
             }
         }
@@ -221,22 +225,23 @@ public class IpsecVpnPingTimer extends TimerTask
     {
         if (tunnel == null) return (false);
         if (tunnel.getPingAddress() == null) return (false);
-        if (tunnel.getPingAddress().length() == 0) return (false);
+        if (tunnel.getPingAddress().isEmpty()) return (false);
         if (tunnel.getRight().equals("%any")) return (false);
 
         try {
             InetAddress target = InetAddress.getByName(tunnel.getPingAddress());
             if (target.isReachable(2000)) {
-                logger.debug("PING SUCCESS: " + tunnel.getPingAddress());
+                logger.debug("PING SUCCESS: {}", tunnel.getPingAddress());
                 return (true);
             }
         } catch (Exception exn) {
-            logger.debug("PING EXCEPTION: " + tunnel.getPingAddress(), exn);
+            logger.debug("PING EXCEPTION: {}", tunnel.getPingAddress(), exn);
         }
 
         IpsecVpnEvent event = new IpsecVpnEvent(app.getManager().resolveLeftAddress(tunnel.getLeft()), tunnel.getRight(), tunnel.getDescription(), IpsecVpnEvent.EventType.UNREACHABLE);
         app.logEvent(event);
-        logger.debug("logEvent(ipsec_vpn_events) " + event.toSummaryString());
+        if (logger.isDebugEnabled())
+            logger.debug("logEvent(ipsec_vpn_events) {}", event.toSummaryString());
         return (false);
     }
 }

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnSettings.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnSettings.java
@@ -8,6 +8,8 @@ import java.util.LinkedList;
 import org.json.JSONString;
 import org.json.JSONObject;
 
+import com.untangle.uvm.util.SafeCheck;
+
 /**
  * This class represents all of the settings for the IPsec application.
  * 
@@ -33,6 +35,7 @@ public class IpsecVpnSettings implements java.io.Serializable, JSONString
     private AuthenticationType authenticationType = AuthenticationType.LOCAL_DIRECTORY;
     private String virtualNetworkPool = ""; // used for GRE
     private String virtualAddressPool = ""; // used for L2TP
+    @SafeCheck
     private String virtualXauthPool = ""; // used for XAUTH
     private String virtualSecret = "Please_Change_Me";
     private String virtualDnsOne = "";

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
@@ -9,6 +9,8 @@ import java.io.Serializable;
 import org.json.JSONObject;
 import org.json.JSONString;
 
+import com.untangle.uvm.util.SafeCheck;
+
 /**
  * This class contains all settings for each configured IPsec tunnel.
  * 
@@ -23,6 +25,7 @@ public class IpsecVpnTunnel implements JSONString, Serializable
     private boolean active;
     private int ikeVersion = 1;
     private String conntype;
+    @SafeCheck
     private String description;
     private String secret;
     private String runmode;
@@ -41,12 +44,14 @@ public class IpsecVpnTunnel implements JSONString, Serializable
     private String left;
     private String leftId;
     private String leftSourceIp;
+    @SafeCheck
     private String leftSubnet;
     private String leftProtoPort;
     private String leftNextHop;
     private String right;
     private String rightId;
     private String rightSourceIp;
+    @SafeCheck
     private String rightSubnet;
     private String rightProtoPort;
     private String rightNextHop;

--- a/uvm/api/com/untangle/uvm/util/SafeCheck.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheck.java
@@ -10,10 +10,31 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a String field as requiring shell-safety validation.
- * Fields annotated with @SafeCheck will be validated by
- * SafeCheckValidator.validateAll() to reject values containing
- * shell metacharacters that could enable command injection.
+ * Marks a String field as requiring shell-safety sanitization.
+ * Fields annotated with {@code @SafeCheck} are automatically sanitized by
+ * {@link SafeCheckValidator#validateAll(Object)} in the JSON-RPC
+ * {@code preInvokeCallback}, stripping command injection constructs
+ * (backtick substitution, {@code $(cmd)}, {@code ${var}}, chaining
+ * operators, pipes, redirects, and newline injection) before settings
+ * reach application code.
+ *
+ * <h3>Usage rules</h3>
+ * <ul>
+ *   <li>Apply only to instance {@code String} fields. Non-String and
+ *       static fields are ignored by the validator.</li>
+ *   <li>The validator traverses into nested objects and Collections/Maps
+ *       automatically, so annotating a field on a deeply nested class
+ *       (e.g. {@code IpsecVpnTunnel.description}) works as long as the
+ *       parent settings object is reachable via the JSON-RPC call.</li>
+ *   <li>Collection and Map fields <b>must</b> declare their generic type
+ *       parameters (e.g. {@code List<MySettings>}, not raw {@code List}).
+ *       The validator uses compile-time generic type info to determine
+ *       whether a Collection's elements need scanning. Raw types make the
+ *       element type invisible and the annotated fields will be silently
+ *       skipped.</li>
+ *   <li>Inherited fields are supported - the validator walks the
+ *       superclass chain.</li>
+ * </ul>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/uvm/api/com/untangle/uvm/util/SafeCheck.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheck.java
@@ -1,0 +1,22 @@
+/**
+ * $Id$
+ */
+
+package com.untangle.uvm.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a String field as requiring shell-safety validation.
+ * Fields annotated with @SafeCheck will be validated by
+ * SafeCheckValidator.validateAll() to reject values containing
+ * shell metacharacters that could enable command injection.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SafeCheck
+{
+}

--- a/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
@@ -5,6 +5,9 @@
 package com.untangle.uvm.util;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,8 +63,44 @@ public class SafeCheckValidator
             "<(?=\\s*[a-zA-Z0-9_/(\\\\.])"            // <          input redirect / <()
         )
     );
+    /** Prefix used to identify JDK classes that should not be reflectively scanned. */
     private static final String JAVA = "java.";
+
+    /** Per-class cache of @SafeCheck and traversable field metadata. Populated once per class on first encounter. */
     private static final ConcurrentHashMap<Class<?>, ClassInfo> CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * Per-class cache of subtree relevance. Stores whether a class (or any class
+     * reachable through its instance fields) contains @SafeCheck annotations.
+     * Classes cached as false are skipped entirely by validateAll(), avoiding
+     * unnecessary traversal of object graphs that have no fields to sanitize.
+     */
+    private static final ConcurrentHashMap<Class<?>, Boolean> RELEVANCE_CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * Collects all instance fields from a class and its superclass chain,
+     * stopping at java.* classes. Static fields are excluded since @SafeCheck
+     * applies only to per-instance settings data. Walking the superclass chain
+     * ensures annotations on parent classes are not missed by getDeclaredFields().
+     *
+     * @param clazz
+     *        The class to inspect
+     * @return List of all instance fields in the class hierarchy
+     */
+    private static List<Field> getAllFields(Class<?> clazz)
+    {
+        List<Field> fields = new ArrayList<>();
+        while (clazz != null && !clazz.getName().startsWith(JAVA)) {
+            for (Field field : clazz.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                fields.add(field);
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return fields;
+    }
 
     /**
      * Cached reflection info for a class.
@@ -85,19 +124,100 @@ public class SafeCheckValidator
             this.traversableFields = traversableFields;
         }
 
-        /**
-         * Returns true if this class has no annotated fields and no traversable fields.
-         *
-         * @return true if scanning this class can be skipped
-         */
-        boolean isEmpty()
-        {
-            return safeCheckFields.isEmpty() && traversableFields.isEmpty();
-        }
     }
 
     /**
-     * Builds and caches reflection info for a class.
+     * Checks whether a class or any class reachable through its fields
+     * has @SafeCheck annotations. Results are cached per class so the
+     * reflection cost is paid only once. Classes with no @SafeCheck
+     * anywhere in their subtree are skipped entirely by validateAll().
+     *
+     * @param clazz
+     *        The class to check
+     * @return true if this class or any reachable class has @SafeCheck fields
+     */
+    private static boolean isRelevant(Class<?> clazz)
+    {
+        Boolean cached = RELEVANCE_CACHE.get(clazz);
+        if (cached != null) {
+            return cached;
+        }
+        return computeRelevance(clazz, new HashSet<>());
+    }
+
+    /**
+     * Recursive relevance check with cycle detection.
+     *
+     * @param clazz
+     *        The class to check
+     * @param visiting
+     *        Set of classes currently being checked to prevent infinite recursion
+     * @return true if @SafeCheck is found in this class or its subtree
+     */
+    private static boolean computeRelevance(Class<?> clazz, Set<Class<?>> visiting)
+    {
+        if (clazz == null || clazz.isPrimitive() || clazz.getName().startsWith(JAVA)) {
+            return false;
+        }
+        Boolean cached = RELEVANCE_CACHE.get(clazz);
+        if (cached != null) {
+            return cached;
+        }
+        if (!visiting.add(clazz)) {
+            return false;
+        }
+
+        boolean relevant = false;
+        for (Field field : getAllFields(clazz)) {
+            // Direct @SafeCheck field found
+            if (field.isAnnotationPresent(SafeCheck.class) && field.getType() == String.class) {
+                relevant = true;
+                break;
+            }
+
+            Class<?> fieldType = field.getType();
+            if (fieldType.isPrimitive()) {
+                continue;
+            }
+
+            // Check Collection/Map generic type arguments
+            if (Collection.class.isAssignableFrom(fieldType) || Map.class.isAssignableFrom(fieldType)) {
+                Type genericType = field.getGenericType();
+                if (genericType instanceof ParameterizedType) {
+                    for (Type typeArg : ((ParameterizedType) genericType).getActualTypeArguments()) {
+                        if (typeArg instanceof Class<?> && computeRelevance((Class<?>) typeArg, visiting)) {
+                            relevant = true;
+                            break;
+                        }
+                    }
+                }
+                if (relevant) {
+                    break;
+                }
+                continue;
+            }
+
+            // Check non-java custom types
+            if (!fieldType.getName().startsWith(JAVA) && computeRelevance(fieldType, visiting)) {
+                relevant = true;
+                break;
+            }
+        }
+
+        RELEVANCE_CACHE.put(clazz, relevant);
+        return relevant;
+    }
+
+    /**
+     * Builds and caches reflection metadata for a class. Partitions instance
+     * fields into two groups:
+     * <ul>
+     *   <li>safeCheckFields: String fields annotated with @SafeCheck (to sanitize)</li>
+     *   <li>traversableFields: non-primitive fields that may contain nested
+     *       @SafeCheck objects. Includes Collection/Map fields (which hold
+     *       settings objects) and non-java custom types. Excludes java.* types
+     *       like String, Integer, etc. that can never have @SafeCheck.</li>
+     * </ul>
      *
      * @param clazz
      *        The class to inspect
@@ -109,11 +229,14 @@ public class SafeCheckValidator
             List<Field> safeCheck = new ArrayList<>();
             List<Field> traversable = new ArrayList<>();
 
-            for (Field field : c.getDeclaredFields()) {
+            for (Field field : getAllFields(c)) {
                 if (field.isAnnotationPresent(SafeCheck.class) && field.getType() == String.class) {
                     field.setAccessible(true);
                     safeCheck.add(field);
-                } else if (!field.getType().isPrimitive() && !field.getType().getName().startsWith(JAVA)) {
+                } else if (!field.getType().isPrimitive()
+                           && (!field.getType().getName().startsWith(JAVA)
+                               || Collection.class.isAssignableFrom(field.getType())
+                               || Map.class.isAssignableFrom(field.getType()))) {
                     field.setAccessible(true);
                     traversable.add(field);
                 }
@@ -145,6 +268,7 @@ public class SafeCheckValidator
      * Scans the given object and all reachable nested objects for fields
      * annotated with @SafeCheck and sanitizes their String values.
      * Recurses into collections, maps, and object fields.
+     * Classes with no @SafeCheck in their subtree are skipped entirely.
      *
      * @param obj
      *        The object to sanitize
@@ -156,11 +280,19 @@ public class SafeCheckValidator
 
     /**
      * Recursive implementation that tracks visited objects to avoid cycles.
+     * Dispatches based on object type:
+     * <ul>
+     *   <li>Collection: iterates elements recursively</li>
+     *   <li>Map: iterates values recursively</li>
+     *   <li>java.* objects: skipped (no @SafeCheck possible)</li>
+     *   <li>Non-relevant classes: skipped via RELEVANCE_CACHE (subtree has no @SafeCheck)</li>
+     *   <li>Relevant classes: sanitizes @SafeCheck fields, then traverses into sub-objects</li>
+     * </ul>
      *
      * @param obj
      *        The object to sanitize
      * @param visited
-     *        Set of already visited objects to prevent infinite recursion
+     *        Set of already visited objects (identity-based) to prevent infinite recursion
      */
     private static void validateAll(Object obj, Set<Object> visited)
     {
@@ -186,10 +318,12 @@ public class SafeCheckValidator
             return;
         }
 
-        ClassInfo info = getClassInfo(obj.getClass());
-        if (info.isEmpty()) {
+        // Skip classes that have no @SafeCheck anywhere in their subtree
+        if (!isRelevant(obj.getClass())) {
             return;
         }
+
+        ClassInfo info = getClassInfo(obj.getClass());
 
         try {
             for (Field field : info.safeCheckFields) {

--- a/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
@@ -1,0 +1,207 @@
+/**
+ * $Id$
+ */
+
+package com.untangle.uvm.util;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+/**
+ * Sanitizes string values for shell-safety.
+ * Detects actual command injection patterns rather than blindly
+ * stripping individual characters. This preserves legitimate uses
+ * of special characters (e.g. "$" in passwords, "|" in descriptions)
+ * while catching injection constructs like `cmd`, $(cmd), ${var},
+ * command chaining (;, &&, ||), pipes, redirects, and newline injection.
+ */
+public class SafeCheckValidator
+{
+    /**
+     * Matches command injection constructs:
+     *
+     * Enclosed patterns (entire construct stripped):
+     *   `command`    backtick command substitution
+     *   $(command)   subshell command substitution
+     *   ${variable}  variable/command expansion
+     *
+     * Chaining operators (stripped when followed by command-like content):
+     *   &&           AND chaining
+     *   ||           OR chaining
+     *   ;            command separator
+     *   |            pipe to command
+     *
+     * Redirect operators (stripped when followed by path-like content):
+     *   > or >>      output redirect
+     *   <            input redirect / process substitution
+     *
+     * Always stripped:
+     *   \n \r        newline injection (acts as command separator)
+     */
+    private static final Pattern INJECTION_PATTERN = Pattern.compile(
+        String.join("|",
+            "`[^`]+`",                              // `command`  backtick substitution
+            "\\$\\([^)]*\\)",                        // $(command) subshell substitution
+            "\\$\\{[^}]*\\}",                        // ${var}     variable expansion
+            "&&(?=\\s*\\S)",                          // &&         AND chaining
+            "\\|\\|(?=\\s*\\S)",                      // ||         OR chaining
+            "[\\r\\n]",                               // \\n \\r    newline injection
+            ";(?=\\s*[a-zA-Z0-9_/\\\\.])",            // ;          command separator
+            "\\|(?=\\s*[a-zA-Z0-9_/\\\\.])",          // |          pipe to command
+            ">{1,2}(?=\\s*[a-zA-Z0-9_/\\\\.])",      // > >>       output redirect
+            "<(?=\\s*[a-zA-Z0-9_/(\\\\.])"            // <          input redirect / <()
+        )
+    );
+    private static final String JAVA = "java.";
+    private static final ConcurrentHashMap<Class<?>, ClassInfo> CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * Cached reflection info for a class.
+     */
+    private static class ClassInfo
+    {
+        final List<Field> safeCheckFields;
+        final List<Field> traversableFields;
+
+        /**
+         * Constructor for ClassInfo.
+         *
+         * @param safeCheckFields
+         *        List of fields annotated with SafeCheck
+         * @param traversableFields
+         *        List of non-primitive fields to recurse into
+         */
+        ClassInfo(List<Field> safeCheckFields, List<Field> traversableFields)
+        {
+            this.safeCheckFields = safeCheckFields;
+            this.traversableFields = traversableFields;
+        }
+
+        /**
+         * Returns true if this class has no annotated fields and no traversable fields.
+         *
+         * @return true if scanning this class can be skipped
+         */
+        boolean isEmpty()
+        {
+            return safeCheckFields.isEmpty() && traversableFields.isEmpty();
+        }
+    }
+
+    /**
+     * Builds and caches reflection info for a class.
+     *
+     * @param clazz
+     *        The class to inspect
+     * @return Cached ClassInfo with annotated and traversable fields
+     */
+    private static ClassInfo getClassInfo(Class<?> clazz)
+    {
+        return CACHE.computeIfAbsent(clazz, c -> {
+            List<Field> safeCheck = new ArrayList<>();
+            List<Field> traversable = new ArrayList<>();
+
+            for (Field field : c.getDeclaredFields()) {
+                if (field.isAnnotationPresent(SafeCheck.class) && field.getType() == String.class) {
+                    field.setAccessible(true);
+                    safeCheck.add(field);
+                } else if (!field.getType().isPrimitive() && !field.getType().getName().startsWith(JAVA)) {
+                    field.setAccessible(true);
+                    traversable.add(field);
+                }
+            }
+
+            return new ClassInfo(
+                safeCheck.isEmpty() ? Collections.emptyList() : safeCheck,
+                traversable.isEmpty() ? Collections.emptyList() : traversable
+            );
+        });
+    }
+
+    /**
+     * Strips shell metacharacters from the given value.
+     *
+     * @param value
+     *        The string value to sanitize
+     * @return The sanitized string with unsafe characters removed, or null if input is null
+     */
+    public static String sanitize(String value)
+    {
+        if (value == null) {
+            return null;
+        }
+        return INJECTION_PATTERN.matcher(value).replaceAll("");
+    }
+
+    /**
+     * Scans the given object and all reachable nested objects for fields
+     * annotated with @SafeCheck and sanitizes their String values.
+     * Recurses into collections, maps, and object fields.
+     *
+     * @param obj
+     *        The object to sanitize
+     */
+    public static void validateAll(Object obj)
+    {
+        validateAll(obj, new HashSet<>());
+    }
+
+    /**
+     * Recursive implementation that tracks visited objects to avoid cycles.
+     *
+     * @param obj
+     *        The object to sanitize
+     * @param visited
+     *        Set of already visited objects to prevent infinite recursion
+     */
+    private static void validateAll(Object obj, Set<Object> visited)
+    {
+        if (obj == null) {
+            return;
+        }
+        if (!visited.add(obj)) {
+            return;
+        }
+        if (obj instanceof Collection) {
+            for (Object item : (Collection<?>) obj) {
+                validateAll(item, visited);
+            }
+            return;
+        }
+        if (obj instanceof Map) {
+            for (Object val : ((Map<?, ?>) obj).values()) {
+                validateAll(val, visited);
+            }
+            return;
+        }
+        if (obj.getClass().getName().startsWith(JAVA)) {
+            return;
+        }
+
+        ClassInfo info = getClassInfo(obj.getClass());
+        if (info.isEmpty()) {
+            return;
+        }
+
+        try {
+            for (Field field : info.safeCheckFields) {
+                String value = (String) field.get(obj);
+                field.set(obj, sanitize(value));
+            }
+            for (Field field : info.traversableFields) {
+                Object child = field.get(obj);
+                validateAll(child, visited);
+            }
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Failed to sanitize object of type: " + obj.getClass().getName(), e);
+        }
+    }
+}

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
@@ -460,4 +460,35 @@ class AdministrationTests(NGFWTestCase):
         #  certificates list should be unchanged after test execution
         assert(len(initial_certificates_list['list']) == len(final_certificates_list['list']))
 
+    def test_030_skin_upload_deprecated(self):
+        """Verify skin upload to /admin/upload is rejected (handleFile deprecated)"""
+        import zipfile
+        import io
+        import urllib.request
+
+        # Build a minimal zip to act as a skin upload
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr("test-skin/skinInfo.json", '{"name":"test"}')
+        skin_bytes = buf.getvalue()
+
+        opener = global_functions.build_admin_http_opener()
+        boundary, body = global_functions.build_upload_multipart_body(
+            "skin", "test-skin", skin_bytes, filename="test-skin.zip"
+        )
+
+        req = urllib.request.Request(
+            "http://localhost/admin/upload",
+            data=body,
+            headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        )
+        try:
+            resp = opener.open(req)
+            resp_body = resp.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as e:
+            resp_body = e.read().decode("utf-8", errors="replace")
+
+        assert "deprecated" in resp_body.lower() or "NoSuchMethodException" in resp_body, \
+            "Skin upload should be rejected as deprecated, got: " + resp_body
+
 test_registry.register_module("administration-tests", AdministrationTests)

--- a/uvm/impl/com/untangle/uvm/SkinManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SkinManagerImpl.java
@@ -28,7 +28,7 @@ import com.untangle.uvm.servlet.UploadHandler;
  */
 public class SkinManagerImpl implements SkinManager
 {
-    private static final String SKINS_DIR = System.getProperty("uvm.skins.dir");;
+    private static final String SKINS_DIR = System.getProperty("uvm.skins.dir");
     private static final String DEFAULT_ADMIN_SKIN = "simple-gray";
 
     private final Logger logger = LogManager.getLogger(getClass());
@@ -70,15 +70,15 @@ public class SkinManagerImpl implements SkinManager
              */
             String skinName = this.settings.getSkinName();
             if (skinName == null) {
-                this.settings.setSkinName("simple-gray");
-                skinName = "simple-gray";
+                this.settings.setSkinName(DEFAULT_ADMIN_SKIN);
+                skinName = DEFAULT_ADMIN_SKIN;
                 this.setSettings(this.settings);
-            } else if (!skinName.equals("simple-gray") && !skinName.equals("modern-rack")) {
-                this.settings.setSkinName("simple-gray");
+            } else if (!skinName.equals(DEFAULT_ADMIN_SKIN) && !skinName.equals("modern-rack")) {
+                this.settings.setSkinName(DEFAULT_ADMIN_SKIN);
                 this.setSettings(this.settings);
             }
-
-            logger.debug("Loading Settings: " + this.settings.toJSONString());
+            if (logger.isDebugEnabled())
+                logger.debug("Loading Settings: {}", this.settings.toJSONString());
         }
 
         /**
@@ -86,7 +86,7 @@ public class SkinManagerImpl implements SkinManager
          */
         this.skinInfo = getSkinInfo(SKINS_DIR + File.separator + this.settings.getSkinName() + File.separator + "skinInfo.json");
         if (this.skinInfo == null || this.skinInfo.isAdminSkinOutOfDate()) {
-            logger.warn("Unable to find skin \"" + this.settings.getSkinName() + "\" - reverting to default skin: " + DEFAULT_ADMIN_SKIN);
+            logger.warn("Unable to find skin  + this.settings.getSkinName() + {}{}", " - reverting to default skin: " , DEFAULT_ADMIN_SKIN);
             this.settings.setSkinName(DEFAULT_ADMIN_SKIN);
             this.setSettings(this.settings);
             this.skinInfo = getSkinInfo(SKINS_DIR + File.separator + this.settings.getSkinName() + File.separator + "skinInfo.json");
@@ -242,7 +242,7 @@ public class SkinManagerImpl implements SkinManager
 
         File[] children = dir.listFiles();
         if (children == null) {
-            logger.warn("Skin dir \"" + SKINS_DIR + "\" does not exist");
+            logger.warn("Skin dir \"{}\" does not exist", SKINS_DIR);
         } else {
             for (int i = 0; i < children.length; i++) {
                 File file = children[i];
@@ -264,7 +264,7 @@ public class SkinManagerImpl implements SkinManager
                         }
                     });
                     if (skinFiles.length < 1) {
-                        logger.warn("Skin folder \"" + file.getName() + "\" does not have skin info file - skinInfo.json");
+                        logger.warn("Skin folder \"{}\" does not have skin info file - skinInfo.json", file.getName());
                     } else {
                         SkinInfo skinInfoTmp;
                         skinInfoTmp = getSkinInfo(skinFiles[0].getPath());
@@ -275,20 +275,17 @@ public class SkinManagerImpl implements SkinManager
                 }
             }
         }
-        Collections.sort(skins, new Comparator<SkinInfo>()
-        {
+        Collections.sort(skins, new Comparator<>() {
             /**
              * Compare for skink sorting
-             * 
-             * @param o1
-             *        Object one
-             * @param o2
-             *        Object two
+             *
+             * @param o1 Object one
+             * @param o2 Object two
              * @return Comparison result
              */
-            public int compare(SkinInfo o1, SkinInfo o2)
-            {
-                if (o1 != null && o2 != null && o1.getDisplayName() != null && o2.getDisplayName() != null) return o1.getDisplayName().compareTo(o2.getDisplayName());
+            public int compare(SkinInfo o1, SkinInfo o2) {
+                if (o1 != null && o2 != null && o1.getDisplayName() != null && o2.getDisplayName() != null)
+                    return o1.getDisplayName().compareTo(o2.getDisplayName());
                 return 0;
             }
         });
@@ -339,7 +336,8 @@ public class SkinManagerImpl implements SkinManager
          */
         this.settings = newSettings;
         try {
-            logger.debug("New Settings: \n" + new org.json.JSONObject(this.settings).toString(2));
+            if (logger.isDebugEnabled())
+                logger.debug("New Settings: \n{}", new org.json.JSONObject(this.settings).toString(2));
         } catch (Exception e) {
         }
 
@@ -377,7 +375,7 @@ public class SkinManagerImpl implements SkinManager
             if (dir.getAbsolutePath().length() > 3) UvmContextFactory.context().execManager().exec("rm -rf " + dir.getAbsolutePath() + "/*");
         } else {
             if (!dir.mkdirs()) {
-                logger.error("Error creating skin folder: " + dir);
+                logger.error("Error creating skin folder: {}", dir);
                 throw new UvmException("Error creating skin folder");
             }
         }
@@ -409,12 +407,13 @@ public class SkinManagerImpl implements SkinManager
          *        The uploaded argument
          * @return Upload result
          * @throws Exception
+         * @deprecated since 17.2 NGFW-13511, scheduled for removal.
          */
+        @Deprecated(forRemoval = true, since = "17.2")
         @Override
         public String handleFile(FileItem fileItem, String argument) throws Exception
         {
-            uploadSkin(fileItem);
-            return "Successfully updated a skin";
+            throw new NoSuchMethodException("Custom skin upload is no longer available");
         }
     }
 }

--- a/uvm/impl/com/untangle/uvm/SkinManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SkinManagerImpl.java
@@ -86,7 +86,7 @@ public class SkinManagerImpl implements SkinManager
          */
         this.skinInfo = getSkinInfo(SKINS_DIR + File.separator + this.settings.getSkinName() + File.separator + "skinInfo.json");
         if (this.skinInfo == null || this.skinInfo.isAdminSkinOutOfDate()) {
-            logger.warn("Unable to find skin  + this.settings.getSkinName() + {}{}", " - reverting to default skin: " , DEFAULT_ADMIN_SKIN);
+            logger.warn("Unable to find skin  \"{}\" - reverting to default skin: {}" , this.getSettings().getSkinName(), DEFAULT_ADMIN_SKIN);
             this.settings.setSkinName(DEFAULT_ADMIN_SKIN);
             this.setSettings(this.settings);
             this.skinInfo = getSkinInfo(SKINS_DIR + File.separator + this.settings.getSkinName() + File.separator + "skinInfo.json");

--- a/uvm/servlets/admin/src/com/untangle/uvm/admin/jabsorb/UtCallbackController.java
+++ b/uvm/servlets/admin/src/com/untangle/uvm/admin/jabsorb/UtCallbackController.java
@@ -9,6 +9,8 @@ import java.lang.reflect.Method;
 import org.jabsorb.JSONRPCBridge;
 import org.jabsorb.callback.CallbackController;
 
+import com.untangle.uvm.util.SafeCheckValidator;
+
 /**
  * UtCallbackController
  */
@@ -34,7 +36,14 @@ public class UtCallbackController extends CallbackController
      * @param arguments
      */
     @Override
-    public void preInvokeCallback(Object context, Object instance, Method method, Object[] arguments) { }
+    public void preInvokeCallback(Object context, Object instance, Method method, Object[] arguments)
+    {
+        if (arguments != null) {
+            for (Object arg : arguments) {
+                SafeCheckValidator.validateAll(arg);
+            }
+        }
+    }
 
     /**
      * postInvokeCallback


### PR DESCRIPTION
- @SafeCheck annotation (uvm/api/.../util/SafeCheck.java) — A runtime-retained field-level annotation that marks String fields requiring sanitization.

- SafeCheckValidator (uvm/api/.../util/SafeCheckValidator.java) — A recursive validator that:

    Scans an object graph (including nested objects, collections, and maps) for @SafeCheck-annotated String fields
    Detects actual command injection patterns (not individual characters) and strips them
    Caches reflection metadata per class for performance
    Handles cycles via visited-object tracking

- UtCallbackController.preInvokeCallback() — The JSON-RPC callback controller that automatically invokes SafeCheckValidator.validateAll() on every API argument before any setSettings() (or other method) executes. This ensures sanitization happens at the API boundary with zero changes needed in individual app setSettings() methods.
- Added @SafeCheck over vulnerable IPSec attributes.
- Deprecated SkinManager upload API, added ATS test case.