### PR TITLE
ngfw-15757 remediation of cybersecurity findings

### DIFF
--- a/.arista/secret_allowlist.yaml
+++ b/.arista/secret_allowlist.yaml
@@ -5,3 +5,14 @@ allowed_secrets:
   reason: >-
     Test-only RSA private key used as a fixture for certificate upload
     validation tests (test_021-test_025). Not used in any production code.
+- filepath_literal: "patch/prepare_system.sh"
+  category: FALSE_POSITIVE
+  reason: >-
+    Commented-out apt-repo URL using the well-known fixed "untangle" password
+    that ships on every deployed NGFW. Repo access is gated server-side by UID
+    and license, not by this password, so it is not a secret.
+- filepath_literal: "debian/control"
+  category: FALSE_POSITIVE
+  reason: >-
+    Substring of a base64 GPG signature/checksum block flagged by the Box
+    token regex. Not a credential.

--- a/i18ntools/translate.py
+++ b/i18ntools/translate.py
@@ -35,49 +35,6 @@ def process_test(po):
             value = "X" + record.msg_id + "X"
         po.records[record_index].msg_str = [value]
 
-def process_google(po):
-    for (record_index, record) in enumerate(po.records):
-        if record.msg_id == "":
-            continue
-#         if len("".join(record.msg_str)) > 0:
-#             continue
-
-#         # print(record.msg_id)
-#         # print(urllib.urlencode({"q": record.msg_id}))
-#         # continue
-#         # sys.exit(1)
-
-#         print(po.language)
-
-#         # lookoup via https
-#         # https://www.googleapis.com/language/translate/v2?key=AIzaSyBlJ_x_7BX0NbbLlbRWdGmGuc4W32jmZzs&source=en&target=fr&q=Press"%"20"%"5C"%"22Add"%"5C"%"22"%"20button"
-#         # -H "Origin: https://translate.google.com"
-#         # -H "Referer: https://translate.google.com/toolkit/workbench?did=006kzas00qnqw0jcshkw&hl=en"
-#         # -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36"
-#         #  --compressed
-#         key = "AIzaSyBlJ_x_7BX0NbbLlbRWdGmGuc4W32jmZzs"
-#         target = po.language
-#         headers = {
-#             "Origin": "https://translate.google.com",
-#             "Referer": "https://translate.google.com/toolkit/workbench?did=006kzas00qnqw0jcshkw&hl=en",
-#             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36"
-#         }
-# #        print(record.msg_id)
-#         query = "q=%7B0%7DThis+web+page+is+blocked%7B1%7D+because+it+violates+network+policy."
-#         c = httplib.HTTPSConnection("www.googleapis.com")
-#         c.request("GET", "/language/translate/v2?key="+key+"&source=en&target="+target+"&format=html&"+query, "", headers)
-#         response = c.getresponse()
-#         print(response.status, response.reason)
-#         data = response.read()
-#         print(data)
-#         rjson = json.loads(data)
-#         print(rjson)
-#         print(rjson["data"]["translations"][0]["translatedText"])
-#         parse = HTMLParser.HTMLParser()
-#         print(parse.unescape(u''+rjson["data"]["translations"][0]["translatedText"]))
-#         sys.exit(1)
-#         break
-
 def main(argv):
     language_ids = Languages.get_enabled_ids()
 
@@ -101,8 +58,6 @@ def main(argv):
         print("")
         if language["id"] == "xx":
             process_test(po)
-        else:
-            process_google(po)
         po.save()
 
     # otherwise, look at languages source and process

--- a/uvm/hier/usr/lib/python3/dist-packages/uvm/login_tools.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/uvm/login_tools.py
@@ -98,7 +98,7 @@ class Totp:
             raw_uri=file.read()
 
         # Format of file is:
-        # otpauth://totp/Edge%20Threat%20Management%20Appliance%20Login%20%28FirstName%20LastName%29?secret=O7OLTABU3XUPCD4Q7MWCZQR2I4JXF5MQTT5MYDHE5SHIGTWROUKZ2IIP6UPLTPBIZWKPYBBB4LSX2CAKWYS6RXWGSKKZDBWMC45N4SQ
+        # otpauth://totp/Edge%20Threat%20Management%20Appliance%20Login%20%28FirstName%20LastName%29?secret=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         # We need to extract the secret query parameter
 
         raw_uri = raw_uri.replace('\/', '/')


### PR DESCRIPTION
## Changes

| Path | Finding(s) | Action |
|---|---|---|
| `uvm/hier/usr/lib/python3/dist-packages/uvm/login_tools.py` | # 8 | Replaced an example TOTP base32 literal in a `#` documentation comment with an `XXXX...` placeholder. The comment shows the format of the per-appliance TOTP URI file; documentation intent is preserved. |
| `i18ntools/translate.py` | # 5, # 6 | Removed the dead `process_google()` function (already 100% commented out internally; contained the rotated-and-verified-dead Google Translate API key) and its caller in `main()`. The `xx` pseudo-locale path is unchanged; non-`xx` languages now load and save the PO file unchanged, which matches what the no-op function did before. |
| `.arista/secret_allowlist.yaml` | # 1, # 3 | Added two `FALSE_POSITIVE` entries with `category` and `reason` fields, matching the existing schema. |
