### PR TITLE
NGFW-15702 Sanitized Network attributes (physicalDev, symbolicDev, deviceName)

### DIFF
--- a/.arista/secret_allowlist.yaml
+++ b/.arista/secret_allowlist.yaml
@@ -1,0 +1,7 @@
+version: v1.0
+allowed_secrets:
+- filepath_literal: "uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py"
+  category: FALSE_POSITIVE
+  reason: >-
+    Test-only RSA private key used as a fixture for certificate upload
+    validation tests (test_021-test_025). Not used in any production code.

--- a/uvm/api/com/untangle/uvm/network/DeviceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/DeviceSettings.java
@@ -8,12 +8,15 @@ import java.io.Serializable;
 import org.json.JSONObject;
 import org.json.JSONString;
 
+import com.untangle.uvm.util.SafeCheck;
+
 /**
  * Device settings.
  */
 @SuppressWarnings("serial")
 public class DeviceSettings implements Serializable, JSONString
 {
+    @SafeCheck
     private String deviceName;
 
     public static enum Duplex { AUTO,

--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -3,6 +3,7 @@
  */
 package com.untangle.uvm.network;
 
+import com.untangle.uvm.util.SafeCheck;
 import com.untangle.uvm.network.generic.InterfaceSettingsGeneric;
 import com.untangle.uvm.network.generic.InterfaceSettingsGeneric.Type;
 import com.untangle.uvm.network.generic.InterfaceSettingsGeneric.V4Alias;
@@ -39,9 +40,13 @@ public class InterfaceSettings implements Serializable, JSONString
     private int     interfaceId; /* the ID of the physical interface (1-254) */
     private String  name; /* human name: ie External, Internal, Wireless */
 
+    @SafeCheck
     private String  physicalDev; /* physical interface name: eth0, etc */
+    @SafeCheck
     private String  systemDev; /* iptables interface name: eth0, eth0:0, eth0.1, etc */
+    @SafeCheck
     private String  symbolicDev; /* symbolic interface name: eth0, eth0:0, eth0.1, br.eth0 etc */
+    @SafeCheck
     private String  imqDev; /* IMQ device name: imq0, imq1, etc (only applies to WANs) */
 
     private Boolean hidden = null; /* Is this interface hidden? null means false */

--- a/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
+++ b/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
@@ -26,7 +26,11 @@ ALLOWED_EXECUTABLES = {
     "/usr/share/untangle/bin/openvpn-generate-client-onc",
     "/usr/bin/systemctl",
     "/usr/share/untangle/bin/ut-update-hosts-file",
-    "/usr/share/untangle/bin/ut-dns-test"
+    "/usr/share/untangle/bin/ut-dns-test",
+    "/usr/share/untangle/bin/ut-uvm-device-status.sh",
+    "/sbin/ifdown",
+    "/sbin/ifup",
+    "/usr/share/untangle/bin/hostapd-logfile"
 
 }
 

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -358,7 +358,7 @@ public class NetworkManagerImpl implements NetworkManager
         }
         
         // just bring the interface up and down 
-        result = UvmContextFactory.context().execManager().exec( "ifdown " + devName );
+        result = UvmContextFactory.context().execManager().execCommand("/sbin/ifdown", List.of(devName));
         try {
             String[] lines = result.getOutput().split("\\r?\\n");
             logger.info("ifdown {}: ", devName );
@@ -366,7 +366,7 @@ public class NetworkManagerImpl implements NetworkManager
                 logger.info("ifdown: {}", line);
         } catch (Exception e) {}
 
-        result = UvmContextFactory.context().execManager().exec( "ifup " + devName );
+        result = UvmContextFactory.context().execManager().execCommand("/sbin/ifup", List.of(devName));
         try {
             String lines[] = result.getOutput().split("\\r?\\n");
             logger.info("ifup {}: ", devName );
@@ -909,12 +909,12 @@ public class NetworkManagerImpl implements NetworkManager
     @SuppressWarnings("unchecked") //JSON
     public List<DeviceStatus> getDeviceStatus( )
     {
-        String argStr = "";
+        List<String> args = new ArrayList<>();
         for (InterfaceSettings intfSettings : this.networkSettings.getInterfaces()) {
-            argStr = argStr + " " + intfSettings.getPhysicalDev() + " ";
+            args.add(intfSettings.getPhysicalDev());
         }
 
-        String output = UvmContextFactory.context().execManager().execOutput(deviceStatusScript + argStr);
+        String output = UvmContextFactory.context().execManager().execCommand(deviceStatusScript, args).getOutput();
         List<DeviceStatus> entryList = null;
         try {
             //expected Java class type
@@ -3481,7 +3481,7 @@ public class NetworkManagerImpl implements NetworkManager
     public String getLogFile(String device)
     {
         logger.debug("hostapd.log getLogFile()");
-        return UvmContextFactory.context().execManager().execOutput(String.format("%s %s", GET_LOGFILE_SCRIPT, device));
+        return UvmContextFactory.context().execManager().execCommand(GET_LOGFILE_SCRIPT, List.of(device)).getOutput();
     }
 
     /**


### PR DESCRIPTION
Add @SafeCheck annotation to network interface and device settings fields to prevent command injection via shell script generation in sync-settings.

Changes

- @SafeCheck annotations added:
InterfaceSettings.java — physicalDev, systemDev, symbolicDev, imqDev
DeviceSettings.java — deviceName (new finding, not in original report)

- exec() migrated to execCommand() in NetworkManagerImpl.java:
getDeviceStatus() (line 912-917) — device status script with physicalDev list
renewDhcpLease() (lines 361, 369) — ifdown/ifup with symbolicDev
getLogFile() (line 3484) — hostapd-logfile with device param

- ut-exec-safe-launcher allowlist updated:
Added /usr/share/untangle/bin/ut-uvm-device-status.sh, /sbin/ifdown, /sbin/ifup, /usr/share/untangle/bin/hostapd-logfile

- Validation
getDeviceStatus() returns correct interface data (eth0, eth1)
renewDhcpLease() completes successfully (ifdown/ifup cycle)
getLogFile() returns hostapd log content
Regression tests passing: test_010_client_is_online, test_080_routes, test_090_static_dns_entry, test_120_mtu, test_190_qos_statistics, test_350_lan_dhcp_server, test_500_status_interface_transfer, test_501_status_interface_ip_address, test_503_status_dynamic_routing, test_505_status_qos, test_506_status_dhcp_leases, test_740_arp_updates_over_wan