### PR TITLE
Ngfw 15741: Convert safecheck to typed allowlist validation

### DIFF
--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnNetwork.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnNetwork.java
@@ -10,6 +10,7 @@ import org.json.JSONObject;
 import org.json.JSONString;
 
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * This class is used to hold the settings for GRE networks. Yes, it probably
@@ -26,13 +27,13 @@ public class IpsecVpnNetwork implements JSONString, Serializable
 {
     private int id;
     private boolean active;
-    @SafeCheck
+    @SafeCheck(SafeType.SIMPLE_TEXT)
     private String description;
-    @SafeCheck
+    @SafeCheck(SafeType.IP_OR_CIDR)
     private String localAddress;
-    @SafeCheck
+    @SafeCheck(SafeType.IP_OR_CIDR)
     private String remoteAddress;
-    @SafeCheck
+    @SafeCheck(SafeType.IP_OR_CIDR_LIST)
     private String remoteNetworks;
     private int ttl = 64;
     private int mtu = 1476;

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnSettings.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnSettings.java
@@ -9,6 +9,7 @@ import org.json.JSONString;
 import org.json.JSONObject;
 
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * This class represents all of the settings for the IPsec application.
@@ -35,7 +36,7 @@ public class IpsecVpnSettings implements java.io.Serializable, JSONString
     private AuthenticationType authenticationType = AuthenticationType.LOCAL_DIRECTORY;
     private String virtualNetworkPool = ""; // used for GRE
     private String virtualAddressPool = ""; // used for L2TP
-    @SafeCheck
+    @SafeCheck(SafeType.IP_OR_CIDR)
     private String virtualXauthPool = ""; // used for XAUTH
     private String virtualSecret = "Please_Change_Me";
     private String virtualDnsOne = "";

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
@@ -10,6 +10,7 @@ import org.json.JSONObject;
 import org.json.JSONString;
 
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * This class contains all settings for each configured IPsec tunnel.
@@ -25,7 +26,7 @@ public class IpsecVpnTunnel implements JSONString, Serializable
     private boolean active;
     private int ikeVersion = 1;
     private String conntype;
-    @SafeCheck
+    @SafeCheck(SafeType.SIMPLE_TEXT)
     private String description;
     private String secret;
     private String runmode;
@@ -44,14 +45,14 @@ public class IpsecVpnTunnel implements JSONString, Serializable
     private String left;
     private String leftId;
     private String leftSourceIp;
-    @SafeCheck
+    @SafeCheck(SafeType.IP_OR_CIDR_LIST)
     private String leftSubnet;
     private String leftProtoPort;
     private String leftNextHop;
     private String right;
     private String rightId;
     private String rightSourceIp;
-    @SafeCheck
+    @SafeCheck(SafeType.IP_OR_CIDR_LIST)
     private String rightSubnet;
     private String rightProtoPort;
     private String rightNextHop;

--- a/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/UtCallbackController.java
+++ b/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/UtCallbackController.java
@@ -9,6 +9,8 @@ import java.lang.reflect.Method;
 import org.jabsorb.JSONRPCBridge;
 import org.jabsorb.callback.CallbackController;
 
+import com.untangle.uvm.util.SafeCheckValidator;
+
 /**
  * Untangle Callback controller.
  */
@@ -44,6 +46,11 @@ public class UtCallbackController extends CallbackController
     public void preInvokeCallback(Object context, Object instance, Method method,
                                   Object[] arguments)
     {
+        if (arguments != null) {
+            for (Object arg : arguments) {
+                SafeCheckValidator.validateAll(arg);
+            }
+        }
     }
 
     /**

--- a/uvm/api/com/untangle/uvm/SnmpSettings.java
+++ b/uvm/api/com/untangle/uvm/SnmpSettings.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 import org.json.JSONString;
 
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * For those not familiar with SNMP, here is a bit of an explanation
@@ -64,30 +65,30 @@ public class SnmpSettings implements Serializable, JSONString
 
     private boolean enabled;
     private int port;
-    @SafeCheck
+    @SafeCheck(SafeType.ALPHANUM)
     private String communityString;
-    @SafeCheck
+    @SafeCheck(SafeType.SIMPLE_TEXT)
     private String sysContact;
-    @SafeCheck
+    @SafeCheck(SafeType.SIMPLE_TEXT)
     private String sysLocation;
 
     private boolean v3Enabled;
     private boolean v3Required;
-    @SafeCheck
+    @SafeCheck(SafeType.ALPHANUM)
     private String v3Username;
-    @SafeCheck
+    @SafeCheck(SafeType.ALPHANUM)
     private String v3AuthenticationProtocol;
-    @SafeCheck
+    @SafeCheck(SafeType.OPAQUE_SECRET)
     private String v3AuthenticationPassphrase;
-    @SafeCheck
+    @SafeCheck(SafeType.ALPHANUM)
     private String v3PrivacyProtocol;
-    @SafeCheck
+    @SafeCheck(SafeType.OPAQUE_SECRET)
     private String v3PrivacyPassphrase;
 
     private boolean sendTraps;
-    @SafeCheck
+    @SafeCheck(SafeType.HOSTNAME)
     private String trapHost;
-    @SafeCheck
+    @SafeCheck(SafeType.ALPHANUM)
     private String trapCommunity;
     private int trapPort;
 

--- a/uvm/api/com/untangle/uvm/SystemSettings.java
+++ b/uvm/api/com/untangle/uvm/SystemSettings.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 import com.untangle.uvm.app.DayOfWeekMatcher;
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 import org.apache.commons.lang3.StringUtils;
 /**
@@ -50,13 +51,13 @@ public class SystemSettings implements Serializable, JSONString
      * to each by default, since that is the name of the cert that is
      * created and signed by our internal CA during the installation.
      */
-    @SafeCheck
+    @SafeCheck(SafeType.FILENAME)
     private String webCertificate = "apache.pem";
-    @SafeCheck
+    @SafeCheck(SafeType.FILENAME)
     private String mailCertificate = "apache.pem";
-    @SafeCheck
+    @SafeCheck(SafeType.FILENAME)
     private String ipsecCertificate = "apache.pem";
-    @SafeCheck
+    @SafeCheck(SafeType.FILENAME)
     private String radiusCertificate = "apache.pem";
 
     /**

--- a/uvm/api/com/untangle/uvm/UriManagerSettings.java
+++ b/uvm/api/com/untangle/uvm/UriManagerSettings.java
@@ -10,6 +10,7 @@ import java.util.LinkedList;
 import org.json.JSONString;
 
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 import org.json.JSONObject;
 
@@ -22,7 +23,7 @@ public class UriManagerSettings implements Serializable, JSONString
     private Integer version = 6;
     private List<UriTranslation> uriTranslations = new LinkedList<>();
 
-    @SafeCheck
+    @SafeCheck(SafeType.HOSTNAME)
     private String dnsTestHost = "updates.edge.arista.com";
     private String tcpTestHost = "updates.edge.arista.com";
 

--- a/uvm/api/com/untangle/uvm/network/DeviceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/DeviceSettings.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 import org.json.JSONString;
 
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * Device settings.
@@ -16,7 +17,7 @@ import com.untangle.uvm.util.SafeCheck;
 @SuppressWarnings("serial")
 public class DeviceSettings implements Serializable, JSONString
 {
-    @SafeCheck
+    @SafeCheck(SafeType.INTERFACE)
     private String deviceName;
 
     public static enum Duplex { AUTO,

--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -4,6 +4,7 @@
 package com.untangle.uvm.network;
 
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 import com.untangle.uvm.network.generic.InterfaceSettingsGeneric;
 import com.untangle.uvm.network.generic.InterfaceSettingsGeneric.Type;
 import com.untangle.uvm.network.generic.InterfaceSettingsGeneric.V4Alias;
@@ -40,13 +41,13 @@ public class InterfaceSettings implements Serializable, JSONString
     private int     interfaceId; /* the ID of the physical interface (1-254) */
     private String  name; /* human name: ie External, Internal, Wireless */
 
-    @SafeCheck
+    @SafeCheck(SafeType.INTERFACE)
     private String  physicalDev; /* physical interface name: eth0, etc */
-    @SafeCheck
+    @SafeCheck(SafeType.INTERFACE)
     private String  systemDev; /* iptables interface name: eth0, eth0:0, eth0.1, etc */
-    @SafeCheck
+    @SafeCheck(SafeType.INTERFACE)
     private String  symbolicDev; /* symbolic interface name: eth0, eth0:0, eth0.1, br.eth0 etc */
-    @SafeCheck
+    @SafeCheck(SafeType.INTERFACE)
     private String  imqDev; /* IMQ device name: imq0, imq1, etc (only applies to WANs) */
 
     private Boolean hidden = null; /* Is this interface hidden? null means false */

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -6,6 +6,7 @@ package com.untangle.uvm.network;
 import com.untangle.uvm.network.generic.InterfaceSettingsGeneric;
 import com.untangle.uvm.network.generic.NetworkSettingsGeneric;
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 import org.json.JSONObject;
 import org.json.JSONString;
@@ -38,9 +39,9 @@ public class NetworkSettings implements Serializable, JSONString
     private List<FilterRule> accessRules = null;
     private List<FilterRule> filterRules = null;
     
-    @SafeCheck
+    @SafeCheck(SafeType.HOSTNAME)
     private String hostName;
-    @SafeCheck
+    @SafeCheck(SafeType.HOSTNAME)
     private String domainName;
 
     private boolean dynamicDnsServiceEnabled = false;

--- a/uvm/api/com/untangle/uvm/network/StaticRoute.java
+++ b/uvm/api/com/untangle/uvm/network/StaticRoute.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 
 import com.untangle.uvm.app.IPMaskedAddress;
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * This in the implementation of a Static Route
@@ -33,7 +34,7 @@ public class StaticRoute implements JSONString, Serializable
     private String description = null; 
     private InetAddress network = null;
     private Integer prefix = null ; /* 0-32 */
-    @SafeCheck
+    @SafeCheck({SafeType.IP_OR_CIDR, SafeType.INTERFACE})
     private String nextHop = null; /* Can store the dev name "eth1" or IP "1.2.3.4" */
     
     public StaticRoute() {}

--- a/uvm/api/com/untangle/uvm/util/SafeCheck.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheck.java
@@ -10,34 +10,74 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a String field as requiring shell-safety sanitization.
- * Fields annotated with {@code @SafeCheck} are automatically sanitized by
+ * Marks a String field as requiring shell-safety validation by
  * {@link SafeCheckValidator#validateAll(Object)} in the JSON-RPC
- * {@code preInvokeCallback}, stripping command injection constructs
- * (backtick substitution, {@code $(cmd)}, {@code ${var}}, chaining
- * operators, pipes, redirects, and newline injection) before settings
- * reach application code.
+ * {@code preInvokeCallback}. Validation is fail-fast: a bad value
+ * raises {@link SafeCheckValidationException} which Jabsorb propagates
+ * to the client as a JSON-RPC error.
  *
- * <h3>Usage rules</h3>
+ * <h3>Usage</h3>
+ * Every annotation should specify the {@link SafeType}(s) the field
+ * accepts:
+ *
+ * <pre>
+ *   &#64;SafeCheck(SafeType.HOSTNAME)
+ *   private String hostName;
+ *
+ *   // dual-purpose field
+ *   &#64;SafeCheck({ SafeType.IP_OR_CIDR, SafeType.INTERFACE })
+ *   private String nextHop;
+ *
+ *   // override the per-type default error message for UI friendliness
+ *   &#64;SafeCheck(value = SafeType.HOSTNAME,
+ *              errorMessage = "Enter a valid SNMP trap target hostname.")
+ *   private String trapHost;
+ * </pre>
+ *
+ * <p>An empty {@code value()} array is permitted as a transitional
+ * default so that an untyped {@code @SafeCheck} declaration continues
+ * to compile during migration. The validator falls back to
+ * {@link SafeType#SIMPLE_TEXT} and logs a one-time warning naming the
+ * field - every shipped {@code @SafeCheck} site should declare a type
+ * explicitly.</p>
+ *
+ * <h3>Rules</h3>
  * <ul>
  *   <li>Apply only to instance {@code String} fields. Non-String and
- *       static fields are ignored by the validator.</li>
- *   <li>The validator traverses into nested objects and Collections/Maps
- *       automatically, so annotating a field on a deeply nested class
- *       (e.g. {@code IpsecVpnTunnel.description}) works as long as the
- *       parent settings object is reachable via the JSON-RPC call.</li>
- *   <li>Collection and Map fields <b>must</b> declare their generic type
- *       parameters (e.g. {@code List<MySettings>}, not raw {@code List}).
- *       The validator uses compile-time generic type info to determine
- *       whether a Collection's elements need scanning. Raw types make the
- *       element type invisible and the annotated fields will be silently
- *       skipped.</li>
- *   <li>Inherited fields are supported - the validator walks the
- *       superclass chain.</li>
+ *       static fields are ignored.</li>
+ *   <li>The validator traverses into nested objects, Collections, Maps,
+ *       and arrays automatically.</li>
+ *   <li>Collection and Map fields <b>must</b> declare their generic
+ *       type parameters (e.g. {@code List<MySettings>}, not raw
+ *       {@code List}). Raw types make element types invisible to
+ *       reflection.</li>
+ *   <li>{@link SafeType#OPAQUE_SECRET} fields permit shell
+ *       metacharacters by design - sinks must use
+ *       {@code execCommand(...)} or {@code shlex.quote(...)} rather
+ *       than string-concat into a shell template.</li>
  * </ul>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface SafeCheck
 {
+    /**
+     * The {@link SafeType}(s) the field's value must match. The
+     * validator accepts the value if any listed type accepts it.
+     *
+     * <p>Default is the empty array, which exists solely so that an
+     * untyped {@code @SafeCheck} declaration continues to compile
+     * during migration. The validator treats an empty list as
+     * {@link SafeType#SIMPLE_TEXT} and logs a warning naming the
+     * field - fix by adding an explicit type.</p>
+     */
+    SafeType[] value() default {};
+
+    /**
+     * Optional override for the per-type default error message, useful
+     * when a UI-facing label gives the admin clearer guidance than the
+     * generic type description. Empty string means "use the default
+     * message(s) of the listed types".
+     */
+    String errorMessage() default "";
 }

--- a/uvm/api/com/untangle/uvm/util/SafeCheckValidationException.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheckValidationException.java
@@ -1,0 +1,24 @@
+/**
+ * $Id$
+ */
+
+package com.untangle.uvm.util;
+
+/**
+ * Thrown by {@link SafeCheckValidator} when a value annotated with
+ * {@link SafeCheck} fails validation against the declared {@link SafeType}.
+ *
+ * <p>The exception message names the field and the format requirement,
+ * but never includes the offending value itself. This avoids leaking
+ * credentials and prevents pivot through error-channel echo when the
+ * exception propagates back to the JSON-RPC client (Jabsorb wraps it
+ * as a JSON-RPC error).</p>
+ */
+@SuppressWarnings("serial")
+public class SafeCheckValidationException extends RuntimeException
+{
+    public SafeCheckValidationException(String message)
+    {
+        super(message);
+    }
+}

--- a/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
@@ -4,6 +4,7 @@
 
 package com.untangle.uvm.util;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
@@ -11,96 +12,93 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
- * Sanitizes string values for shell-safety.
- * Detects actual command injection patterns rather than blindly
- * stripping individual characters. This preserves legitimate uses
- * of special characters (e.g. "$" in passwords, "|" in descriptions)
- * while catching injection constructs like `cmd`, $(cmd), ${var},
- * command chaining (;, &&, ||), pipes, redirects, and newline injection.
+ * Validates {@link SafeCheck}-annotated String fields on an object
+ * graph against the field's declared {@link SafeType}(s). Validation
+ * is fail-fast and read-only:
+ * <ul>
+ *   <li>A field whose value matches at least one of its declared
+ *       SafeTypes is accepted.</li>
+ *   <li>A field whose value matches none of them causes
+ *       {@link SafeCheckValidationException} to be thrown. Jabsorb
+ *       wraps this as a JSON-RPC error returned to the client.</li>
+ *   <li>The input object is never mutated. Validation runs against
+ *       {@code field.get(obj)} only - no {@code field.set} call. This
+ *       makes the validator safe on final fields under Java 9+.</li>
+ * </ul>
+ *
+ * <p>Empty / null values are accepted by every type - see
+ * {@link SafeType#validate(String)} for the rationale.</p>
+ *
+ * <h3>Object graph traversal</h3>
+ * The validator dispatches on the runtime class of every value:
+ * Collections recurse into elements, Maps recurse into both keys and
+ * values, arrays recurse into elements, custom objects recurse into
+ * their non-primitive non-{@code java.*} fields. {@code java.*}
+ * objects (String, Integer, etc.) are skipped because they cannot
+ * carry {@code @SafeCheck} annotations.
+ *
+ * <h3>Cycle and resource protection</h3>
+ * Cycles are broken by an identity-keyed visited-set. Recursion is
+ * bounded by {@link #MAX_DEPTH}; collection iteration is bounded by
+ * {@link #MAX_COLLECTION_ITER}. Exceeding either limit raises
+ * {@link SafeCheckValidationException}.
+ *
+ * <h3>Empty {@code @SafeCheck} fallback</h3>
+ * A field annotated with bare {@code @SafeCheck} (no SafeType
+ * specified) is treated as {@link SafeType#SIMPLE_TEXT} and a
+ * one-time warning is logged naming the field. This is a transitional
+ * compatibility shim; every shipped annotation should declare a type
+ * explicitly.
  */
 public class SafeCheckValidator
 {
-    /**
-     * Matches command injection constructs:
-     *
-     * Enclosed patterns (entire construct stripped):
-     *   `command`    backtick command substitution
-     *   $(command)   subshell command substitution
-     *   ${variable}  variable/command expansion
-     *
-     * Chaining operators (stripped when followed by command-like content):
-     *   &&           AND chaining
-     *   ||           OR chaining
-     *   ;            command separator
-     *   |            pipe to command
-     *
-     * Redirect operators (stripped when followed by path-like content):
-     *   > or >>      output redirect
-     *   <            input redirect / process substitution
-     *
-     * Always stripped:
-     *   \n \r        newline injection (acts as command separator)
-     */
-    private static final Pattern INJECTION_PATTERN = Pattern.compile(
-        String.join("|",
-            "`[^`]+`",                              // `command`  backtick substitution
-            "\\$\\([^)]*\\)",                        // $(command) subshell substitution
-            "\\$\\{[^}]*\\}",                        // ${var}     variable expansion
-            "&&(?=\\s*\\S)",                          // &&         AND chaining
-            "\\|\\|(?=\\s*\\S)",                      // ||         OR chaining
-            "[\\r\\n]",                               // \\n \\r    newline injection
-            ";(?=\\s*[a-zA-Z0-9_/\\\\.])",            // ;          command separator
-            "\\|(?=\\s*[a-zA-Z0-9_/\\\\.])",          // |          pipe to command
-            ">{1,2}(?=\\s*[a-zA-Z0-9_/\\\\.])",      // > >>       output redirect
-            "<(?=\\s*[a-zA-Z0-9_/(\\\\.])"            // <          input redirect / <()
-        )
-    );
+    private static final Logger logger = LogManager.getLogger(SafeCheckValidator.class);
+
     /** Prefix used to identify JDK classes that should not be reflectively scanned. */
     private static final String JAVA = "java.";
 
-    /** Per-class cache of @SafeCheck and traversable field metadata. Populated once per class on first encounter. */
+    /**
+     * Maximum recursion depth into the object graph. Real settings
+     * graphs in this codebase reach depth ~3-7; 64 leaves a comfortable
+     * margin while bounding pathological / cyclic inputs.
+     */
+    private static final int MAX_DEPTH = 64;
+
+    /**
+     * Maximum number of elements processed from any single Collection,
+     * Map, or array during one validateAll call. Caps the cost of an
+     * attacker-supplied multi-million-element collection.
+     */
+    private static final int MAX_COLLECTION_ITER = 100_000;
+
+    /** Per-class cache of @SafeCheck and traversable field metadata. */
     private static final ConcurrentHashMap<Class<?>, ClassInfo> CACHE = new ConcurrentHashMap<>();
 
     /**
-     * Per-class cache of subtree relevance. Stores whether a class (or any class
-     * reachable through its instance fields) contains @SafeCheck annotations.
-     * Classes cached as false are skipped entirely by validateAll(), avoiding
-     * unnecessary traversal of object graphs that have no fields to sanitize.
+     * Per-class cache of subtree relevance. Stores whether a class (or any
+     * class reachable through its instance fields) contains @SafeCheck
+     * annotations. Classes cached as false are skipped entirely by
+     * validateAll(), avoiding unnecessary traversal of object graphs that
+     * have no fields to validate.
      */
     private static final ConcurrentHashMap<Class<?>, Boolean> RELEVANCE_CACHE = new ConcurrentHashMap<>();
 
     /**
-     * Collects all instance fields from a class and its superclass chain,
-     * stopping at java.* classes. Static fields are excluded since @SafeCheck
-     * applies only to per-instance settings data. Walking the superclass chain
-     * ensures annotations on parent classes are not missed by getDeclaredFields().
-     *
-     * @param clazz
-     *        The class to inspect
-     * @return List of all instance fields in the class hierarchy
+     * Tracks fields for which we have already logged the
+     * "empty @SafeCheck() - falling back to SIMPLE_TEXT" warning.
+     * Prevents log spam.
      */
-    private static List<Field> getAllFields(Class<?> clazz)
-    {
-        List<Field> fields = new ArrayList<>();
-        while (clazz != null && !clazz.getName().startsWith(JAVA)) {
-            for (Field field : clazz.getDeclaredFields()) {
-                if (Modifier.isStatic(field.getModifiers())) {
-                    continue;
-                }
-                fields.add(field);
-            }
-            clazz = clazz.getSuperclass();
-        }
-        return fields;
-    }
+    private static final Set<String> WARNED_EMPTY_VALUE = ConcurrentHashMap.newKeySet();
 
     /**
      * Cached reflection info for a class.
@@ -110,118 +108,140 @@ public class SafeCheckValidator
         final List<Field> safeCheckFields;
         final List<Field> traversableFields;
 
-        /**
-         * Constructor for ClassInfo.
-         *
-         * @param safeCheckFields
-         *        List of fields annotated with SafeCheck
-         * @param traversableFields
-         *        List of non-primitive fields to recurse into
-         */
         ClassInfo(List<Field> safeCheckFields, List<Field> traversableFields)
         {
             this.safeCheckFields = safeCheckFields;
             this.traversableFields = traversableFields;
         }
-
     }
 
     /**
-     * Checks whether a class or any class reachable through its fields
-     * has @SafeCheck annotations. Results are cached per class so the
-     * reflection cost is paid only once. Classes with no @SafeCheck
-     * anywhere in their subtree are skipped entirely by validateAll().
-     *
-     * @param clazz
-     *        The class to check
-     * @return true if this class or any reachable class has @SafeCheck fields
+     * Collects all instance fields from a class and its superclass chain,
+     * stopping at java.* classes. Static and synthetic fields are
+     * excluded.
+     */
+    private static List<Field> getAllFields(Class<?> clazz)
+    {
+        List<Field> fields = new ArrayList<>();
+        while (clazz != null && !clazz.getName().startsWith(JAVA)) {
+            for (Field field : clazz.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) continue;
+                if (field.isSynthetic()) continue;
+                fields.add(field);
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return fields;
+    }
+
+    /**
+     * Determines whether validating an instance of {@code clazz} could
+     * encounter any {@code @SafeCheck} field directly or via a reachable
+     * field. Cached. Conservatively returns {@code true} on cycle or on
+     * unknown shapes (raw collections, type variables) so traversal is
+     * never wrongly skipped.
      */
     private static boolean isRelevant(Class<?> clazz)
     {
         Boolean cached = RELEVANCE_CACHE.get(clazz);
-        if (cached != null) {
-            return cached;
-        }
-        return computeRelevance(clazz, new HashSet<>());
+        if (cached != null) return cached;
+        Set<Class<?>> visiting = Collections.newSetFromMap(new IdentityHashMap<>());
+        boolean rel = computeRelevance(clazz, visiting);
+        RELEVANCE_CACHE.putIfAbsent(clazz, rel);
+        return rel;
     }
 
-    /**
-     * Recursive relevance check with cycle detection.
-     *
-     * @param clazz
-     *        The class to check
-     * @param visiting
-     *        Set of classes currently being checked to prevent infinite recursion
-     * @return true if @SafeCheck is found in this class or its subtree
-     */
     private static boolean computeRelevance(Class<?> clazz, Set<Class<?>> visiting)
     {
         if (clazz == null || clazz.isPrimitive() || clazz.getName().startsWith(JAVA)) {
             return false;
         }
         Boolean cached = RELEVANCE_CACHE.get(clazz);
-        if (cached != null) {
-            return cached;
-        }
+        if (cached != null) return cached;
         if (!visiting.add(clazz)) {
-            return false;
+            // Cycle hit. Return conservative true so the traversal does
+            // not silently skip a cyclic graph. Do NOT cache here - the
+            // result is not yet stable.
+            return true;
         }
 
-        boolean relevant = false;
-        for (Field field : getAllFields(clazz)) {
-            // Direct @SafeCheck field found
-            if (field.isAnnotationPresent(SafeCheck.class) && field.getType() == String.class) {
-                relevant = true;
-                break;
-            }
+        try {
+            for (Field field : getAllFields(clazz)) {
+                if (field.isAnnotationPresent(SafeCheck.class) && field.getType() == String.class) {
+                    return true;
+                }
 
-            Class<?> fieldType = field.getType();
-            if (fieldType.isPrimitive()) {
-                continue;
-            }
+                Class<?> fieldType = field.getType();
+                if (fieldType.isPrimitive()) continue;
 
-            // Check Collection/Map generic type arguments
-            if (Collection.class.isAssignableFrom(fieldType) || Map.class.isAssignableFrom(fieldType)) {
-                Type genericType = field.getGenericType();
-                if (genericType instanceof ParameterizedType) {
-                    for (Type typeArg : ((ParameterizedType) genericType).getActualTypeArguments()) {
-                        if (typeArg instanceof Class<?> && computeRelevance((Class<?>) typeArg, visiting)) {
-                            relevant = true;
-                            break;
-                        }
+                if (fieldType.isArray()) {
+                    Class<?> component = fieldType.getComponentType();
+                    if (component != null && !component.isPrimitive()
+                        && !component.getName().startsWith(JAVA)
+                        && computeRelevance(component, visiting)) {
+                        return true;
                     }
+                    continue;
                 }
-                if (relevant) {
-                    break;
-                }
-                continue;
-            }
 
-            // Check non-java custom types
-            if (!fieldType.getName().startsWith(JAVA) && computeRelevance(fieldType, visiting)) {
-                relevant = true;
-                break;
+                if (Collection.class.isAssignableFrom(fieldType)
+                    || Map.class.isAssignableFrom(fieldType)) {
+                    Type generic = field.getGenericType();
+                    if (generic instanceof ParameterizedType) {
+                        for (Type arg : ((ParameterizedType) generic).getActualTypeArguments()) {
+                            if (isTypeRelevant(arg, visiting)) {
+                                return true;
+                            }
+                        }
+                    } else {
+                        // Raw Collection/Map -  element type is invisible.
+                        // Treat conservatively as relevant; warn once.
+                        logger.warn("@SafeCheck-aware traversal: raw {} field {}.{} - declare generic type",
+                            fieldType.getSimpleName(),
+                            clazz.getName(), field.getName());
+                        return true;
+                    }
+                    continue;
+                }
+
+                if (!fieldType.getName().startsWith(JAVA) && computeRelevance(fieldType, visiting)) {
+                    return true;
+                }
             }
+            return false;
+        } finally {
+            visiting.remove(clazz);
         }
-
-        RELEVANCE_CACHE.put(clazz, relevant);
-        return relevant;
     }
 
     /**
-     * Builds and caches reflection metadata for a class. Partitions instance
-     * fields into two groups:
-     * <ul>
-     *   <li>safeCheckFields: String fields annotated with @SafeCheck (to sanitize)</li>
-     *   <li>traversableFields: non-primitive fields that may contain nested
-     *       @SafeCheck objects. Includes Collection/Map fields (which hold
-     *       settings objects) and non-java custom types. Excludes java.* types
-     *       like String, Integer, etc. that can never have @SafeCheck.</li>
-     * </ul>
-     *
-     * @param clazz
-     *        The class to inspect
-     * @return Cached ClassInfo with annotated and traversable fields
+     * Recursively check a generic Type (Class, ParameterizedType,
+     * WildcardType, GenericArrayType, TypeVariable) for relevance.
+     * Conservative - anything not analyzable is treated as relevant.
+     */
+    private static boolean isTypeRelevant(Type type, Set<Class<?>> visiting)
+    {
+        if (type instanceof Class<?>) {
+            return computeRelevance((Class<?>) type, visiting);
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType pt = (ParameterizedType) type;
+            Type raw = pt.getRawType();
+            if (raw instanceof Class<?>
+                && computeRelevance((Class<?>) raw, visiting)) {
+                return true;
+            }
+            for (Type arg : pt.getActualTypeArguments()) {
+                if (isTypeRelevant(arg, visiting)) return true;
+            }
+            return false;
+        }
+        // WildcardType / TypeVariable / GenericArrayType - assume relevant.
+        return true;
+    }
+
+    /**
+     * Builds and caches reflection metadata for a class.
      */
     private static ClassInfo getClassInfo(Class<?> clazz)
     {
@@ -230,13 +250,24 @@ public class SafeCheckValidator
             List<Field> traversable = new ArrayList<>();
 
             for (Field field : getAllFields(c)) {
-                if (field.isAnnotationPresent(SafeCheck.class) && field.getType() == String.class) {
-                    field.setAccessible(true);
-                    safeCheck.add(field);
-                } else if (!field.getType().isPrimitive()
-                           && (!field.getType().getName().startsWith(JAVA)
-                               || Collection.class.isAssignableFrom(field.getType())
-                               || Map.class.isAssignableFrom(field.getType()))) {
+                if (field.isAnnotationPresent(SafeCheck.class)) {
+                    if (field.getType() == String.class) {
+                        field.setAccessible(true);
+                        safeCheck.add(field);
+                    }
+                    // Non-String @SafeCheck fields are silently ignored
+                    // (matches the prior validator's behavior).
+                    continue;
+                }
+
+                Class<?> ft = field.getType();
+                if (ft.isPrimitive()) continue;
+
+                // Recurse into arrays, Collections, Maps, and user
+                // objects (anything not in java.*).
+                if (ft.isArray() || Collection.class.isAssignableFrom(ft)
+                    || Map.class.isAssignableFrom(ft)
+                    || !ft.getName().startsWith(JAVA)) {
                     field.setAccessible(true);
                     traversable.add(field);
                 }
@@ -244,98 +275,134 @@ public class SafeCheckValidator
 
             return new ClassInfo(
                 safeCheck.isEmpty() ? Collections.emptyList() : safeCheck,
-                traversable.isEmpty() ? Collections.emptyList() : traversable
-            );
+                traversable.isEmpty() ? Collections.emptyList() : traversable);
         });
     }
 
     /**
-     * Strips shell metacharacters from the given value.
+     * Validate a single value against the SafeType list of an
+     * annotation. Returns silently on success; throws
+     * {@link SafeCheckValidationException} on failure.
      *
-     * @param value
-     *        The string value to sanitize
-     * @return The sanitized string with unsafe characters removed, or null if input is null
+     * @param value     the field value being checked (may be null)
+     * @param ann       the SafeCheck annotation on the field
+     * @param fieldName "ClassSimpleName.fieldName" for error reporting
      */
-    public static String sanitize(String value)
+    private static void validateValue(String value, SafeCheck ann, String fieldName)
     {
-        if (value == null) {
-            return null;
+        SafeType[] types = ann.value();
+        if (types.length == 0) {
+            // Transitional fallback for un-typed @SafeCheck. Log once
+            // per field so the developer notices.
+            if (WARNED_EMPTY_VALUE.add(fieldName)) {
+                logger.warn("@SafeCheck on field {} has empty value() - falling back to SafeType.SIMPLE_TEXT. "
+                    + "Add an explicit SafeType to silence this warning.",
+                    fieldName);
+            }
+            types = new SafeType[]{SafeType.SIMPLE_TEXT};
         }
-        return INJECTION_PATTERN.matcher(value).replaceAll("");
+
+        for (SafeType type : types) {
+            if (type.validate(value)) return;
+        }
+
+        // No type accepted. Build the message - the offending value is
+        // never included (avoids credential leakage and pivot through
+        // error-channel echo).
+        String message;
+        String override = ann.errorMessage();
+        if (override != null && !override.isEmpty()) {
+            message = override;
+        } else {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < types.length; i++) {
+                if (i > 0) sb.append(" OR ");
+                sb.append(types[i].defaultMessage());
+            }
+            message = sb.toString();
+        }
+        throw new SafeCheckValidationException(
+            "Invalid value in field " + fieldName + ": " + message);
     }
 
     /**
-     * Scans the given object and all reachable nested objects for fields
-     * annotated with @SafeCheck and sanitizes their String values.
-     * Recurses into collections, maps, and object fields.
-     * Classes with no @SafeCheck in their subtree are skipped entirely.
-     *
-     * @param obj
-     *        The object to sanitize
+     * Top-level entry: validate every {@code @SafeCheck} field reachable
+     * from {@code obj}. Throws {@link SafeCheckValidationException} on
+     * the first failing field. Caller (Jabsorb preInvokeCallback or App
+     * setSettings method) propagates the exception.
      */
     public static void validateAll(Object obj)
     {
-        validateAll(obj, new HashSet<>());
+        Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        validateAll(obj, visited, 0);
     }
 
-    /**
-     * Recursive implementation that tracks visited objects to avoid cycles.
-     * Dispatches based on object type:
-     * <ul>
-     *   <li>Collection: iterates elements recursively</li>
-     *   <li>Map: iterates values recursively</li>
-     *   <li>java.* objects: skipped (no @SafeCheck possible)</li>
-     *   <li>Non-relevant classes: skipped via RELEVANCE_CACHE (subtree has no @SafeCheck)</li>
-     *   <li>Relevant classes: sanitizes @SafeCheck fields, then traverses into sub-objects</li>
-     * </ul>
-     *
-     * @param obj
-     *        The object to sanitize
-     * @param visited
-     *        Set of already visited objects (identity-based) to prevent infinite recursion
-     */
-    private static void validateAll(Object obj, Set<Object> visited)
+    private static void validateAll(Object obj, Set<Object> visited, int depth)
     {
-        if (obj == null) {
-            return;
+        if (obj == null) return;
+        if (depth > MAX_DEPTH) {
+            throw new SafeCheckValidationException(
+                "Validation aborted: object graph exceeds maximum depth of " + MAX_DEPTH);
         }
-        if (!visited.add(obj)) {
-            return;
-        }
+        if (!visited.add(obj)) return;
+
         if (obj instanceof Collection) {
+            int n = 0;
             for (Object item : (Collection<?>) obj) {
-                validateAll(item, visited);
+                if (++n > MAX_COLLECTION_ITER) {
+                    throw new SafeCheckValidationException(
+                        "Validation aborted: collection exceeds maximum size of " + MAX_COLLECTION_ITER);
+                }
+                validateAll(item, visited, depth + 1);
             }
             return;
         }
         if (obj instanceof Map) {
-            for (Object val : ((Map<?, ?>) obj).values()) {
-                validateAll(val, visited);
+            int n = 0;
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) obj).entrySet()) {
+                if (++n > MAX_COLLECTION_ITER) {
+                    throw new SafeCheckValidationException(
+                        "Validation aborted: map exceeds maximum size of " + MAX_COLLECTION_ITER);
+                }
+                validateAll(entry.getKey(), visited, depth + 1);
+                validateAll(entry.getValue(), visited, depth + 1);
             }
             return;
         }
-        if (obj.getClass().getName().startsWith(JAVA)) {
+        if (obj.getClass().isArray()) {
+            // Skip primitive arrays - they cannot carry @SafeCheck.
+            if (obj.getClass().getComponentType().isPrimitive()) return;
+            int len = Array.getLength(obj);
+            if (len > MAX_COLLECTION_ITER) {
+                throw new SafeCheckValidationException(
+                    "Validation aborted: array exceeds maximum size of " + MAX_COLLECTION_ITER);
+            }
+            for (int i = 0; i < len; i++) {
+                validateAll(Array.get(obj, i), visited, depth + 1);
+            }
             return;
         }
+        if (obj.getClass().getName().startsWith(JAVA)) return;
 
-        // Skip classes that have no @SafeCheck anywhere in their subtree
-        if (!isRelevant(obj.getClass())) {
-            return;
-        }
+        // Skip subtrees we know contain no @SafeCheck.
+        if (!isRelevant(obj.getClass())) return;
 
         ClassInfo info = getClassInfo(obj.getClass());
 
         try {
             for (Field field : info.safeCheckFields) {
                 String value = (String) field.get(obj);
-                field.set(obj, sanitize(value));
+                SafeCheck ann = field.getAnnotation(SafeCheck.class);
+                String fieldName = obj.getClass().getSimpleName() + "." + field.getName();
+                validateValue(value, ann, fieldName);
             }
             for (Field field : info.traversableFields) {
                 Object child = field.get(obj);
-                validateAll(child, visited);
+                validateAll(child, visited, depth + 1);
             }
         } catch (IllegalAccessException e) {
-            throw new RuntimeException("Failed to sanitize object of type: " + obj.getClass().getName(), e);
+            throw new SafeCheckValidationException(
+                "Failed to access field on " + obj.getClass().getName() + ": " + e.getMessage());
         }
     }
 }

--- a/uvm/api/com/untangle/uvm/util/SafeType.java
+++ b/uvm/api/com/untangle/uvm/util/SafeType.java
@@ -1,0 +1,372 @@
+/**
+ * $Id$
+ */
+
+package com.untangle.uvm.util;
+
+import java.net.URI;
+import java.util.regex.Pattern;
+
+/**
+ * Typed allowlists used by {@link SafeCheck} to validate string field
+ * values at the JSON-RPC boundary.
+ *
+ * <p>Each enum value carries (a) a validation rule and (b) a default
+ * error message describing the format requirement. Rules are
+ * <b>allowlist-based</b> - the value must match the type's pattern,
+ * not merely lack particular metacharacters.</p>
+ *
+ * <h3>Null / empty policy</h3>
+ * Every type accepts {@code null} and the empty string {@code ""} as
+ * valid. Most settings fields are nullable by design (unset password,
+ * unconfigured WAN test, etc.), and many ship with empty-string
+ * defaults. Rejecting those would break round-trips on any settings
+ * panel that has not been touched yet.
+ *
+ * <h3>Leading-character rule</h3>
+ * Every regex-based type requires the first character to be
+ * {@code [A-Za-z0-9]}. This closes the argv-option-injection class -
+ * a value beginning with {@code -} would otherwise be parsed as a flag
+ * by downstream CLI tools.
+ *
+ * <h3>OPAQUE_SECRET contract</h3>
+ * {@link #OPAQUE_SECRET} permits any printable Unicode (excluding
+ * control characters) so that legitimate passwords containing
+ * {@code $}, {@code &}, {@code "} etc. are not rejected. Fields of
+ * this type <b>must never</b> be passed to a string-concatenation
+ * exec sink or naive single/double-quote-wrapped into a shell
+ * template - every sink is responsible for using
+ * {@code execCommand(...)} (Java) or {@code shlex.quote(...)} (Python)
+ * around the value.
+ */
+public enum SafeType
+{
+    /**
+     * Hostname / DNS label. Length 1-253, leading alphanumeric.
+     * Allows '_' for parity with the existing UI vtype
+     * (uvm/servlets/admin/app/overrides/form/field/VTypes.js:23 accepts
+     * {@code [a-zA-Z0-9\-_.]+}) and to support Windows / NetBIOS-style
+     * hostnames such as {@code SERVER_01} that have always been accepted
+     * by the legacy validator. Non-ASCII is intentionally not allowed -
+     * neither the UI vtype nor the legacy {@code hostnamePat} in
+     * {@code NetworkManagerImpl.TroubleshootingValidator} accept it.
+     */
+    HOSTNAME(
+        Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+        253,
+        "must be a valid hostname (alphanumeric, '.', '_', '-'; first char alphanumeric; max 253)"),
+
+    /**
+     * Linux interface name. Length 1-32 - matches the existing
+     * {@code INTERFACE_NAME_PATTERN} in {@code NetworkManagerImpl}
+     * (Linux kernel IFNAMSIZ is 16 but the codebase already accepts up
+     * to 32, so we match it for backwards compatibility).
+     * Allows ':' and '.' for aliases/VLANs ('eth0:0', 'eth0.1', 'br.eth0-1').
+     * Leading character must be alphanumeric - closes the argv-option-injection
+     * class (a value like '-rf' would otherwise be parsed as a flag by
+     * downstream CLI tools; the kernel itself does not allow leading '-' either).
+     */
+    INTERFACE(
+        Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._:-]*$"),
+        32,
+        "must be a valid interface name (alphanumeric, '.', '_', ':', '-'; first char alphanumeric; max 32)"),
+
+    /**
+     * Single-segment filename. Excludes '/' and '..'. The validator further
+     * rejects any value containing '..' as a substring or any '/' character.
+     * Path canonicalization at the sink is still required for TOCTOU safety.
+     */
+    FILENAME(
+        Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+        255,
+        "must be a valid filename (alphanumeric, '.', '_', '-'; no '..' or '/'; max 255)"),
+
+    /**
+     * Alphanumeric token with '_', '.', '-'. Length 1-64.
+     *
+     * <p>Widened from the original {@code [A-Za-z0-9_]+} to support
+     * real-world SNMP community strings that commonly include '-' or
+     * '.' (e.g. {@code "net-monitoring"}, {@code "site.east"}). The
+     * leading-character rule restricts the first char to
+     * {@code [A-Za-z0-9_]} - this keeps backwards compatibility with
+     * the legacy underscore-leading tokens AND blocks the
+     * argv-option-injection class (a value like {@code -rf} cannot pass
+     * because '-' is forbidden at position 0; a value like {@code .conf}
+     * is also blocked because '.' would be interpreted as an OID prefix
+     * in some snmpd directives).</p>
+     *
+     * <p>The remaining allowed characters ('-', '.', '_') are inert in
+     * every current sink: snmpd.conf is whitespace/newline-delimited,
+     * argv tokens are space-delimited, and none of these characters are
+     * shell metacharacters. Spaces, newlines, and the shell-meta set
+     * ({@code $ & ` ; | < > " ' \ * ?}) remain rejected.</p>
+     */
+    ALPHANUM(
+        Pattern.compile("^[A-Za-z0-9_][A-Za-z0-9._-]*$"),
+        64,
+        "must be alphanumeric (letters, digits, '_', '.', '-'; first char alphanumeric or '_'; max 64)"),
+
+    /**
+     * Permissive text for descriptions, contact strings, system locations.
+     * Allows Unicode letters, digits, whitespace, and the safe punctuation
+     * set [. _ - @ : , / + ( )]. Excludes shell metacharacters
+     * ({@code $ & ` ; | < > \n \r " '}).
+     */
+    SIMPLE_TEXT(
+        Pattern.compile("^[\\p{L}\\p{N}\\p{Zs}._@:,/+()-]{1,256}$"),
+        256,
+        "must contain only letters, digits, spaces, and the safe punctuation . _ - @ : , / + ( ) (max 256)"),
+
+    /**
+     * IPv4/IPv6 literal address (no DNS lookup) with optional CIDR prefix.
+     * Validated with pure-Java regexes - no third-party dependency. See
+     * {@link #IPV4_PATTERN} and {@link #IPV6_PATTERN}.
+     */
+    IP_OR_CIDR(
+        null, // validated programmatically, see validate()
+        49,   // longest IPv6 (39) + '/' + 3-digit prefix; 6 chars headroom
+        "must be a valid IPv4/IPv6 address or CIDR (no hostnames; e.g. 10.0.0.1 or 192.168.1.0/24)"),
+
+    /**
+     * List of {@link #IP_OR_CIDR} entries separated by commas, newlines,
+     * or both. Used for multi-CIDR fields like
+     * {@code IpsecVpnNetwork.remoteNetworks} (newline-separated in UI
+     * textarea) and {@code IpsecVpnTunnel.leftSubnet}/{@code rightSubnet}
+     * (comma-separated, natively supported by strongswan's
+     * {@code leftsubnet=} directive).
+     *
+     * <p><b>Whitespace handling:</b> each entry is trimmed before
+     * validation; blank entries are skipped. Accepts LF, CRLF, comma,
+     * or any combination as separators.</p>
+     *
+     * <p><b>Limits:</b> total string length lessthan equals 8192 chars; max 256
+     * entries - both well above the size of any realistic VPN config
+     * but bounded to avoid pathological input.</p>
+     */
+    IP_OR_CIDR_LIST(
+        null,  // validated programmatically, see validate()
+        8192,
+        "must be a comma- or newline-separated list of valid IPv4/IPv6 addresses or CIDRs (max 256 entries)"),
+
+    /** http(s) URL with required host and no embedded credentials. */
+    URL(
+        null, // validated programmatically, see validate()
+        2048,
+        "must be a valid http(s) URL with a host and no embedded credentials"),
+
+    /**
+     * Base64-encoded 32-byte key shape (e.g. WireGuard public/private keys).
+     * SHAPE-ONLY: this validates only the regex, NOT that the decoded
+     * payload is exactly 32 bytes. Sinks that need the strict 32-byte
+     * guarantee must additionally call their domain-specific check
+     * (e.g. {@code WireGuardVpnManager.isValidWGKey}).
+     */
+    BASE64_KEY(
+        Pattern.compile("^[A-Za-z0-9+/]{43}=$"),
+        44,
+        "must be a 44-character base64-encoded key"),
+
+    /**
+     * Free-form secret. Accepts any printable Unicode including shell
+     * metacharacters; rejects only control characters. See class
+     * Javadoc for the sink-side handling contract.
+     */
+    OPAQUE_SECRET(
+        null, // validated programmatically, see validate()
+        256,
+        "must be 1-256 characters; no control characters allowed");
+
+    /** Strict IPv4 dotted-quad: each octet 0-255, no leading zeros beyond a single 0. */
+    private static final Pattern IPV4_PATTERN = Pattern.compile(
+        "^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.){3}" +
+        "(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$");
+
+    /**
+     * IPv6 literal. Covers full form (8 groups), zero-compressed form (::),
+     * and IPv4-mapped tail (e.g. ::ffff:1.2.3.4). Excludes scope IDs (%eth0)
+     * and IPv6-in-brackets - both legal forms are not used in our settings.
+     */
+    private static final Pattern IPV6_PATTERN = Pattern.compile(
+        "^(" +
+            // full 8-group form
+            "([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}" +
+            "|" +
+            // :: at start (e.g. ::1, ::ffff:0:0)
+            "::([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,6})?" +
+            "|" +
+            // :: in middle (e.g. fe80::1, 2001:db8::1)
+            "([0-9A-Fa-f]{1,4}:){1,6}(:[0-9A-Fa-f]{1,4}){1,6}" +
+            "|" +
+            // :: at end (e.g. 2001:db8::)
+            "([0-9A-Fa-f]{1,4}:){1,7}:" +
+            "|" +
+            // IPv4-mapped tail in zero-compressed form (e.g. ::ffff:192.168.1.1)
+            "::([0-9A-Fa-f]{1,4}:){0,5}" +
+                "(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.){3}" +
+                "(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])" +
+            "|" +
+            // IPv4-mapped tail with explicit groups (e.g. 0:0:0:0:0:ffff:1.2.3.4)
+            "([0-9A-Fa-f]{1,4}:){6}" +
+                "(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\\.){3}" +
+                "(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])" +
+        ")$");
+
+    private final Pattern pattern;
+    private final int maxLength;
+    private final String defaultMessage;
+
+    SafeType(Pattern pattern, int maxLength, String defaultMessage)
+    {
+        this.pattern = pattern;
+        this.maxLength = maxLength;
+        this.defaultMessage = defaultMessage;
+    }
+
+    /**
+     * @return the per-type human-readable error message used when an
+     *         annotation does not supply its own {@code errorMessage()}.
+     */
+    public String defaultMessage()
+    {
+        return defaultMessage;
+    }
+
+    /**
+     * Validates a value against this type.
+     *
+     * <p><b>Null and empty policy:</b> {@code null} and {@code ""} always
+     * return {@code true}. Defaults across the codebase frequently use
+     * empty string for optional fields; rejecting those would break
+     * round-trips on unconfigured panels.</p>
+     *
+     * @param value the string to check (may be null / empty)
+     * @return {@code true} if the value is acceptable for this type,
+     *         {@code false} otherwise. Never throws - programmatic
+     *         validators (IP_OR_CIDR, URL) catch their own parser
+     *         exceptions and convert to {@code false}.
+     */
+    public boolean validate(String value)
+    {
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+        if (value.length() > maxLength) {
+            return false;
+        }
+
+        switch (this) {
+            case IP_OR_CIDR:
+                return validateIpOrCidr(value);
+            case IP_OR_CIDR_LIST:
+                return validateIpOrCidrList(value);
+            case URL:
+                return validateUrl(value);
+            case OPAQUE_SECRET:
+                return validateOpaqueSecret(value);
+            case FILENAME:
+                if (value.indexOf('/') >= 0 || value.contains("..")) {
+                    return false;
+                }
+                return pattern.matcher(value).matches();
+            default:
+                return pattern.matcher(value).matches();
+        }
+    }
+
+    /**
+     * Comma- or newline-separated IP_OR_CIDR list. Splits on any
+     * combination of commas, LF, and CRLF; trims each segment; skips
+     * blank entries; requires every non-empty segment to validate as
+     * IP_OR_CIDR. Bounded to 256 entries to prevent pathological input.
+     */
+    private static boolean validateIpOrCidrList(String value)
+    {
+        // Split on any run of commas/newlines (handles "1.1.1.1,\n2.2.2.2"
+        // and other mixed-separator forms).
+        String[] entries = value.split("[,\\r\\n]+", -1);
+        if (entries.length > 256) {
+            return false;
+        }
+        for (String entry : entries) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (!validateIpOrCidr(trimmed)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * IP literal (no DNS) optionally followed by a CIDR prefix length.
+     * Pure regex - no third-party dependency.
+     */
+    private static boolean validateIpOrCidr(String value)
+    {
+        String addressPart = value;
+        int slash = value.indexOf('/');
+        if (slash >= 0) {
+            addressPart = value.substring(0, slash);
+            String prefixPart = value.substring(slash + 1);
+            int prefix;
+            try {
+                prefix = Integer.parseInt(prefixPart);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+            if (prefix < 0) {
+                return false;
+            }
+            // Per-family prefix range check
+            if (IPV4_PATTERN.matcher(addressPart).matches()) {
+                if (prefix > 32) return false;
+            } else if (IPV6_PATTERN.matcher(addressPart).matches()) {
+                if (prefix > 128) return false;
+            } else {
+                return false;
+            }
+            return true;
+        }
+        return IPV4_PATTERN.matcher(addressPart).matches()
+            || IPV6_PATTERN.matcher(addressPart).matches();
+    }
+
+    /** http(s) URL with required host and no userinfo (no embedded credentials). */
+    private static boolean validateUrl(String value)
+    {
+        try {
+            URI uri = new URI(value);
+            String scheme = uri.getScheme();
+            if (scheme == null) {
+                return false;
+            }
+            scheme = scheme.toLowerCase();
+            if (!"http".equals(scheme) && !"https".equals(scheme)) {
+                return false;
+            }
+            if (uri.getHost() == null || uri.getHost().isEmpty()) {
+                return false;
+            }
+            if (uri.getUserInfo() != null) {
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /** Printable Unicode; reject any Cc-class control character. */
+    private static boolean validateOpaqueSecret(String value)
+    {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (Character.getType(c) == Character.CONTROL) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/UtCallbackController.java
+++ b/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/UtCallbackController.java
@@ -9,6 +9,8 @@ import java.lang.reflect.Method;
 import org.jabsorb.JSONRPCBridge;
 import org.jabsorb.callback.CallbackController;
 
+import com.untangle.uvm.util.SafeCheckValidator;
+
 /**
  * UtCallbackController
  */
@@ -34,7 +36,14 @@ public class UtCallbackController extends CallbackController
      * @param arguments
      */
     @Override
-    public void preInvokeCallback( Object context, Object instance, Method method, Object[] arguments ) { }
+    public void preInvokeCallback( Object context, Object instance, Method method, Object[] arguments )
+    {
+        if (arguments != null) {
+            for (Object arg : arguments) {
+                SafeCheckValidator.validateAll(arg);
+            }
+        }
+    }
 
     /**
      * postInvokeCallback

--- a/wan-failover/src/com/untangle/app/wan_failover/WanTestSettings.java
+++ b/wan-failover/src/com/untangle/app/wan_failover/WanTestSettings.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 import org.json.JSONString;
 
 import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * Settings for a given WAN Test
@@ -27,9 +28,9 @@ public class WanTestSettings implements Serializable, JSONString
     private Integer testHistorySize = 10;
     private Integer failureThreshold = 3;
 
-    @SafeCheck
+    @SafeCheck({SafeType.HOSTNAME, SafeType.IP_OR_CIDR})
     private String pingHostname;
-    @SafeCheck
+    @SafeCheck(SafeType.URL)
     private String httpUrl;
 
     public Boolean getEnabled()


### PR DESCRIPTION
**Summary**
Replaces the sanitization-based SafeCheck annotation with a typed, fail-fast validation model using a new SafeType enum. Annotated fields now declare what kind of value they accept (e.g. HOSTNAME, IP_OR_CIDR, INTERFACE, OPAQUE_SECRET); invalid values are rejected at the JSON-RPC boundary via the new SafeCheckValidationException, which Jabsorb propagates back to the client as a JSON-RPC error.

**Changes**

**New:** SafeType enum - typed allowlists with per-type regex/length rules and default error messages; every regex type enforces a leading alphanumeric character to block argv-option injection.

**New:** SafeCheckValidationException -  fail-fast exception that names the field but never echoes the offending value.

**Updated:** SafeCheck annotation now takes SafeType[] value() and an optional errorMessage() override.

**Updated:** SafeCheckValidator rewritten for fail-fast validation (was sanitization).

**Updated:** UtCallbackController (admin/setup/reports ) - propagate validation exceptions.

Migrated existing @SafeCheck fields to declare their SafeType across:

**IPsec VPN:** IpsecVpnNetwork, IpsecVpnSettings, IpsecVpnTunnel
**Network:** DeviceSettings, InterfaceSettings, NetworkSettings, StaticRoute
**UVM:** SnmpSettings, SystemSettings, UriManagerSettings
**WAN Failover:** WanTestSettings
