### PR TITLE
Ngfw-15708 Reports app iframe changes

### DIFF
--- a/reports/js/Main.js
+++ b/reports/js/Main.js
@@ -6,39 +6,26 @@ Ext.define('Ung.apps.reports.Main', {
 
     viewModel: {
         data: {
-            googleDriveConfigured: false,
-            reportQueueSize: 0
+            vueMigrated: true
+        }
+    },
+
+    listeners: {
+        activate: function (panel) {
+            var target = panel.down('#iframeHolder');
+            Util.attachIframeToTarget(target, '/console/settings/services/reports', false);
+            Util.setupVueMessageHandlers(panel, {
+                appName: 'reports',
+                enableRemoveHandler: true
+            });
         },
-        formulas: {
-            driveConfiguredText: function (get) {
-                return get('googleDriveConfigured') ? 'The Google Connector is configured'.t() : 'The Google Connector is unconfigured.'.t();
-            },
-            emailIntervals: function( get ){
-                var availableIntervals = [];
-                var dbRetentionTime = get('settings').dbRetention * 86400;
-                for(var interval in Renderer.timeIntervalMap ){
-                    if( interval <= dbRetentionTime ){
-                        availableIntervals.push( [ Number(interval), Renderer.timeIntervalMap[interval] ] );
-                    }
-                }
-                return availableIntervals;
-            }
-        },
-        stores: {
-            users: { data: '{settings.reportsUsers.list}' },
-            hostnames: { data: '{settings.hostnameMap.list}' },
-            emailTemplates: { data: '{settings.emailTemplates.list}' },
-            reportEntries: { data: '{settings.reportEntries.list}' }
+        destroy: function (panel) {
+            Util.cleanupVueMessageHandlers(panel);
         }
     },
 
     items: [
-        { xtype: 'app-reports-status' },
-        { xtype: 'app-reports-allreports' },
-        { xtype: 'app-reports-data' },
-        { xtype: 'app-reports-emailtemplates' },
-        { xtype: 'app-reports-users' },
-        { xtype: 'app-reports-namemap' }
+        Field.iframeHolder
     ]
 
 });

--- a/reports/js/Main.js
+++ b/reports/js/Main.js
@@ -6,6 +6,8 @@ Ext.define('Ung.apps.reports.Main', {
 
     viewModel: {
         data: {
+            title: 'Reports'.t(),
+            iconName: 'reports',
             vueMigrated: true
         }
     },

--- a/reports/js/MainController.js
+++ b/reports/js/MainController.js
@@ -2,15 +2,6 @@ Ext.define('Ung.apps.reports.MainController', {
     extend: 'Ext.app.ViewController',
     alias: 'controller.app-reports',
 
-    control: {
-        '#': {
-            afterrender: 'getSettings',
-            activate: 'checkGoogleDrive'
-        },
-        '#email-templates': {
-            afterrender: 'emailTemplatesAfterRender'
-        }
-    },
 
     getSettings: function () {
         var me = this, v = me.getView(), vm = me.getViewModel();


### PR DESCRIPTION
Description:
 Replace the static ExtJS tab components (status, all reports, data, email templates, users, name map) with a single iframe holder that loads /console/settings/services/reports.

<img width="1898" height="1027" alt="image" src="https://github.com/user-attachments/assets/6c87b82c-b5b0-40e3-aa4a-7a9ee9272dfc" />
