### PR TITLE
NGFW-15703 Sanitizing WanFailOver and backup restore process attributes

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -1080,10 +1080,10 @@ class UvmTests(NGFWTestCase):
         #compare original and modified certs
         assert(newline == newCertFileLines[1])
 
-    def test_121_upload_restore_deprecated_endpoint_blocked(self):
+    def test_121_upload_restbackupore_deprecated_endpoint_blocked(self):
         """Verify /admin/upload rejects restore type with deprecation error (command injection fix)"""
         poc_file = "/tmp/poc_backup.txt"
-        backup_file = "/tmp/untangleBackup.backup"
+        backup_filebackup = "/tmp/untangleBackup.backup"
         subprocess.call(f"rm -f {poc_file}", shell=True)
 
         # Download a real backup file to use as the upload payload
@@ -1783,5 +1783,74 @@ class UvmTests(NGFWTestCase):
             print(f"Expected redirect_uri: {expected.get('redirect_uri')}, actual: {redirect_uri}")
 
         assert(result)
+
+    def test_125_backup_restore_zipslip_blocked(self):
+        """
+        Verify that a crafted backup file with path traversal entries
+        (files outside usr/share/untangle/settings/) is rejected by
+        ut-restore.sh and does not extract malicious files to the filesystem.
+        """
+        malicious_file = "/tmp/zipslip_test_proof"
+        backup_file = "/tmp/test_backup.backup"
+        work_dir = "/tmp/zipslip_test_workdir"
+        subprocess.call(f"rm -f {malicious_file} {backup_file}", shell=True)
+        subprocess.call(f"rm -rf {work_dir}", shell=True)
+
+        try:
+            # Step 1: Download a legitimate backup
+            result = subprocess.call(
+                global_functions.build_wget_command(
+                    output_file=backup_file,
+                    post_data='type=backup',
+                    uri="http://localhost/admin/download"),
+                shell=True)
+            assert result == 0, "Failed to download backup"
+
+            # Step 2: Craft a malicious backup with a file outside settings/
+            os.makedirs(work_dir, exist_ok=True)
+
+            # Extract the outer tar
+            subprocess.call(f"tar xzf {backup_file} -C {work_dir}", shell=True)
+
+            # Find the inner files tarball
+            inner_tarball = glob.glob(f"{work_dir}/files-*.tar.gz")[0]
+            inner_name = os.path.basename(inner_tarball)
+
+            # Extract inner tarball, add malicious entry, repack
+            inner_dir = f"{work_dir}/inner"
+            os.makedirs(inner_dir, exist_ok=True)
+            subprocess.call(f"tar xzf {inner_tarball} -C {inner_dir}", shell=True)
+
+            # Add a file that would write to /tmp/ (outside settings/)
+            os.makedirs(f"{inner_dir}/tmp", exist_ok=True)
+            with open(f"{inner_dir}/tmp/zipslip_test_proof", "w") as f:
+                f.write("ZIPSLIP_PROOF")
+
+            # Repack inner tarball
+            subprocess.call(
+                f"tar czf {work_dir}/{inner_name} -C {inner_dir} .",
+                shell=True)
+
+            # Repack outer backup
+            subprocess.call(
+                f"tar czf {backup_file} -C {work_dir} ./PUBVERSION ./{inner_name}",
+                shell=True)
+
+            # Step 3: Run ut-restore.sh in check+restore mode
+            # Use the restore script directly with -c (check) first
+            restore_result = subprocess.run(
+                ["/usr/share/untangle/bin/ut-restore.sh", "-i", backup_file, "-v", "-c"],
+                capture_output=True, text=True, timeout=30)
+
+            # Step 4: Validate restore script rejected the file
+            assert restore_result.returncode != 0, \
+                "Restore script should have rejected backup with files outside usr/share/untangle/settings/"
+            assert not os.path.exists(malicious_file), \
+                "Zip Slip: malicious file was extracted to /tmp/zipslip_test_proof"
+
+        finally:
+            subprocess.call(f"rm -f {malicious_file} {backup_file}", shell=True)
+            subprocess.call(f"rm -rf {work_dir}", shell=True)
+
 
 test_registry.register_module("uvm", UvmTests)

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -1080,10 +1080,10 @@ class UvmTests(NGFWTestCase):
         #compare original and modified certs
         assert(newline == newCertFileLines[1])
 
-    def test_121_upload_restbackupore_deprecated_endpoint_blocked(self):
+    def test_121_upload_restore_deprecated_endpoint_blocked(self):
         """Verify /admin/upload rejects restore type with deprecation error (command injection fix)"""
         poc_file = "/tmp/poc_backup.txt"
-        backup_filebackup = "/tmp/untangleBackup.backup"
+        backup_file = "/tmp/untangleBackup.backup"
         subprocess.call(f"rm -f {poc_file}", shell=True)
 
         # Download a real backup file to use as the upload payload

--- a/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
+++ b/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
@@ -35,7 +35,11 @@ ALLOWED_EXECUTABLES = {
     "/usr/share/untangle/bin/ut-uvm-device-status.sh",
     "/sbin/ifdown",
     "/sbin/ifup",
-    "/usr/share/untangle/bin/hostapd-logfile"
+    "/usr/share/untangle/bin/hostapd-logfile",
+    "/usr/share/untangle/bin/wan-failover-arp-test.sh",
+    "/usr/share/untangle/bin/wan-failover-ping-test.sh",
+    "/usr/share/untangle/bin/wan-failover-http-test.sh",
+    "/usr/share/untangle/bin/wan-failover-dns-test.sh"
 
 }
 

--- a/uvm/hier/usr/share/untangle/bin/ut-restore.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-restore.sh
@@ -55,9 +55,9 @@ function doRestore()
     debug "Restoring files..."
 
     if [ "true" == $VERBOSE ]; then
-      tar zxhfv $WORKING_DIR/$TARBALL_FILE -C /
+      tar zxfv $WORKING_DIR/$TARBALL_FILE -C /
     else
-      tar zxhf $WORKING_DIR/$TARBALL_FILE -C /
+      tar zxf $WORKING_DIR/$TARBALL_FILE -C /
     fi
 
     # update date on all files
@@ -157,7 +157,17 @@ function expandFile()
     echo $BACKUP_VERSION | grep -qE "$ACCEPTED_PREVIOUS_VERSION"
     PREV_VERSION_CHECK=$?
     if [ "$BACKUP_VERSION" != "$CURRENT_VERSION" ] && [ $PREV_VERSION_CHECK != 0 ] ; then
-        err "Backup file version $BACKUP_VERSION is not supported, supported version(s) = $ACCEPTED_PREVIOUS_VERSION and $CURRENT_VERSION" 
+        err "Backup file version $BACKUP_VERSION is not supported, supported version(s) = $ACCEPTED_PREVIOUS_VERSION and $CURRENT_VERSION"
+        return 1
+    fi
+
+    # NGFW-15703 Validate all tar entries are under /usr/share/untangle/settings/
+    # Prevents Zip Slip path traversal (e.g. ../../etc/cron.d/backdoor)
+    UNSAFE_ENTRIES=$(tar tzf $WORKING_DIR/$TARBALL_FILE | grep -vE '^usr/share/untangle/settings/|^usr/share/untangle/$|^usr/share/$|^usr/$')
+    if [ ! -z "$UNSAFE_ENTRIES" ]; then
+        err "Backup file contains files outside /usr/share/untangle/settings/ (invalid backup):"
+        err "$UNSAFE_ENTRIES"
+        err "Aborting restore."
         return 1
     fi
 

--- a/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/BackupManagerImpl.java
@@ -215,8 +215,9 @@ public class BackupManagerImpl implements BackupManager
          * @param argument
          *        Upload argument
          * @return Deprecated response message
+         * @deprecated use handleV2File instead
          */
-        @Deprecated
+        @Deprecated(since = "17.5", forRemoval = true)
         @Override
         public ExecManagerResult handleFile(FileItem fileItem, String argument) 
         {

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -359,20 +359,24 @@ public class NetworkManagerImpl implements NetworkManager
         
         // just bring the interface up and down 
         result = UvmContextFactory.context().execManager().execCommand("/sbin/ifdown", List.of(devName));
-        try {
-            String[] lines = result.getOutput().split("\\r?\\n");
-            logger.info("ifdown {}: ", devName );
-            for ( String line : lines )
-                logger.info("ifdown: {}", line);
-        } catch (Exception e) {}
+        if (result != null) {
+            try {
+                String[] lines = result.getOutput().split("\\r?\\n");
+                logger.info("ifdown {}: ", devName );
+                for ( String line : lines )
+                    logger.info("ifdown: {}", line);
+            } catch (Exception e) {}
+        }
 
         result = UvmContextFactory.context().execManager().execCommand("/sbin/ifup", List.of(devName));
-        try {
-            String lines[] = result.getOutput().split("\\r?\\n");
-            logger.info("ifup {}: ", devName );
-            for ( String line : lines )
-                logger.info("ifup: {}", line);
-        } catch (Exception e) {}
+        if (result != null) {
+            try {
+                String lines[] = result.getOutput().split("\\r?\\n");
+                logger.info("ifup {}: ", devName );
+                for ( String line : lines )
+                    logger.info("ifup: {}", line);
+            } catch (Exception e) {}
+        }
     }
         
     /**
@@ -914,7 +918,8 @@ public class NetworkManagerImpl implements NetworkManager
             args.add(intfSettings.getPhysicalDev());
         }
 
-        String output = UvmContextFactory.context().execManager().execCommand(deviceStatusScript, args).getOutput();
+        ExecManagerResult execResult = UvmContextFactory.context().execManager().execCommand(deviceStatusScript, args);
+        String output = execResult != null ? execResult.getOutput() : "";
         List<DeviceStatus> entryList = null;
         try {
             //expected Java class type
@@ -3386,7 +3391,8 @@ public class NetworkManagerImpl implements NetworkManager
             );
         }
     
-        return execManager.execCommand(statusScript, args).getOutput();
+        ExecManagerResult execResult = execManager.execCommand(statusScript, args);
+        return execResult != null ? execResult.getOutput() : "";
     }
     
     /**
@@ -3481,7 +3487,8 @@ public class NetworkManagerImpl implements NetworkManager
     public String getLogFile(String device)
     {
         logger.debug("hostapd.log getLogFile()");
-        return UvmContextFactory.context().execManager().execCommand(GET_LOGFILE_SCRIPT, List.of(device)).getOutput();
+        ExecManagerResult execResult = UvmContextFactory.context().execManager().execCommand(GET_LOGFILE_SCRIPT, List.of(device));
+        return execResult != null ? execResult.getOutput() : "";
     }
 
     /**

--- a/wan-failover/hier/usr/lib/python3/dist-packages/tests/test_wan_failover.py
+++ b/wan-failover/hier/usr/lib/python3/dist-packages/tests/test_wan_failover.py
@@ -417,4 +417,54 @@ class WanFailoverTests(NGFWTestCase):
 
 
 
+    def test_060_ping_hostname_injection_blocked(self):
+        """
+        Verify that shell metacharacters in pingHostname do not execute
+        arbitrary commands. WanTestSettings.pingHostname is a String field
+        that flows into execCommand(). @SafeCheck strips injection constructs.
+        Tests backtick, $(), and semicolon patterns.
+        """
+        if len(indexOfWans) == 0:
+            raise unittest.SkipTest("No WANS to test WAN Failover")
+
+        payloads = [
+            ("8.8.8.8`echo PING_BACKTICK`", "PING_BACKTICK"),
+            ("8.8.8.8$(echo PING_SUBSHELL)", "PING_SUBSHELL"),
+        ]
+
+        failures = []
+        for pingHost, marker in payloads:
+            payload = build_wan_test_payload(indexOfWans[0][0], "ping", pingHost=pingHost)
+            result = self._app.runTest(payload)
+            if result is not None and marker in str(result):
+                failures.append(f"  {marker} found in output (payload: {pingHost!r})")
+
+        assert not failures, \
+            "Injection found in ping test output:\n" + "\n".join(failures)
+
+    def test_061_http_url_injection_blocked(self):
+        """
+        Verify that shell metacharacters in httpUrl do not execute
+        arbitrary commands. WanTestSettings.httpUrl is a String field
+        that flows into execCommand(). @SafeCheck strips injection constructs.
+        """
+        if len(indexOfWans) == 0:
+            raise unittest.SkipTest("No WANS to test WAN Failover")
+
+        payloads = [
+            ("http://test.untangle.com`echo HTTP_BACKTICK`", "HTTP_BACKTICK"),
+            ("http://test.untangle.com$(echo HTTP_SUBSHELL)", "HTTP_SUBSHELL"),
+        ]
+
+        failures = []
+        for httpUrl, marker in payloads:
+            payload = build_wan_test_payload(indexOfWans[0][0], "http", httpURL=httpUrl)
+            result = self._app.runTest(payload)
+            if result is not None and marker in str(result):
+                failures.append(f"  {marker} found in output (payload: {httpUrl!r})")
+
+        assert not failures, \
+            "Injection found in HTTP test output:\n" + "\n".join(failures)
+
+
 test_registry.register_module("wan-failover", WanFailoverTests)

--- a/wan-failover/src/com/untangle/app/wan_failover/WanFailoverTester.java
+++ b/wan-failover/src/com/untangle/app/wan_failover/WanFailoverTester.java
@@ -5,11 +5,13 @@
 package com.untangle.app.wan_failover;
 
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.util.I18nUtil;
 import com.untangle.uvm.network.InterfaceSettings;
@@ -260,7 +262,8 @@ public class WanFailoverTester implements Runnable
 
         try {
             if ("arp".equals(testType)) {
-                result.output = WanFailoverApp.execManager.execOutput(ARP_TEST + " " + String.valueOf(interfaceId) + " " + osName + " " + String.valueOf(timeoutMs));
+                ExecManagerResult execResult = WanFailoverApp.execManager.execCommand(ARP_TEST, List.of(String.valueOf(interfaceId), osName, String.valueOf(timeoutMs)));
+                result.output = execResult != null ? execResult.getOutput() : "";
             }
 
             else if ("ping".equals(testType)) {
@@ -273,11 +276,13 @@ public class WanFailoverTester implements Runnable
                     result.message = "Error: Empty ping hostname";
                     return result;
                 }
-                result.output = WanFailoverApp.execManager.execOutput(PING_TEST + " " + String.valueOf(interfaceId) + " " + osName + " " + String.valueOf(timeoutMs) + " " + pingHost);
+                ExecManagerResult execResult = WanFailoverApp.execManager.execCommand(PING_TEST, List.of(String.valueOf(interfaceId), osName, String.valueOf(timeoutMs), pingHost));
+                result.output = execResult != null ? execResult.getOutput() : "";
             }
 
             else if ("dns".equals(testType)) {
-                result.output = WanFailoverApp.execManager.execOutput(DNS_TEST + " " + String.valueOf(interfaceId) + " " + osName + " " + String.valueOf(timeoutMs));
+                ExecManagerResult execResult = WanFailoverApp.execManager.execCommand(DNS_TEST, List.of(String.valueOf(interfaceId), osName, String.valueOf(timeoutMs)));
+                result.output = execResult != null ? execResult.getOutput() : "";
             }
 
             else if ("http".equals(testType)) {
@@ -290,7 +295,8 @@ public class WanFailoverTester implements Runnable
                     result.message = "Error: Empty URL";
                     return result;
                 }
-                result.output = WanFailoverApp.execManager.execOutput(HTTP_TEST + " " + String.valueOf(interfaceId) + " " + osName + " " + String.valueOf(timeoutMs) + " " + httpUrl);
+                ExecManagerResult execResult = WanFailoverApp.execManager.execCommand(HTTP_TEST, List.of(String.valueOf(interfaceId), osName, String.valueOf(timeoutMs), httpUrl));
+                result.output = execResult != null ? execResult.getOutput() : "";
             }
 
             else {

--- a/wan-failover/src/com/untangle/app/wan_failover/WanTestSettings.java
+++ b/wan-failover/src/com/untangle/app/wan_failover/WanTestSettings.java
@@ -7,6 +7,8 @@ import java.io.Serializable;
 import org.json.JSONObject;
 import org.json.JSONString;
 
+import com.untangle.uvm.util.SafeCheck;
+
 /**
  * Settings for a given WAN Test
  */
@@ -25,7 +27,9 @@ public class WanTestSettings implements Serializable, JSONString
     private Integer testHistorySize = 10;
     private Integer failureThreshold = 3;
 
+    @SafeCheck
     private String pingHostname;
+    @SafeCheck
     private String httpUrl;
 
     public Boolean getEnabled()


### PR DESCRIPTION
- WAN Failover pingHostname/httpUrl injection

WanTestSettings.pingHostname and httpUrl are user-editable String fields (configurable from UI) that were passed directly to execOutput() (shell=True) in WanFailoverTester.java. An authenticated admin could inject shell commands via the ping hostname or HTTP URL fields during WAN failover test cycles.

Fix:
- Added @SafeCheck annotation to WanTestSettings.pingHostname and WanTestSettings.httpUrl — strips injection constructs (\n, ;cmd, `cmd`, $(cmd)) at JSON-RPC entry point
- Migrated all 4 exec calls in WanFailoverTester.java (ARP, PING, DNS, HTTP) from execOutput() to execCommand() with List.of() arguments — routes through ut-exec-safe-launcher with Popen(shell=False)
- Added null checks on execCommand() return values to prevent NPE if safe launcher rejects the command
- Added wan-failover-arp-test.sh, wan-failover-ping-test.sh, wan-failover-http-test.sh, wan-failover-dns-test.sh to ut-exec-safe-launcher ALLOWED_EXECUTABLES

- Backup restore Zip Slip path traversal

ut-restore.sh extracted backup tar archives to filesystem root (tar -C /) without validating entry paths. A crafted .backup file containing entries like etc/cron.d/backdoor or tmp/malicious would extract those files to arbitrary filesystem locations during restore.

Fix:
- Added path validation in expandFile() function — rejects any tar entry not under usr/share/untangle/settings/ (the only directory ut-backup.sh creates backups from). Validation runs during both check (-c) and restore modes.
- Removed -h (dereference symlinks) flag from tar extraction — prevents symlink-following attacks. Flag was originally added for developer mode convenience but is unnecessary in production.
- Parent directory entries (usr/, usr/share/, usr/share/untangle/) are allowed since they're part of the tar directory structure.

Testing
test_060_ping_hostname_injection_blocked — backtick and $() payloads in pingHostname stripped by @SafeCheck, markers absent from output
test_061_http_url_injection_blocked — same for httpUrl
test_125_backup_restore_zipslip_blocked — crafted backup with tmp/zipslip_test_proof entry rejected by path validation, file not extracted, restore script returns non-zero
Verified legitimate backup restore still works from UI
WAN failover tests functional with valid ping/HTTP targets