### PR TITLE
ngfw-15741: Added annotations over v2 calls generic class

### DIFF
--- a/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
@@ -10,6 +10,8 @@ import com.untangle.uvm.SystemSettings;
 import com.untangle.uvm.app.DayOfWeekMatcher;
 import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.util.Constants;
+import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 import org.json.JSONObject;
 import org.json.JSONString;
 import org.apache.commons.lang3.StringUtils;
@@ -44,7 +46,9 @@ public class SystemSettingsGeneric implements Serializable, JSONString {
     /**
      * These are required for Hostname Settings
      */
+    @SafeCheck(SafeType.HOSTNAME)
     private String hostName;
+    @SafeCheck(SafeType.HOSTNAME)
     private String domainName;
 
     private boolean supportEnabled = false;

--- a/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
@@ -9,6 +9,8 @@ import com.untangle.uvm.network.InterfaceSettings.DhcpType;
 import com.untangle.uvm.network.InterfaceSettings.InterfaceAlias;
 import com.untangle.uvm.network.InterfaceSettings.WirelessEncryption;
 import com.untangle.uvm.network.InterfaceSettings.WirelessMode;
+import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 import com.untangle.uvm.util.StringUtil;
 import org.json.JSONObject;
 import org.json.JSONString;
@@ -30,9 +32,13 @@ public class InterfaceSettingsGeneric implements Serializable, JSONString {
     private int interfaceId;        /* the ID of the physical interface (1-254) */
     private String name;            /* human name: ie External, Internal, Wireless */
 
+    @SafeCheck(SafeType.INTERFACE)
     private String  physicalDev;    /* physical interface name: eth0, etc */
+    @SafeCheck(SafeType.INTERFACE)
     private String  systemDev;      /* iptables interface name: eth0, eth0:0, eth0.1, etc */
+    @SafeCheck(SafeType.INTERFACE)
     private String  symbolicDev;    /* symbolic interface name: eth0, eth0:0, eth0.1, br.eth0 etc */
+    @SafeCheck(SafeType.INTERFACE)
     private String  imqDev;         /* IMQ device name: imq0, imq1, etc (only applies to WANs) */
     private String device;          /* physical interface name: eth0, etc */
 

--- a/uvm/api/com/untangle/uvm/network/generic/StaticRouteGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/StaticRouteGeneric.java
@@ -5,6 +5,8 @@ package com.untangle.uvm.network.generic;
 
 import com.untangle.uvm.app.IPMaskedAddress;
 import com.untangle.uvm.network.StaticRoute;
+import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
 import org.json.JSONObject;
 import org.json.JSONString;
 
@@ -25,6 +27,7 @@ public class StaticRouteGeneric implements JSONString, Serializable {
     private Integer ruleId;
     private String description;
     private String network;
+    @SafeCheck({SafeType.IP_OR_CIDR, SafeType.INTERFACE})
     private String nextHop;
 
     public StaticRouteGeneric() {}


### PR DESCRIPTION
**ISSUE :** 

The V2 settings flow (getNetworkSettingsV2 / setNetworkSettingsV2, setSystemSettingsV2, etc.) accepts *Generic POJOs from the UI -- SystemSettingsGeneric, InterfaceSettingsGeneric, StaticRouteGeneric. These Generic classes duplicate fields from their canonical counterparts (SystemSettings, InterfaceSettings, StaticRoute) but were missing the field-level SafeCheck annotations.

The JSON-RPC validator walks the received object's fields. Because the V2 entry point receives a *Generic instance, validation is performed against the Generic class. The canonical class's SafeCheck annotations never fire on this path -- *Generic.applyTo() calls plain Java setters (target.setX(this.x)) which bypass the validator entirely.

Net effect: any field hardened on the canonical class (e.g., InterfaceSettings.physicalDev with SafeCheck(INTERFACE)) was silently bypassed when the same value arrived via the V2 UI panels-- leaving open shell-injection / config-injection sinks downstream (sync-settings, dnsmasq, iptables, FRR).

**FIX :** 

Mirrored the canonical SafeCheck annotations onto the matching Generic fields:

SystemSettingsGeneric.java-- hostName, domainName --> HOSTNAME
InterfaceSettingsGeneric.java -- physicalDev, systemDev, symbolicDev, imqDev --> INTERFACE; dhcpDNSOverride --> IPV4_LITERAL
StaticRouteGeneric.java -- nextHop --> {IP_OR_CIDR, INTERFACE}