### PR TITLE
ngfw-15674: Fix command injection in DBL, HostsFileManager and ConnectivityTester

### DIFF
--- a/dynamic-blocklists/hier/usr/lib/python3/dist-packages/tests/test_dynamic_blocklists.py
+++ b/dynamic-blocklists/hier/usr/lib/python3/dist-packages/tests/test_dynamic_blocklists.py
@@ -1,3 +1,5 @@
+import os
+import shlex
 import subprocess
 import copy
 import re
@@ -236,6 +238,128 @@ class DynamicBlocklistsTests(NGFWTestCase):
         # If ping succeeds, fail — means not blocked
         assert pingResult != 0, f"DBL did not block IP {pingable_ip}"
         app.setSettingsV2(orig_dbl_settings)
+
+    def _get_result_type(self, result):
+        """
+        Extract the 'type' field from a runJobsByConfigIdsV2 result.
+        Handles jabsorb JABSORB-mode Map serialization which wraps the map under
+        a 'map' key (e.g. {"javaClass": "...", "map": {"type": "Error", ...}}).
+        """
+        if result is None:
+            return None
+        result_data = result.get("map", result)
+        return result_data.get("type")
+
+    def test_017_run_jobs_invalid_uuid_format_rejected(self):
+        """
+        Verify that runJobsByConfigIdsV2 rejects configIds that are not valid UUIDs.
+        A non-UUID string must never be used to look up or execute a cron command.
+        """
+        result = app.runJobsByConfigIdsV2(["not-a-valid-uuid"])
+        assert self._get_result_type(result) == "Error", \
+            f"Expected Error response for non-UUID configId, got: {result}"
+
+    def test_018_run_jobs_injection_chars_in_id_rejected(self):
+        """
+        Verify that configIds containing shell injection characters are rejected by
+        UUID format validation before any cron lookup or command execution occurs.
+        A sentinel file must not be created by the injected payload.
+        """
+        poc_file = "/tmp/dbl_injection_test.txt"
+        subprocess.call(f"rm -f {poc_file}", shell=True)
+
+        # Looks UUID-ish but contains injection payload after a semicolon
+        malicious_id = "12345678-1234-1234-1234-123456789012; touch " + poc_file
+
+        result = app.runJobsByConfigIdsV2([malicious_id])
+        assert self._get_result_type(result) == "Error", \
+            f"Expected Error response for injection configId, got: {result}"
+
+        time.sleep(1)
+        assert not os.path.exists(poc_file), \
+            "Command injection succeeded via runJobsByConfigIdsV2 (sentinel file was created)"
+
+    def test_019_run_jobs_unknown_uuid_returns_error(self):
+        """
+        Verify that a well-formed UUID that has no matching cron job entry
+        returns an Error response without executing any command.
+        """
+        # This UUID is valid but will not match any entry in the dbl-crons file
+        unknown_uuid = "00000000-0000-0000-0000-000000000000"
+        result = app.runJobsByConfigIdsV2([unknown_uuid])
+        assert self._get_result_type(result) == "Error", \
+            f"Expected Error for unknown UUID, got: {result}"
+
+    def test_020_run_jobs_mixed_valid_invalid_ids(self):
+        """
+        Verify that when a list contains both invalid and valid UUIDs,
+        only the invalid ones are skipped and the overall response reflects
+        whether any valid UUID succeeded.
+        """
+        # Mix: one known-bad format, one unknown-but-valid UUID
+        result = app.runJobsByConfigIdsV2(["bad-id", "00000000-0000-0000-0000-000000000000"])
+        # Both should fail (bad format + not in cron), so the response must be Error
+        assert self._get_result_type(result) == "Error", \
+            f"Expected Error when all configIds fail, got: {result}"
+
+
+    def test_021_cron_job_source_url_is_shell_quoted(self):
+        """
+        Verify that when sync-settings writes /etc/cron.d/dbl-crons, user-supplied
+        fields containing shell metacharacters (source URL, parsingMethod) are
+        shell-quoted via shlex.quote() so they cannot break out and execute arbitrary
+        commands through the generated cron job.
+        """
+        global app, orig_dbl_settings
+
+        cron_file = "/etc/cron.d/dbl-crons"
+        sentinel_file = "/tmp/dbl_cron_write_injection_test.txt"
+        subprocess.call(["rm", "-f", sentinel_file])
+
+        # Craft a source URL with a shell injection payload embedded after a semicolon.
+        # Without proper quoting in the cron file, cron would execute:
+        #   /usr/share/untangle/bin/fetch_ip_list.py ... http://example.com/list.txt
+        #   ; touch /tmp/dbl_cron_write_injection_test.txt ...
+        malicious_url = "http://example.com/list.txt; touch " + sentinel_file
+
+        dblSettings = copy.deepcopy(orig_dbl_settings)
+        dblSettings['enabled'] = True
+        dblSettings['configurations'][0]['enabled'] = True
+        dblSettings['configurations'][0]['source'] = malicious_url
+
+        # setSettingsV2 triggers sync-settings, which calls write_cron_file()
+        app.setSettingsV2(dblSettings)
+        time.sleep(3)  # Allow sync-settings to finish writing the cron file
+
+        assert os.path.exists(cron_file), f"Cron file was not created at {cron_file}"
+
+        with open(cron_file) as f:
+            cron_content = f.read()
+
+        # The raw unquoted URL must NOT appear bare in the cron file.
+        # Note: the URL text also appears inside the single-quoted form produced by
+        # shlex.quote(), so we strip that quoted form out first and then check that
+        # no bare copy of the URL remains.
+        cron_without_quoted_url = cron_content.replace(shlex.quote(malicious_url), "QUOTED_URL")
+        assert malicious_url not in cron_without_quoted_url, (
+            "Shell injection payload found unquoted in cron file — "
+            "source URL is not being properly shell-escaped."
+        )
+
+        # shlex.quote() wraps the URL in single quotes so the semicolon is inert.
+        # Confirm the properly-quoted form IS present in the cron file.
+        assert shlex.quote(malicious_url) in cron_content, (
+            f"Expected shell-quoted URL '{shlex.quote(malicious_url)}' not found in cron file.\n"
+            f"Cron content:\n{cron_content}"
+        )
+
+        # Writing the cron file must never execute the injected payload.
+        assert not os.path.exists(sentinel_file), (
+            "Sentinel file was created — shell injection occurred during cron file write."
+        )
+
+        app.setSettingsV2(orig_dbl_settings)
+
 
 test_registry.register_module("dynamic-blocklists", DynamicBlocklistsTests)
 

--- a/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsApp.java
+++ b/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsApp.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import com.untangle.uvm.ExecManagerResult;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -216,8 +217,39 @@ public class DynamicBlockListsApp extends AppBase
      * @throws Exception if the job execution is interrupted.
      */
     public Object runJobsByConfigIdsV2(LinkedList<String> configIds) throws Exception {
-        List<String> cronLines = Files.readAllLines(Paths.get(CRON_FILE));
         List<String> successfulIds = new ArrayList<>();
+
+        // Validate all configIds as UUIDs before doing any file I/O
+        for (String configId : configIds) {
+            try {
+                UUID.fromString(configId);
+            } catch (IllegalArgumentException e) {
+                logger.error("Invalid configId format (must be UUID): {}", configId);
+                Map<String, Object> messageMap = new HashMap<>();
+                messageMap.put("message", "invalid_config_id_format");
+                messageMap.put("vars", null);
+                return Map.of(
+                    "type", "Error",
+                    "success", false,
+                    "messages", List.of(messageMap)
+                );
+            }
+        }
+
+        List<String> cronLines;
+        try {
+            cronLines = Files.readAllLines(Paths.get(CRON_FILE));
+        } catch (java.nio.file.NoSuchFileException e) {
+            logger.warn("Cron file not found: {}", CRON_FILE);
+            Map<String, Object> messageMap = new HashMap<>();
+            messageMap.put("message", "download_blocklist_to_appliance_failure");
+            messageMap.put("vars", null);
+            return Map.of(
+                "type", "Error",
+                "success", false,
+                "messages", List.of(messageMap)
+            );
+        }
 
         for (String configId : configIds) {
             boolean found = false;
@@ -241,7 +273,10 @@ public class DynamicBlockListsApp extends AppBase
                         command = command.replace("2>&1 | logger -t dynamic_list_manager", "").trim();
                     }
                     try {
-                        ExecManagerResult result = UvmContextFactory.context().execManager().exec(command);
+                        String[] cmdParts = command.split("\\s+");
+                        String script = cmdParts[0];
+                        List<String> args = Arrays.asList(Arrays.copyOfRange(cmdParts, 1, cmdParts.length));
+                        ExecManagerResult result = UvmContextFactory.context().execManager().execCommand(script, args);
                         String resultOutput = result.getOutput();
                         // Mark as failed if output contains [ERROR]/[WARNING]
                         if ( (resultOutput != null && (resultOutput.contains("[ERROR]") || resultOutput.contains("[WARNING]")))) {

--- a/uvm/api/com/untangle/uvm/UriManagerSettings.java
+++ b/uvm/api/com/untangle/uvm/UriManagerSettings.java
@@ -8,6 +8,9 @@ import java.util.List;
 import java.util.LinkedList;
 
 import org.json.JSONString;
+
+import com.untangle.uvm.util.SafeCheck;
+
 import org.json.JSONObject;
 
 /**
@@ -19,6 +22,7 @@ public class UriManagerSettings implements Serializable, JSONString
     private Integer version = 6;
     private List<UriTranslation> uriTranslations = new LinkedList<>();
 
+    @SafeCheck
     private String dnsTestHost = "updates.edge.arista.com";
     private String tcpTestHost = "updates.edge.arista.com";
 

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -5,6 +5,8 @@ package com.untangle.uvm.network;
 
 import com.untangle.uvm.network.generic.InterfaceSettingsGeneric;
 import com.untangle.uvm.network.generic.NetworkSettingsGeneric;
+import com.untangle.uvm.util.SafeCheck;
+
 import org.json.JSONObject;
 import org.json.JSONString;
 
@@ -36,7 +38,9 @@ public class NetworkSettings implements Serializable, JSONString
     private List<FilterRule> accessRules = null;
     private List<FilterRule> filterRules = null;
     
+    @SafeCheck
     private String hostName;
+    @SafeCheck
     private String domainName;
 
     private boolean dynamicDnsServiceEnabled = false;

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -20,6 +20,7 @@ import fnmatch
 import base64
 
 from urllib.parse import urlparse, parse_qs
+from jsonrpc import JSONRPCException
 from tests.common import NGFWTestCase
 import tests.global_functions as global_functions
 import runtests.test_registry as test_registry
@@ -982,6 +983,44 @@ class UvmTests(NGFWTestCase):
                                                'login', 'admin' )
         assert( found )
 
+    def test_111_hosts_file_manager_injection_blocked(self):
+        """
+        Verify that HostsFileManagerImpl.refreshHostsFile() passes the fully-qualified
+        hostname as a safe argument (via execCommand) so that shell metacharacters in
+        the hostname do not execute arbitrary commands.
+
+        The test:
+        1. Touches an interface-status file so refreshHostsFile() will detect a change.
+        2. Sets a network hostname that embeds a shell injection payload, which triggers
+           the network-settings change hook that calls refreshHostsFile() synchronously.
+        3. Confirms the injected command was never executed (sentinel file not created).
+        """
+        # No dots in the path: sanitizeNetworkSettings strips everything after the
+        # first dot in the hostname, so a path like "/tmp/poc.txt" would become
+        # "/tmp/poc" and the wrong file would be checked (false negative).
+        poc_file = "/tmp/hosts_injection_poc"
+        status_file = "/var/lib/interface-status/test_injection_trigger"
+        subprocess.call(f"rm -f {poc_file} {status_file}", shell=True)
+
+        orig_netsettings = global_functions.uvmContext.networkManager().getNetworkSettings()
+        try:
+            malicious_settings = copy.deepcopy(orig_netsettings)
+            malicious_settings['hostName'] = "ngfw; touch " + poc_file + "; echo"
+
+            # Touch an interface-status file BEFORE setNetworkSettings so that when
+            # the hook fires and calls refreshHostsFile(), it detects the new file
+            # and executes the update script with the (malicious) hostname.
+            subprocess.call(f"mkdir -p /var/lib/interface-status && touch {status_file}", shell=True)
+
+            global_functions.uvmContext.networkManager().setNetworkSettings(malicious_settings)
+        finally:
+            subprocess.call(f"rm -f {status_file}", shell=True)
+            global_functions.uvmContext.networkManager().setNetworkSettings(orig_netsettings)
+
+        time.sleep(1)
+        assert not os.path.exists(poc_file), \
+            "Command injection succeeded via HostsFileManagerImpl.refreshHostsFile() (sentinel file was created)"
+
     # Make sure the HostsFileManager is working as expected
     def test_110_hosts_file_manager(self):
         # get the hostname and settings from the network manager
@@ -1120,6 +1159,67 @@ class UvmTests(NGFWTestCase):
         assert not os.path.exists(poc_file), \
             "Command injection succeeded via /admin/v2/upload argument field (poc file was created)"
 
+    def test_123_connectivity_tester_dns_injection_blocked(self):
+        """
+        Verify that ConnectivityTesterImpl passes dnsTestHost as a safe argument
+        (via execCommand) so that shell metacharacters in dnsTestHost do not
+        execute arbitrary commands.
+
+        The test temporarily sets dnsTestHost to a value containing a shell
+        injection payload, triggers a connectivity check, and confirms the
+        injected command was never executed (sentinel file not created).
+        """
+        poc_file = "/tmp/conn_dns_injection_test.txt"
+        subprocess.call(f"rm -f {poc_file}", shell=True)
+
+        orig_uri_settings = global_functions.uvmContext.uriManager().getSettings()
+        try:
+            malicious_uri_settings = copy.deepcopy(orig_uri_settings)
+            malicious_uri_settings['dnsTestHost'] = "updates.edge.arista.com; touch " + poc_file
+            global_functions.uvmContext.uriManager().setSettings(malicious_uri_settings)
+            # Trigger connectivity test — this calls isDnsWorking() with the malicious dnsTestHost
+            global_functions.uvmContext.getConnectivityTester().getStatus()
+        finally:
+            global_functions.uvmContext.uriManager().setSettings(orig_uri_settings)
+
+        time.sleep(1)
+        assert not os.path.exists(poc_file), \
+            "Command injection succeeded via ConnectivityTesterImpl dnsTestHost (sentinel file was created)"
+
+    def test_124_connectivity_tester_dns_server_injection_blocked(self):
+        """
+        Verify that the DNS server address field (v4StaticDns1) is validated as an
+        InetAddress, preventing shell injection strings from being stored or executed
+        by ConnectivityTesterImpl.
+
+        The v4StaticDns1 field is typed as InetAddress on the server side, so the
+        JSON-RPC layer will reject any value that is not a valid IP address.  The
+        test confirms that attempting to store a malicious DNS value raises a
+        JSONRPCException (the expected API-level rejection) and that the injected
+        command is never executed.
+        """
+        poc_file = "/tmp/conn_server_injection_test.txt"
+        subprocess.call(f"rm -f {poc_file}", shell=True)
+
+        orig_netsettings = global_functions.uvmContext.networkManager().getNetworkSettings()
+        try:
+            malicious_settings = copy.deepcopy(orig_netsettings)
+            for iface in malicious_settings.get('interfaces', {}).get('list', []):
+                if iface.get('isWan'):
+                    iface['v4StaticDns1'] = "8.8.8.8; touch " + poc_file
+                    break
+            try:
+                global_functions.uvmContext.networkManager().setNetworkSettings(malicious_settings)
+            except JSONRPCException:
+                # Expected: the server rejects the malicious value because v4StaticDns1
+                # is unmarshalled as InetAddress, which only accepts valid IP addresses.
+                pass
+        finally:
+            global_functions.uvmContext.networkManager().setNetworkSettings(orig_netsettings)
+
+        time.sleep(1)
+        assert not os.path.exists(poc_file), \
+            "Command injection succeeded via network settings DNS field (sentinel file was created)"
 
     def test_130_check_cmd_connected(self):
         """Check if cmd is connected using alert rule"""

--- a/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
+++ b/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
@@ -24,7 +24,10 @@ ALLOWED_EXECUTABLES = {
     "/usr/share/untangle/bin/openvpn-generate-client-exec",
     "/usr/share/untangle/bin/openvpn-generate-client-ovpn",
     "/usr/share/untangle/bin/openvpn-generate-client-onc",
-    "/usr/bin/systemctl"
+    "/usr/bin/systemctl",
+    "/usr/share/untangle/bin/ut-update-hosts-file",
+    "/usr/share/untangle/bin/ut-dns-test"
+
 }
 
 while True:

--- a/uvm/impl/com/untangle/uvm/ConnectivityTesterImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConnectivityTesterImpl.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.util.List;
 
 import org.json.JSONObject;
 import org.apache.logging.log4j.Logger;
@@ -85,8 +86,8 @@ public class ConnectivityTesterImpl implements ConnectivityTester
 
         domainName = UvmContextFactory.context().uriManager().getSettings().getDnsTestHost();
 
-        if (primaryServer != null && UvmContextFactory.context().execManager().execResult(DNS_TEST_SCRIPT + " " + primaryServer + " " + domainName) != 0) isWorking = false;
-        if (secondaryServer != null && UvmContextFactory.context().execManager().execResult(DNS_TEST_SCRIPT + " " + secondaryServer + " " + domainName) != 0) isWorking = false;
+        if (primaryServer != null && UvmContextFactory.context().execManager().execCommand(DNS_TEST_SCRIPT, List.of(primaryServer, domainName)).getResult() != 0) isWorking = false;
+        if (secondaryServer != null && UvmContextFactory.context().execManager().execCommand(DNS_TEST_SCRIPT, List.of(secondaryServer, domainName)).getResult() != 0) isWorking = false;
 
         return isWorking;
     }

--- a/uvm/impl/com/untangle/uvm/HostsFileManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/HostsFileManagerImpl.java
@@ -6,6 +6,7 @@ package com.untangle.uvm;
 
 import java.util.TimerTask;
 import java.util.Timer;
+import java.util.List;
 import java.io.File;
 
 import org.apache.logging.log4j.Logger;
@@ -166,7 +167,7 @@ public class HostsFileManagerImpl extends TimerTask implements HostsFileManager
         String fullName = UvmContextFactory.context().networkManager().getFullyQualifiedHostname();
 
         // call the script to update the hosts file
-        UvmContextFactory.context().execManager().exec(HOSTS_FILE_UPDATE_SCRIPT + " " + fullName);
+        UvmContextFactory.context().execManager().execCommand(HOSTS_FILE_UPDATE_SCRIPT, List.of(fullName));
 
         // execute the command to activate the updated hosts file
         UvmContextFactory.context().execManager().exec(HOSTS_FILE_RELOAD_COMMAND);


### PR DESCRIPTION

Replace shell-interpolated exec() calls with structured execCommand() (argument
list) calls in three components to eliminate shell injection vectors:

- DynamicBlockListsApp: validate configIds as UUIDs before any file I/O; use
  execCommand(script, args) instead of exec(command-string) when running cron jobs;
  add graceful handling when the cron file is missing.
- HostsFileManagerImpl: pass the fully-qualified hostname as a safe argument via
  execCommand() instead of string-interpolating it into a shell command.
- ConnectivityTesterImpl: pass DNS server and domain name as separate args via
  execCommand() instead of concatenating them into an exec string.
- ut-exec-safe-launcher: add ut-update-hosts-file and ut-dns-test to the
  allowlist so they can be invoked through the safe launcher.

Tests added for all three components verifying that shell metacharacters in
user-controlled inputs are rejected or safely passed as arguments without
executing injected commands.

**BEFORE :**

<img width="993" height="589" alt="dbl-before-fix" src="https://github.com/user-attachments/assets/4816f370-4898-49eb-b016-629c7081ebb6" />
<img width="993" height="589" alt="before-fix-uvm-host" src="https://github.com/user-attachments/assets/5cbe6d42-2ded-43af-9564-2dbb0f4004fd" />


**AFTER:**

<img width="1475" height="589" alt="dbl-after-fix" src="https://github.com/user-attachments/assets/31e84013-cbcc-4e11-84a5-d9d7a5f85954" />
<img width="1475" height="589" alt="after-fix-uvm-host png" src="https://github.com/user-attachments/assets/915462bb-36cf-407e-8212-65a496864b12" />


