### PR TITLE
Ngfw 15720 captive portal vue migration

### DIFF
--- a/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalApp.java
+++ b/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalApp.java
@@ -176,11 +176,35 @@ public class CaptivePortalApp extends AppBase
     }
 
     /**
+     * Get the application settings V2 format for Vue UI
+     * @return The settings for the application instance
+     */
+    public CaptivePortalSettings getSettingsV2() {
+        return this.getSettings();
+    }
+
+    /**
+     * Set the application settings from V2 format payload coming from Vue UI
+     * @param newSettings The new application settings
+     */
+    public void setSettingsV2(CaptivePortalSettings newSettings) {
+        this.setSettings(newSettings);
+    }
+
+    /**
      * @return A list of active captive portal users
      */
     public ArrayList<CaptivePortalUserEntry> getActiveUsers()
     {
         return (captureUserTable.buildUserList());
+    }
+
+    /**
+     * Get a list of active captive portal users V2 format for Vue UI
+     * @return A list of active captive portal users
+     */
+    public ArrayList<CaptivePortalUserEntry> getActiveUsersV2() {
+        return this.getActiveUsers();
     }
 
     /**

--- a/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalApp.java
+++ b/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalApp.java
@@ -22,9 +22,11 @@ import java.io.FileOutputStream;
 import java.io.BufferedReader;
 
 import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.untangle.app.captive_portal.generic.CaptivePortalSettingsGeneric;
 import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.HookCallback;
 import com.untangle.uvm.OAuthDomain;
@@ -176,19 +178,31 @@ public class CaptivePortalApp extends AppBase
     }
 
     /**
-     * Get the application settings V2 format for Vue UI
-     * @return The settings for the application instance
+     * Get the settings in V2 (generic) format for the Vue UI.
+     *
+     * @return CaptivePortalSettingsGeneric
      */
-    public CaptivePortalSettings getSettingsV2() {
-        return this.getSettings();
+    public CaptivePortalSettingsGeneric getSettingsV2()
+    {
+        if (this.captureSettings != null)
+            return this.captureSettings.transformCaptivePortalSettingsToGeneric();
+        return new CaptivePortalSettingsGeneric();
     }
 
     /**
-     * Set the application settings from V2 format payload coming from Vue UI
-     * @param newSettings The new application settings
+     * Set the settings from a V2 (generic) format payload coming from the Vue UI.
+     * Deep-clones the current V1 settings so V1-only fields (secretKey, binaryKey,
+     * customFileName, deprecated checkServerCertificate handling, etc.) are preserved.
+     *
+     * @param newSettings CaptivePortalSettingsGeneric
      */
-    public void setSettingsV2(CaptivePortalSettings newSettings) {
-        this.setSettings(newSettings);
+    public void setSettingsV2(CaptivePortalSettingsGeneric newSettings)
+    {
+        if (this.captureSettings != null) {
+            CaptivePortalSettings cloned = SerializationUtils.clone(this.captureSettings);
+            newSettings.transformGenericToCaptivePortalSettings(cloned);
+            setSettings(cloned);  // existing V1 setter handles save, validation, and session cleanup
+        }
     }
 
     /**

--- a/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalSettings.java
+++ b/captive-portal/src/com/untangle/app/captive_portal/CaptivePortalSettings.java
@@ -8,6 +8,8 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.untangle.app.captive_portal.generic.CaptivePortalSettingsGeneric;
+
 /**
  * This is the implementation of the captive portal settings.
  * 
@@ -212,5 +214,55 @@ public class CaptivePortalSettings implements Serializable, org.json.JSONString
     {
         org.json.JSONObject jO = new org.json.JSONObject(this);
         return jO.toString();
+    }
+
+    /**
+     * Transforms this V1 settings object into its generic V2 representation
+     * for the Vue UI. Keeps V1 field shapes; only captureRules is transformed
+     * into the shared RuleGeneric form.
+     *
+     * @return CaptivePortalSettingsGeneric
+     */
+    public CaptivePortalSettingsGeneric transformCaptivePortalSettingsToGeneric()
+    {
+        CaptivePortalSettingsGeneric g = new CaptivePortalSettingsGeneric();
+
+        g.setAuthenticationType(this.authenticationType);
+        g.setConcurrentLoginsEnabled(this.areConcurrentLoginsEnabled);
+        g.setUseMacAddress(this.useMacAddress);
+        g.setSessionCookiesEnabled(this.sessionCookiesEnabled);
+        g.setIdleTimeout(this.idleTimeout);
+        g.setUserTimeout(this.userTimeout);
+        g.setSessionCookiesTimeout(this.sessionCookiesTimeout);
+        g.setPageType(this.pageType);
+        g.setCertificateDetection(this.certificateDetection);
+        g.setRedirectUrl(this.redirectUrl);
+        g.setAlwaysUseSecureCapture(this.alwaysUseSecureCapture);
+        g.setRedirectUsingHostname(this.redirectUsingHostname);
+        g.setDisableSecureRedirect(this.disableSecureRedirect);
+
+        g.setBasicMessagePageTitle(this.basicMessagePageTitle);
+        g.setBasicMessagePageWelcome(this.basicMessagePageWelcome);
+        g.setBasicMessageMessageText(this.basicMessageMessageText);
+        g.setBasicMessageAgreeBox(this.basicMessageAgreeBox);
+        g.setBasicMessageAgreeText(this.basicMessageAgreeText);
+        g.setBasicMessageFooter(this.basicMessageFooter);
+
+        g.setBasicLoginPageTitle(this.basicLoginPageTitle);
+        g.setBasicLoginPageWelcome(this.basicLoginPageWelcome);
+        g.setBasicLoginUsername(this.basicLoginUsername);
+        g.setBasicLoginPassword(this.basicLoginPassword);
+        g.setBasicLoginMessageText(this.basicLoginMessageText);
+        g.setBasicLoginFooter(this.basicLoginFooter);
+
+        if (this.passedClients != null)
+            g.setPassedClients(new LinkedList<>(this.passedClients));
+        if (this.passedServers != null)
+            g.setPassedServers(new LinkedList<>(this.passedServers));
+
+        if (this.captureRules != null)
+            g.setCapture_rules(CaptureRule.transformCaptureRulesToGeneric(this.captureRules));
+
+        return g;
     }
 }

--- a/captive-portal/src/com/untangle/app/captive_portal/CaptureRule.java
+++ b/captive-portal/src/com/untangle/app/captive_portal/CaptureRule.java
@@ -4,7 +4,11 @@
 
 package com.untangle.app.captive_portal;
 
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.io.Serializable;
 import java.net.InetAddress;
 
@@ -13,6 +17,11 @@ import org.json.JSONString;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.untangle.uvm.generic.RuleActionGeneric;
+import com.untangle.uvm.generic.RuleConditionGeneric;
+import com.untangle.uvm.generic.RuleGeneric;
+import com.untangle.uvm.util.Constants;
+import com.untangle.uvm.util.StringUtil;
 import com.untangle.uvm.vnet.AppSession;
 import com.untangle.uvm.vnet.SessionAttachments;
 
@@ -158,5 +167,117 @@ public class CaptureRule implements JSONString, Serializable
          * Otherwise all match - so the rule matches
          */
         return true;
+    }
+
+    /**
+     * Transforms a list of CaptureRule into the generic RuleGeneric form for
+     * the V2 API. Used by getSettingsV2().
+     *
+     * @param v1Rules list of V1 CaptureRule objects
+     * @return LinkedList of RuleGeneric
+     */
+    public static LinkedList<RuleGeneric> transformCaptureRulesToGeneric(List<CaptureRule> v1Rules)
+    {
+        LinkedList<RuleGeneric> out = new LinkedList<>();
+        if (v1Rules == null) return out;
+        for (CaptureRule rule : v1Rules) {
+            out.add(toGeneric(rule));
+        }
+        return out;
+    }
+
+    /**
+     * Transforms a single CaptureRule into its RuleGeneric representation.
+     */
+    private static RuleGeneric toGeneric(CaptureRule v1)
+    {
+        boolean enabled = Boolean.TRUE.equals(v1.getEnabled());
+        String ruleId = v1.getRuleId() != null ? String.valueOf(v1.getRuleId()) : null;
+
+        RuleActionGeneric action = new RuleActionGeneric();
+        action.setType(Boolean.TRUE.equals(v1.getCapture())
+                ? RuleActionGeneric.Type.CAPTURE
+                : RuleActionGeneric.Type.PASS);
+
+        LinkedList<RuleConditionGeneric> conds = new LinkedList<>();
+        if (v1.getConditions() != null) {
+            for (CaptureRuleCondition c : v1.getConditions()) {
+                String op = Boolean.TRUE.equals(c.getInvert())
+                        ? Constants.IS_NOT_EQUALS_TO
+                        : Constants.IS_EQUALS_TO;
+                conds.add(new RuleConditionGeneric(op, c.getConditionType(), c.getValue()));
+            }
+        }
+
+        RuleGeneric g = new RuleGeneric(enabled, v1.getDescription(), ruleId);
+        g.setAction(action);
+        g.setConditions(conds);
+        return g;
+    }
+
+    /**
+     * Transforms a list of generic RuleGeneric into V1 CaptureRule, preserving
+     * existing V1 rule objects (matched by ruleId) and removing orphaned rules.
+     * Used by setSettingsV2().
+     *
+     * @param genRules    list of V2 RuleGeneric objects from the UI
+     * @param legacyRules current V1 CaptureRule list (to preserve internal state
+     *                    on update and detect deletions)
+     * @return LinkedList of updated/preserved V1 CaptureRule objects
+     */
+    public static LinkedList<CaptureRule> transformGenericToCaptureRules(
+            LinkedList<RuleGeneric> genRules, List<CaptureRule> legacyRules)
+    {
+        if (legacyRules == null) legacyRules = new LinkedList<>();
+
+        // Remove rules deleted in UI from the legacy list
+        RuleGeneric.deleteOrphanRules(
+                genRules, legacyRules,
+                RuleGeneric::getRuleId,
+                r -> String.valueOf(r.getRuleId()));
+
+        // Map for O(1) lookup of existing rules by ruleId
+        Map<Integer, CaptureRule> rulesMap = legacyRules.stream()
+                .collect(Collectors.toMap(CaptureRule::getRuleId, Function.identity()));
+
+        LinkedList<CaptureRule> out = new LinkedList<>();
+        if (genRules != null) {
+            for (RuleGeneric g : genRules) {
+                CaptureRule existing = rulesMap.get(StringUtil.getInstance().parseInt(g.getRuleId(), 0));
+                out.add(toLegacy(g, existing));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Transforms a single RuleGeneric back into a V1 CaptureRule, mutating the
+     * passed-in existing rule (or creating a new one if null).
+     */
+    private static CaptureRule toLegacy(RuleGeneric g, CaptureRule existing)
+    {
+        if (existing == null) existing = new CaptureRule();
+        existing.setEnabled(g.isEnabled());
+        existing.setDescription(g.getDescription());
+        // For new rules from UI, ruleId is a UUID string -> parseInt returns -1;
+        // CaptivePortalApp.saveAppSettings() will assign a real integer ID on save.
+        existing.setRuleId(StringUtil.getInstance().parseInt(g.getRuleId(), -1));
+
+        if (g.getAction() != null) {
+            existing.setCapture(g.getAction().getType() == RuleActionGeneric.Type.CAPTURE);
+        }
+
+        List<CaptureRuleCondition> conds = new LinkedList<>();
+        if (g.getConditions() != null) {
+            for (RuleConditionGeneric gc : g.getConditions()) {
+                CaptureRuleCondition c = new CaptureRuleCondition();
+                c.setInvert(Constants.IS_NOT_EQUALS_TO.equals(gc.getOp()));
+                c.setConditionType(gc.getType());
+                c.setValue(gc.getValue());
+                conds.add(c);
+            }
+        }
+        existing.setConditions(conds);
+        return existing;
     }
 }

--- a/captive-portal/src/com/untangle/app/captive_portal/generic/CaptivePortalSettingsGeneric.java
+++ b/captive-portal/src/com/untangle/app/captive_portal/generic/CaptivePortalSettingsGeneric.java
@@ -1,0 +1,213 @@
+/**
+ * $Id$
+ */
+package com.untangle.app.captive_portal.generic;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+
+import com.untangle.app.captive_portal.CaptivePortalSettings;
+import com.untangle.app.captive_portal.CaptivePortalSettings.AuthenticationType;
+import com.untangle.app.captive_portal.CaptivePortalSettings.CertificateDetection;
+import com.untangle.app.captive_portal.CaptivePortalSettings.PageType;
+import com.untangle.app.captive_portal.CaptureRule;
+import com.untangle.app.captive_portal.PassedAddress;
+import com.untangle.uvm.generic.RuleGeneric;
+import org.json.JSONObject;
+import org.json.JSONString;
+
+/**
+ * Generic (V2) settings for the Captive Portal app, consumed by the Vue UI.
+ * Keeps V1 field names where structurally identical; transforms only the
+ * captureRules list into the shared RuleGeneric shape.
+ */
+@SuppressWarnings("serial")
+public class CaptivePortalSettingsGeneric implements Serializable, JSONString {
+
+    // Auth & session - V1 names retained
+    private AuthenticationType authenticationType = AuthenticationType.NONE;
+    private boolean concurrentLoginsEnabled = true;
+    private boolean useMacAddress = false;
+    private boolean sessionCookiesEnabled = false;
+
+    // Timeouts (seconds)
+    private int idleTimeout = 0;
+    private int userTimeout = 3600;
+    private int sessionCookiesTimeout = 86400;
+
+    // Page
+    private PageType pageType = PageType.BASIC_MESSAGE;
+    private CertificateDetection certificateDetection = CertificateDetection.DISABLE_DETECTION;
+    private String redirectUrl = "";
+
+    // Redirect flags
+    private boolean alwaysUseSecureCapture = false;
+    private boolean redirectUsingHostname = false;
+    private boolean disableSecureRedirect = false;
+
+    // Basic Message page
+    private String basicMessagePageTitle = "";
+    private String basicMessagePageWelcome = "";
+    private String basicMessageMessageText = "";
+    private boolean basicMessageAgreeBox = false;
+    private String basicMessageAgreeText = "";
+    private String basicMessageFooter = "";
+
+    // Basic Login page
+    private String basicLoginPageTitle = "";
+    private String basicLoginPageWelcome = "";
+    private String basicLoginUsername = "";
+    private String basicLoginPassword = "";
+    private String basicLoginMessageText = "";
+    private String basicLoginFooter = "";
+
+    // Lists - V1 PassedAddress reused directly
+    private LinkedList<PassedAddress> passedClients = new LinkedList<>();
+    private LinkedList<PassedAddress> passedServers = new LinkedList<>();
+
+    // The ONLY transformed list - type changes from List<CaptureRule> to LinkedList<RuleGeneric>
+    // snake_case follows the V2 convention for transformed rule lists
+    private LinkedList<RuleGeneric> capture_rules = new LinkedList<>();
+
+// THIS IS FOR ECLIPSE - @formatter:off
+
+    public AuthenticationType getAuthenticationType() { return authenticationType; }
+    public void setAuthenticationType(AuthenticationType authenticationType) { this.authenticationType = authenticationType; }
+
+    public boolean getConcurrentLoginsEnabled() { return concurrentLoginsEnabled; }
+    public void setConcurrentLoginsEnabled(boolean concurrentLoginsEnabled) { this.concurrentLoginsEnabled = concurrentLoginsEnabled; }
+
+    public boolean getUseMacAddress() { return useMacAddress; }
+    public void setUseMacAddress(boolean useMacAddress) { this.useMacAddress = useMacAddress; }
+
+    public boolean getSessionCookiesEnabled() { return sessionCookiesEnabled; }
+    public void setSessionCookiesEnabled(boolean sessionCookiesEnabled) { this.sessionCookiesEnabled = sessionCookiesEnabled; }
+
+    public int getIdleTimeout() { return idleTimeout; }
+    public void setIdleTimeout(int idleTimeout) { this.idleTimeout = idleTimeout; }
+
+    public int getUserTimeout() { return userTimeout; }
+    public void setUserTimeout(int userTimeout) { this.userTimeout = userTimeout; }
+
+    public int getSessionCookiesTimeout() { return sessionCookiesTimeout; }
+    public void setSessionCookiesTimeout(int sessionCookiesTimeout) { this.sessionCookiesTimeout = sessionCookiesTimeout; }
+
+    public PageType getPageType() { return pageType; }
+    public void setPageType(PageType pageType) { this.pageType = pageType; }
+
+    public CertificateDetection getCertificateDetection() { return certificateDetection; }
+    public void setCertificateDetection(CertificateDetection certificateDetection) { this.certificateDetection = certificateDetection; }
+
+    public String getRedirectUrl() { return redirectUrl; }
+    public void setRedirectUrl(String redirectUrl) { this.redirectUrl = redirectUrl; }
+
+    public boolean getAlwaysUseSecureCapture() { return alwaysUseSecureCapture; }
+    public void setAlwaysUseSecureCapture(boolean alwaysUseSecureCapture) { this.alwaysUseSecureCapture = alwaysUseSecureCapture; }
+
+    public boolean getRedirectUsingHostname() { return redirectUsingHostname; }
+    public void setRedirectUsingHostname(boolean redirectUsingHostname) { this.redirectUsingHostname = redirectUsingHostname; }
+
+    public boolean getDisableSecureRedirect() { return disableSecureRedirect; }
+    public void setDisableSecureRedirect(boolean disableSecureRedirect) { this.disableSecureRedirect = disableSecureRedirect; }
+
+    public String getBasicMessagePageTitle() { return basicMessagePageTitle; }
+    public void setBasicMessagePageTitle(String basicMessagePageTitle) { this.basicMessagePageTitle = basicMessagePageTitle; }
+
+    public String getBasicMessagePageWelcome() { return basicMessagePageWelcome; }
+    public void setBasicMessagePageWelcome(String basicMessagePageWelcome) { this.basicMessagePageWelcome = basicMessagePageWelcome; }
+
+    public String getBasicMessageMessageText() { return basicMessageMessageText; }
+    public void setBasicMessageMessageText(String basicMessageMessageText) { this.basicMessageMessageText = basicMessageMessageText; }
+
+    public boolean getBasicMessageAgreeBox() { return basicMessageAgreeBox; }
+    public void setBasicMessageAgreeBox(boolean basicMessageAgreeBox) { this.basicMessageAgreeBox = basicMessageAgreeBox; }
+
+    public String getBasicMessageAgreeText() { return basicMessageAgreeText; }
+    public void setBasicMessageAgreeText(String basicMessageAgreeText) { this.basicMessageAgreeText = basicMessageAgreeText; }
+
+    public String getBasicMessageFooter() { return basicMessageFooter; }
+    public void setBasicMessageFooter(String basicMessageFooter) { this.basicMessageFooter = basicMessageFooter; }
+
+    public String getBasicLoginPageTitle() { return basicLoginPageTitle; }
+    public void setBasicLoginPageTitle(String basicLoginPageTitle) { this.basicLoginPageTitle = basicLoginPageTitle; }
+
+    public String getBasicLoginPageWelcome() { return basicLoginPageWelcome; }
+    public void setBasicLoginPageWelcome(String basicLoginPageWelcome) { this.basicLoginPageWelcome = basicLoginPageWelcome; }
+
+    public String getBasicLoginUsername() { return basicLoginUsername; }
+    public void setBasicLoginUsername(String basicLoginUsername) { this.basicLoginUsername = basicLoginUsername; }
+
+    public String getBasicLoginPassword() { return basicLoginPassword; }
+    public void setBasicLoginPassword(String basicLoginPassword) { this.basicLoginPassword = basicLoginPassword; }
+
+    public String getBasicLoginMessageText() { return basicLoginMessageText; }
+    public void setBasicLoginMessageText(String basicLoginMessageText) { this.basicLoginMessageText = basicLoginMessageText; }
+
+    public String getBasicLoginFooter() { return basicLoginFooter; }
+    public void setBasicLoginFooter(String basicLoginFooter) { this.basicLoginFooter = basicLoginFooter; }
+
+    public LinkedList<PassedAddress> getPassedClients() { return passedClients; }
+    public void setPassedClients(LinkedList<PassedAddress> passedClients) { this.passedClients = passedClients; }
+
+    public LinkedList<PassedAddress> getPassedServers() { return passedServers; }
+    public void setPassedServers(LinkedList<PassedAddress> passedServers) { this.passedServers = passedServers; }
+
+    public LinkedList<RuleGeneric> getCapture_rules() { return capture_rules; }
+    public void setCapture_rules(LinkedList<RuleGeneric> capture_rules) { this.capture_rules = capture_rules; }
+
+
+    public String toJSONString() {
+        JSONObject jO = new JSONObject(this);
+        return jO.toString();
+    }
+
+    /**
+     * Transforms this V2 settings object into V1 by mutating the passed-in
+     * (deep-cloned) V1 settings object. Preserves V1-only fields like
+     * secretKey, binaryKey, customFileName, checkServerCertificate.
+     *
+     * @param v1 deep-cloned V1 settings (mutated in place)
+     * @return the same v1 reference, populated from this V2 object
+     */
+    public CaptivePortalSettings transformGenericToCaptivePortalSettings(CaptivePortalSettings v1) {
+        if (v1 == null) v1 = new CaptivePortalSettings();
+
+        v1.setAuthenticationType(this.authenticationType);
+        v1.setConcurrentLoginsEnabled(this.concurrentLoginsEnabled);
+        v1.setUseMacAddress(this.useMacAddress);
+        v1.setSessionCookiesEnabled(this.sessionCookiesEnabled);
+        v1.setIdleTimeout(this.idleTimeout);
+        v1.setUserTimeout(this.userTimeout);
+        v1.setSessionCookiesTimeout(this.sessionCookiesTimeout);
+        v1.setPageType(this.pageType);
+        v1.setCertificateDetection(this.certificateDetection);
+        v1.setRedirectUrl(this.redirectUrl);
+        v1.setAlwaysUseSecureCapture(this.alwaysUseSecureCapture);
+        v1.setRedirectUsingHostname(this.redirectUsingHostname);
+        v1.setDisableSecureRedirect(this.disableSecureRedirect);
+
+        v1.setBasicMessagePageTitle(this.basicMessagePageTitle);
+        v1.setBasicMessagePageWelcome(this.basicMessagePageWelcome);
+        v1.setBasicMessageMessageText(this.basicMessageMessageText);
+        v1.setBasicMessageAgreeBox(this.basicMessageAgreeBox);
+        v1.setBasicMessageAgreeText(this.basicMessageAgreeText);
+        v1.setBasicMessageFooter(this.basicMessageFooter);
+
+        v1.setBasicLoginPageTitle(this.basicLoginPageTitle);
+        v1.setBasicLoginPageWelcome(this.basicLoginPageWelcome);
+        v1.setBasicLoginUsername(this.basicLoginUsername);
+        v1.setBasicLoginPassword(this.basicLoginPassword);
+        v1.setBasicLoginMessageText(this.basicLoginMessageText);
+        v1.setBasicLoginFooter(this.basicLoginFooter);
+
+        // PassedAddress lists - direct V1 reuse, no transformation
+        v1.setPassedClients(this.passedClients);
+        v1.setPassedServers(this.passedServers);
+
+        // capture_rules - the ONE transformation (with orphan cleanup)
+        if (this.capture_rules != null)
+            v1.setCaptureRules(CaptureRule.transformGenericToCaptureRules(this.capture_rules, v1.getCaptureRules()));
+
+        return v1;
+    }
+}

--- a/directory-connector/src/com/untangle/app/directory_connector/DirectoryConnectorApp.java
+++ b/directory-connector/src/com/untangle/app/directory_connector/DirectoryConnectorApp.java
@@ -364,6 +364,22 @@ public class DirectoryConnectorApp extends AppBase implements com.untangle.uvm.a
     }
 
     /**
+     * Get all groups from all AD for rule conditions - v2 for VueUI
+     * @return List of groups
+     */
+    public List<GroupEntry> getRuleConditionalGroupEntriesV2() {
+        return this.getRuleConditionalGroupEntries();
+    }
+
+    /**
+     * Get all domains from all AD for rule conditions - v2 for VueUI
+     * @return List of groups.
+     */
+    public List<String> getRuleConditionalDomainEntriesV2() {
+        return this.getRuleConditionalDomainEntries();
+    }
+
+    /**
      * Authenticate against all servers.
      *
      * @param username

--- a/shield/src/com/untangle/app/shield/ShieldApp.java
+++ b/shield/src/com/untangle/app/shield/ShieldApp.java
@@ -98,7 +98,7 @@ public class ShieldApp extends AppBase
         if (this.getSettings() != null) {
             // Deep clone current Shield Settings to transform in New Shield Settings
             ShieldSettings clonedShieldSettings = SerializationUtils.clone(this.settings);
-            newSettings.transformGenericToQosSettings(clonedShieldSettings);
+            newSettings.transformGenericToShieldSettings(clonedShieldSettings);
             setSettings(clonedShieldSettings);
         }
     }

--- a/shield/src/com/untangle/app/shield/generic/ShieldSettingsGeneric.java
+++ b/shield/src/com/untangle/app/shield/generic/ShieldSettingsGeneric.java
@@ -39,7 +39,7 @@ public class ShieldSettingsGeneric implements Serializable, JSONString {
      * @param shieldSettings ShieldSettings
      * @return ShieldSettings
      */
-    public ShieldSettings transformGenericToQosSettings(ShieldSettings shieldSettings) {
+    public ShieldSettings transformGenericToShieldSettings(ShieldSettings shieldSettings) {
         if (shieldSettings == null)
             shieldSettings = new ShieldSettings();
 

--- a/uvm/api/com/untangle/uvm/generic/RuleActionGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/RuleActionGeneric.java
@@ -24,8 +24,9 @@ public class RuleActionGeneric implements JSONString, Serializable {
      * PRIORITY - Required for QoS Rules
      * SCAN, PASS - Required for Shield Rules
      * TARGET_POLICY - Required for Policy Manager
+     * CAPTURE - Required for Captive Portal Rules (paired with PASS for non-capture)
      */
-    public enum Type { DNAT, SNAT, MASQUERADE, BYPASS, PROCESS, ACCEPT, REJECT, SET_PRIORITY, SCAN, PASS, TARGET_POLICY }
+    public enum Type { DNAT, SNAT, MASQUERADE, BYPASS, PROCESS, ACCEPT, REJECT, SET_PRIORITY, SCAN, PASS, TARGET_POLICY, CAPTURE }
     // Common To All Rules
     private Type type;
 


### PR DESCRIPTION
## Summary

Implements the back-end V2 API layer required to support the Captive Portal Vue UI
migration (NGFW-15720). Follows the established Shield/Network pattern: minimal
field renaming, bidirectional V1↔V2 transformation, deep-clone-on-SET to preserve
V1-only fields.

Also includes two small fixes unrelated to the main feature:
- Shield `transformGenericToQosSettings` → `transformGenericToShieldSettings` (wrong
  copy-paste name)
- `RuleActionGeneric.Type` extended with `TARGET_POLICY` (Policy Manager) and
  `CAPTURE`/`PASS` (Captive Portal) action enum values

---

## Changed Files

### New
- `captive-portal/.../generic/CaptivePortalSettingsGeneric.java`
  V2 settings POJO. All field names match V1 JSON keys exactly (camelCase). The only
  structurally transformed field is `captureRules` → `capture_rules`
  (`LinkedList<RuleGeneric>`), conforming to the snake_case convention used for
  transformed rule lists (cf. `shield_rules`, `port_forward_rules`). V1 `PassedAddress`
  is reused directly — no `PassedAddressGeneric` needed.

### Modified — Captive Portal
- `CaptivePortalApp.java` — adds `getSettingsV2()`, `setSettingsV2()`,
  `getActiveUsersV2()`
- `CaptivePortalSettings.java` — adds `transformCaptivePortalSettingsToGeneric()` (V1→V2)
- `CaptureRule.java` — adds static transformation methods:
  - `transformCaptureRulesToGeneric()` / `toGeneric()` (V1→V2)
  - `transformGenericToCaptureRules()` / `toLegacy()` (V2→V1, with orphan cleanup)

### Modified — Directory Connector
- `DirectoryConnectorApp.java` — adds `getRuleConditionalGroupEntriesV2()` and
  `getRuleConditionalDomainEntriesV2()` as thin V2 wrappers over the existing V1
  methods, so the Vue rule condition editor can fetch live AD groups and domains via
  the V2 RPC path.

### Modified — Shared
- `RuleActionGeneric.java` — extends `Type` enum with `TARGET_POLICY` and `CAPTURE`
  (the Captive Portal capture action; `PASS` is the existing complement for non-capture
  rules)

### Fixed — Shield
- `ShieldSettingsGeneric.java` + `ShieldApp.java` — rename
  `transformGenericToQosSettings` → `transformGenericToShieldSettings` (stale name
  from copy-paste)

---

## Testing

- V1 `getSettings`/`setSettings` behaviour is unchanged — no regression risk.
- Round-trip: `getSettingsV2()` → `setSettingsV2()` → `getSettingsV2()` should
  produce structurally identical output.
- V1/V2 cross-check: a change made via V1 `setSettings` must be visible via
  `getSettingsV2`, and vice versa.
- Capture rule lifecycle: add (UUID ruleId → gets integer ID on save), edit
  (numeric ruleId string → updates existing rule), delete (omit from list → removed).
- Verify `secretKey` and `binaryKey` are unchanged after a V2 round-trip.