### PR TITLE
ngfw-15765/ ngfw-15766 - SafeCheckParam Validation Implementation

### DIFF
--- a/bandwidth-control/src/com/untangle/app/bandwidth_control/BandwidthControlApp.java
+++ b/bandwidth-control/src/com/untangle/app/bandwidth_control/BandwidthControlApp.java
@@ -14,6 +14,8 @@ import com.untangle.uvm.SettingsManager;
 import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.HookCallback;
 import com.untangle.uvm.util.I18nUtil;
+import com.untangle.uvm.util.SafeCheckParam;
+import com.untangle.uvm.util.SafeType; 
 import com.untangle.uvm.app.AppMetric;
 import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.vnet.Affinity;
@@ -221,7 +223,7 @@ public class BandwidthControlApp extends AppBase
      * This is called by the setup wizard
      * @param defaultConfiguration (ie "school")
      */
-    public void wizardLoadDefaults( String defaultConfiguration )
+    public void wizardLoadDefaults( @SafeCheckParam(SafeType.ALPHANUM) String defaultConfiguration )
     {
         SettingsManager settingsManager = UvmContextFactory.context().settingsManager();
         BandwidthControlSettings readSettings = null;

--- a/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/UtCallbackController.java
+++ b/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/UtCallbackController.java
@@ -4,11 +4,13 @@
 package com.untangle.uvm.reports.jabsorb;
 
 import java.io.Serializable;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 import org.jabsorb.JSONRPCBridge;
 import org.jabsorb.callback.CallbackController;
 
+import com.untangle.uvm.util.SafeCheckParam;
 import com.untangle.uvm.util.SafeCheckValidator;
 
 /**
@@ -46,8 +48,21 @@ public class UtCallbackController extends CallbackController
     public void preInvokeCallback(Object context, Object instance, Method method,
                                   Object[] arguments)
     {
-        if (arguments != null) {
-            for (Object arg : arguments) {
+        if (arguments == null) return;
+        Annotation[][] paramAnns = method.getParameterAnnotations();
+        String mLabel = method.getDeclaringClass().getSimpleName() + "." + method.getName();
+        for (int i = 0; i < arguments.length; i++) {
+            Object arg = arguments[i];
+            if (arg instanceof String) {
+                String s = (String) arg;
+                for (Annotation a : paramAnns[i]) {
+                    if (a instanceof SafeCheckParam) {
+                        SafeCheckParam scp = (SafeCheckParam) a;
+                        SafeCheckValidator.validate(s, scp.value(), scp.errorMessage(),
+                            mLabel + "(arg " + i + ")");
+                    }
+                }
+            } else {
                 SafeCheckValidator.validateAll(arg);
             }
         }

--- a/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
+++ b/tunnel-vpn/src/com/untangle/app/tunnel_vpn/TunnelVpnApp.java
@@ -33,6 +33,8 @@ import com.untangle.uvm.vnet.PipelineConnector;
 import com.untangle.uvm.servlet.UploadHandler;
 import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.network.InterfaceSettings;
+import com.untangle.uvm.util.SafeCheckParam;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * The Tunnel VPN application connects to 3rd party VPN tunnel providers.
@@ -444,7 +446,9 @@ public class TunnelVpnApp extends AppBase
      * @param tunnelId
      *        The tunnel ID
      */
-    public void importTunnelConfig(String filename, String provider, int tunnelId)
+    public void importTunnelConfig(@SafeCheckParam(SafeType.FILE_PATH) String filename,
+                                   @SafeCheckParam(SafeType.ALPHANUM)  String provider,
+                                   int tunnelId)
     {
         this.tunnelVpnManager.importTunnelConfig(filename, provider, tunnelId);
 

--- a/uvm/api/com/untangle/uvm/util/SafeCheckParam.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheckParam.java
@@ -1,0 +1,66 @@
+/**
+ * $Id$
+ */
+
+package com.untangle.uvm.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code String} parameter on a JSON-RPC method as requiring
+ * shell-safety validation. The Jabsorb {@code preInvokeCallback}
+ * inspects parameter annotations on each invoked method and routes
+ * annotated String arguments through
+ * {@link SafeCheckValidator#validate(String, SafeType[], String, String)}.
+ * A bad value raises {@link SafeCheckValidationException} which Jabsorb
+ * propagates to the client as a JSON-RPC error.
+ *
+ * <h3>Why a parameter-level analog to {@link SafeCheck}</h3>
+ * {@code @SafeCheck} only covers fields on POJOs that pass through
+ * {@code SafeCheckValidator.validateAll(Object)}. Raw {@code String}
+ * arguments to RPC methods (e.g. {@code setAdminPassword(String, String, String)})
+ * bypass that path entirely - {@code validateAll} short-circuits on
+ * {@code java.*} objects. {@code @SafeCheckParam} closes that gap.
+ *
+ * <h3>Usage</h3>
+ * <pre>
+ *   public void setAdminPassword(
+ *       &#64;SafeCheckParam(SafeType.OPAQUE_SECRET) String password,
+ *       &#64;SafeCheckParam(SafeType.EMAIL)         String email,
+ *       &#64;SafeCheckParam(SafeType.ALPHANUM)      String installType)
+ * </pre>
+ *
+ * <p>Multiple types specify OR-semantics, matching {@link SafeCheck}.</p>
+ *
+ * <h3>Where to declare it</h3>
+ * Place the annotation on the <b>implementation</b> method, not the
+ * interface. Jabsorb's {@code ClassAnalyzer} resolves methods via
+ * {@code Class.getMethods()} on the impl class, and Java's
+ * {@code Method.getParameterAnnotations()} does <b>not</b> inherit
+ * parameter annotations from interfaces.
+ *
+ * <h3>Null / empty policy</h3>
+ * Same as {@link SafeType#validate(String)}: {@code null} and {@code ""}
+ * are accepted by every type. Required-ness checks remain the caller
+ * layer's responsibility - this annotation speaks only to <i>content</i>.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface SafeCheckParam
+{
+    /**
+     * The {@link SafeType}(s) the parameter's value must match. The
+     * validator accepts the value if any listed type accepts it.
+     */
+    SafeType[] value();
+
+    /**
+     * Optional override for the per-type default error message. Empty
+     * string means "use the default message(s) of the listed types".
+     * The offending value is never echoed in the error.
+     */
+    String errorMessage() default "";
+}

--- a/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
@@ -316,6 +316,61 @@ public class SafeCheckValidator
     }
 
     /**
+     * Validate a single String value against an explicit SafeType list.
+     * Returns silently on success; throws
+     * {@link SafeCheckValidationException} on failure.
+     *
+     * <p>This is the entry point for the {@link SafeCheckParam}
+     * parameter-path used by the Jabsorb {@code preInvokeCallback}.
+     * It is a sibling to {@link #validateValue(String, SafeCheck, String)}
+     * (the field-path) - the two share identical OR-semantics and
+     * error-formatting rules, but stay independent so a change to one
+     * cannot regress the other.</p>
+     *
+     * <p>OR-semantics: the value is accepted if at least one listed
+     * type accepts it. The offending value is never echoed in the
+     * error message (avoids credential leakage and pivot through the
+     * error channel).</p>
+     *
+     * @param value           the value being checked (may be null - accepted by every type)
+     * @param types           the SafeType list to check against; null or empty falls back
+     *                        to {@link SafeType#SIMPLE_TEXT} with a one-time warning
+     * @param overrideMessage optional override for the per-type default error message;
+     *                        empty/null means concatenate the type defaults with " OR "
+     * @param contextLabel    short identifier for what is being validated
+     *                        (e.g. {@code "ClassName.method(arg 2)"}) used in the error
+     */
+    public static void validate(String value, SafeType[] types, String overrideMessage, String contextLabel)
+    {
+        if (types == null || types.length == 0) {
+            if (WARNED_EMPTY_VALUE.add("param:" + contextLabel)) {
+                logger.warn("@SafeCheckParam at {} has empty value() - falling back to SafeType.SIMPLE_TEXT. "
+                    + "Add an explicit SafeType to silence this warning.",
+                    contextLabel);
+            }
+            types = new SafeType[]{SafeType.SIMPLE_TEXT};
+        }
+
+        for (SafeType type : types) {
+            if (type.validate(value)) return;
+        }
+
+        String message;
+        if (overrideMessage != null && !overrideMessage.isEmpty()) {
+            message = overrideMessage;
+        } else {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < types.length; i++) {
+                if (i > 0) sb.append(" OR ");
+                sb.append(types[i].defaultMessage());
+            }
+            message = sb.toString();
+        }
+        throw new SafeCheckValidationException(
+            "Invalid value in " + contextLabel + ": " + message);
+    }
+
+    /**
      * Validate a single value against the SafeType list of an
      * annotation. Returns silently on success; throws
      * {@link SafeCheckValidationException} on failure.

--- a/uvm/api/com/untangle/uvm/util/SafeType.java
+++ b/uvm/api/com/untangle/uvm/util/SafeType.java
@@ -107,10 +107,19 @@ public enum SafeType
         "must be alphanumeric (letters, digits, '_', '.', '-'; first char alphanumeric or '_'; max 64)"),
 
     /**
-     * Permissive text for descriptions, contact strings, system locations.
-     * Allows Unicode letters, digits, whitespace, and the safe punctuation
-     * set [. _ - @ : , / + ( )]. Excludes shell metacharacters
-     * ({@code $ & ` ; | < > \n \r " '}).
+     * Permissive text for descriptions, contact strings, system locations,
+     * and natural-language names like {@code O'Brien} or {@code John's Folder}.
+     * Allows Unicode letters, digits, whitespace, the safe punctuation
+     * set [. _ - @ : , / + ( )], and the apostrophe ['].
+     * Excludes shell metacharacters ({@code $ & ` ; | < > \n \r "}).
+     *
+     * <p>The apostrophe is permitted because every current sink consumes
+     * {@code SIMPLE_TEXT} values either argv-form (e.g. openssl), URL-encoded
+     * (URIBuilder), or as JSON HTTP-body content - none string-concatenate
+     * the value into a shell command line. Future sinks that do shell
+     * interpolation must quote with {@code shlex.quote(...)} (Python) or
+     * {@code execCommand(List.of(...))} (Java); this is the same contract
+     * already required for {@link #OPAQUE_SECRET}.</p>
      */
     SIMPLE_TEXT(
         Pattern.compile("^[\\p{L}\\p{N}\\p{Zs}._@:,/+()-]{1,256}$"),
@@ -174,7 +183,144 @@ public enum SafeType
     OPAQUE_SECRET(
         null, // validated programmatically, see validate()
         256,
-        "must be 1-256 characters; no control characters allowed");
+        "must be 1-256 characters; control characters (NUL, ESC, BEL, etc.) are not allowed"),
+
+    /**
+     * RFC 5321-style email address. Length 1-254 (the SMTP path limit).
+     * Pattern requires a single '@', a non-empty local part starting
+     * with an alphanumeric character (closes argv-option-injection),
+     * and a domain with at least one dot and a 2+ letter TLD. The
+     * local-part character class is the conservative subset
+     * {@code [A-Za-z0-9._%+-]} - quoted-local-parts and IP-literal
+     * domains are not accepted; neither has ever been used in this
+     * codebase's UI flows.
+     */
+    EMAIL(
+        Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._%+-]*@[A-Za-z0-9][A-Za-z0-9.-]*\\.[A-Za-z]{2,}$"),
+        254,
+        "must be an email address like user@example.com , local part must start with a letter or digit, domain must have at least one dot and a 2+ letter TLD (max 254 chars)"),
+
+    /**
+     * Multi-line email subject/body template that may contain
+     * {@code ${var}} placeholders. Length up to 8192 chars to fit
+     * realistic alert templates with multiple variable substitutions.
+     *
+     * <p>Validated programmatically: rejects any character whose
+     * Unicode category is {@code Cc} (control) <i>except</i> the line
+     * separators {@code \r} and {@code \n} and the horizontal tab
+     * {@code \t}. This blocks NUL, ESC, BEL, etc. - vectors that could
+     * be smuggled into a subject header or body for downstream
+     * mail-injection - while preserving normal multiline content.</p>
+     */
+    EMAIL_TEMPLATE(
+        null, // validated programmatically, see validate()
+        8192,
+        "must contain only printable text, line breaks (CR/LF), and tabs , other control characters (NUL, ESC, BEL, etc.) are not allowed (max 8192 chars)"),
+
+    /**
+     * PEM-encoded data block (certificate, key, or chain). Length cap
+     * 16384 chars - sized to cover a worst-case real-world chain
+     * (server + 3 RSA-4096 intermediates &asymp; 9-12 KB) with margin
+     * for unusual but legitimate cases (cross-sign certs, long DNs).
+     * Rejects gross abuse (multi-MB blobs) without blocking real uploads.
+     *
+     * <p>Validated programmatically: requires at least one
+     * {@code -----BEGIN <LABEL>-----} ... {@code -----END <LABEL>-----}
+     * envelope; permits multiple concatenated blocks separated by
+     * whitespace (legal for cert chains). Body characters between the
+     * BEGIN/END markers are restricted to the base64 alphabet plus
+     * whitespace. Cryptographic validity is <b>not</b> checked here -
+     * the OpenSSL sink layer handles that.</p>
+     */
+    PEM(
+        null, // validated programmatically, see validate()
+        16384,
+        "must be a PEM block bounded by -----BEGIN ...----- and -----END ...----- markers with a base64 body (max 16 KB)"),
+
+    /**
+     * X.500 distinguished name as composed by the certificate UI:
+     * {@code /CN=Foo/C=US/ST=CA/L=City/O=Org} etc. Each RDN is a 1-4
+     * letter type label, an {@code =}, and a value drawn from the
+     * conservative subset {@code [A-Za-z0-9 ._@:+()*-]}. No quoted
+     * RDNs, no embedded slashes inside values - both legal in X.500
+     * but neither used by the UI dialog. {@code *} is permitted to
+     * support wildcard CNs (e.g. {@code /CN=*.example.com}); this is
+     * safe because the value is passed argv-form to openssl and never
+     * interpreted by a shell. Length capped at 512.
+     */
+    CERT_SUBJECT(
+        Pattern.compile("^/[A-Za-z]{1,4}=[A-Za-z0-9 ._@:+()*-]+(/[A-Za-z]{1,4}=[A-Za-z0-9 ._@:+()*-]+)*$"),
+        512,
+        "each field in the certificate subject must be non-empty and use only letters, digits, spaces, or . _ @ : + ( ) * - (e.g. /CN=Host/C=US/ST=California/L=City/O=Org or /CN=*.example.com; max 512 chars)"),
+
+    /**
+     * X.509 Subject Alternative Name list as composed by the certificate
+     * UI. Comma-separated entries; each entry is one of:
+     * <ul>
+     *   <li>{@code DNS:hostname} or {@code DNS:*.hostname} (wildcard SAN)</li>
+     *   <li>{@code IP:ipv4}</li>
+     *   <li>bare hostname (with optional {@code *.} prefix)</li>
+     *   <li>bare IPv4 literal</li>
+     * </ul>
+     *
+     * <p>Length cap 1024 - covers realistic multi-SAN certs without
+     * permitting pathological input. Each entry is trimmed; blank
+     * entries are skipped.</p>
+     *
+     * <p>Sink: passed argv-form to openssl as the {@code subjectAltName}
+     * extension. {@code *} is permitted for wildcard SANs and is not a
+     * shell metacharacter in this argv path.</p>
+     */
+    SAN_LIST(
+        null,  // validated programmatically, see validate()
+        1024,
+        "must be a comma-separated list of SAN entries (e.g. DNS:host.example.com, DNS:*.example.com, IP:10.0.0.1; max 1024 chars)"),
+
+    /**
+     * Regular-expression pattern. Permits any printable Unicode -
+     * including all regex metacharacters ({@code . * + ? ^ $ ( ) [ ] { } | \})
+     * and chars like {@code $ & ;} - so legitimate patterns such as
+     * {@code .*\/network.*} or {@code ^/etc/.*\.conf$} are not rejected.
+     *
+     * <p>The only chars rejected are control characters (Unicode {@code Cc}
+     * category) other than the horizontal tab. This blocks NUL, ESC, BEL,
+     * CR, LF - vectors for log-line smuggling, terminal-escape injection,
+     * and string-truncation in C-based regex engines.</p>
+     *
+     * <p>Length cap 1024 - large enough for any realistic regex, small
+     * enough to bound pathological input.</p>
+     *
+     * <p><b>Sink contract:</b> use only when the value is passed
+     * <i>argv-form</i> (e.g. {@code execCommand(script, List.of(..., regex))}).
+     * Never string-concatenate a {@code REGEX_PATTERN} value into a shell
+     * command line - regex chars like {@code $ ` ( )} are also shell metas
+     * and will execute if the value reaches a shell.</p>
+     */
+    REGEX_PATTERN(
+        null,  // validated programmatically, see validate()
+        1024,
+        "must be a regular expression up to 1024 characters; control characters (NUL, ESC, BEL, CR, LF) are not allowed"),
+
+    /**
+     * Absolute filesystem path for a server-controlled file (e.g. a
+     * tempfile path returned by an upload handler). Length up to 4096
+     * (Linux {@code PATH_MAX}).
+     *
+     * <p>Pattern: must begin with {@code /} (absolute) - this closes the
+     * argv-option-injection class (a value starting with {@code -}
+     * cannot pass). Body characters limited to
+     * {@code [A-Za-z0-9._/-]} - no whitespace, no shell metacharacters,
+     * no backslash. The validator additionally rejects any {@code ..}
+     * substring to block path traversal.</p>
+     *
+     * <p>This is a content check only; canonicalisation and the
+     * "must live under {@code /tmp/...}" check (where applicable)
+     * remain the responsibility of the sink.</p>
+     */
+    FILE_PATH(
+        Pattern.compile("^/[A-Za-z0-9._/-]+$"),
+        4096,
+        "must be an absolute path starting with '/' using only letters, digits, '.', '_', '/', or '-' , no '..', whitespace, or shell metacharacters (max 4096 chars)");
 
     /** Strict IPv4 dotted-quad: each octet 0-255, no leading zeros beyond a single 0. */
     private static final Pattern IPV4_PATTERN = Pattern.compile(
@@ -275,8 +421,21 @@ public enum SafeType
                 return validateUrl(value);
             case OPAQUE_SECRET:
                 return validateOpaqueSecret(value);
+            case EMAIL_TEMPLATE:
+                return validateEmailTemplate(value);
+            case PEM:
+                return validatePem(value);
+            case SAN_LIST:
+                return validateSanList(value);
+            case REGEX_PATTERN:
+                return validateRegexPattern(value);
             case FILENAME:
                 if (value.indexOf('/') >= 0 || value.contains("..")) {
+                    return false;
+                }
+                return pattern.matcher(value).matches();
+            case FILE_PATH:
+                if (value.contains("..")) {
                     return false;
                 }
                 return pattern.matcher(value).matches();
@@ -309,6 +468,78 @@ public enum SafeType
                 continue;
             }
             if (!validateIpOrCidr(trimmed)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Hostname segment with optional leading '*.' wildcard. */
+    private static final Pattern SAN_HOSTNAME_PATTERN = Pattern.compile(
+        "^(\\*\\.)?[A-Za-z0-9][A-Za-z0-9._-]*$");
+
+    /**
+     * Comma-separated SAN list. Each entry is one of:
+     *   DNS:hostname (with optional '*.' wildcard)
+     *   IP:ipv4
+     *   bare hostname (with optional '*.' wildcard)
+     *   bare ipv4
+     * Bounded to 64 entries; blank entries skipped.
+     *
+     * @param value the candidate list; assumed non-null and non-empty.
+     * @return {@code true} if every non-blank entry parses as one of the
+     *         shapes above; {@code false} otherwise.
+     */
+    private static boolean validateSanList(String value)
+    {
+        String[] entries = value.split(",", -1);
+        if (entries.length > 64) {
+            return false;
+        }
+        for (String entry : entries) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            String body = trimmed;
+            if (trimmed.startsWith("DNS:")) {
+                body = trimmed.substring(4);
+                if (body.isEmpty()) return false;
+                if (!SAN_HOSTNAME_PATTERN.matcher(body).matches()) return false;
+            } else if (trimmed.startsWith("IP:")) {
+                body = trimmed.substring(3);
+                if (body.isEmpty()) return false;
+                if (!IPV4_PATTERN.matcher(body).matches()
+                    && !IPV6_PATTERN.matcher(body).matches()) {
+                    return false;
+                }
+            } else {
+                // bare entry: IPv4 literal or hostname (with optional '*.' )
+                if (!IPV4_PATTERN.matcher(trimmed).matches()
+                    && !SAN_HOSTNAME_PATTERN.matcher(trimmed).matches()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Regex pattern body. Permissive: rejects only Unicode {@code Cc}
+     * (control) characters other than the horizontal tab. All other
+     * printable code points - including regex metas {@code . * + ? ^ $ ( ) [ ] { } | \}
+     * and shell-shaped chars like {@code $ & ;} - are accepted.
+     *
+     * @param value the candidate regex; assumed non-null and non-empty.
+     * @return {@code true} if {@code value} contains no disallowed control
+     *         characters; {@code false} otherwise.
+     */
+    private static boolean validateRegexPattern(String value)
+    {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\t') continue;
+            if (Character.getType(c) == Character.CONTROL) {
                 return false;
             }
         }
@@ -400,6 +631,85 @@ public enum SafeType
             if (Character.getType(c) == Character.CONTROL) {
                 return false;
             }
+        }
+        return true;
+    }
+
+    /**
+     * Multi-line template body. Permits CR, LF, and TAB; rejects every
+     * other Cc-class control character (NUL, ESC, BEL, etc.) - those are
+     * the vectors for SMTP header smuggling and similar downstream
+     * mail-injection attacks.
+     *
+     * @param value the candidate template string; assumed non-null and non-empty.
+     * @return {@code true} if no disallowed control characters are present.
+     */
+    private static boolean validateEmailTemplate(String value)
+    {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\r' || c == '\n' || c == '\t') continue;
+            if (Character.getType(c) == Character.CONTROL) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Recognises lines like "-----BEGIN CERTIFICATE-----" / "-----END CERTIFICATE-----". */
+    private static final Pattern PEM_BEGIN = Pattern.compile("-----BEGIN ([A-Z0-9 ]+)-----");
+    private static final Pattern PEM_END   = Pattern.compile("-----END ([A-Z0-9 ]+)-----");
+
+    /** Base64 alphabet plus PEM line-wrap whitespace. */
+    private static final Pattern PEM_BODY_CHARS = Pattern.compile("^[A-Za-z0-9+/=\\s]*$");
+
+    /**
+     * PEM envelope check. Requires at least one
+     * {@code -----BEGIN <LABEL>-----} ... {@code -----END <LABEL>-----}
+     * pair with matching label and a base64-only body. Permits multiple
+     * concatenated blocks (cert chain) separated by whitespace. Rejects
+     * any character outside the base64 alphabet within a block - this
+     * blocks shell metacharacter smuggling between BEGIN/END markers.
+     *
+     * <p>Cryptographic validity is not checked - the OpenSSL sink
+     * parses the PEM for real before use.</p>
+     *
+     * @param value the candidate PEM string; assumed non-null and non-empty.
+     * @return {@code true} if at least one well-formed envelope is present
+     *         and the entire input parses as a sequence of envelopes.
+     */
+    private static boolean validatePem(String value)
+    {
+        java.util.regex.Matcher beginM = PEM_BEGIN.matcher(value);
+        java.util.regex.Matcher endM   = PEM_END.matcher(value);
+        int pos = 0;
+        int blocks = 0;
+        while (beginM.find(pos)) {
+            int beginStart = beginM.start();
+            int beginEnd   = beginM.end();
+            String label   = beginM.group(1);
+
+            // Anything between pos and beginStart must be whitespace
+            // (blank lines or stray newlines between blocks are legal;
+            // shell metacharacters / commentary are not).
+            for (int i = pos; i < beginStart; i++) {
+                if (!Character.isWhitespace(value.charAt(i))) return false;
+            }
+
+            if (!endM.find(beginEnd)) return false;
+            if (!label.equals(endM.group(1))) return false; // mismatched label
+
+            String body = value.substring(beginEnd, endM.start());
+            if (!PEM_BODY_CHARS.matcher(body).matches()) return false;
+
+            pos = endM.end();
+            blocks++;
+        }
+        if (blocks == 0) return false;
+
+        // Trailing whitespace (only) after the last END marker is OK.
+        for (int i = pos; i < value.length(); i++) {
+            if (!Character.isWhitespace(value.charAt(i))) return false;
         }
         return true;
     }

--- a/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
@@ -38,6 +38,8 @@ import com.untangle.uvm.servlet.UploadHandler;
 import com.untangle.uvm.servlet.DownloadHandler;
 import com.untangle.uvm.network.InterfaceSettings;
 import com.untangle.uvm.util.I18nUtil;
+import com.untangle.uvm.util.SafeCheckParam;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * The Certificate Manager handles the internal certificate authority that is
@@ -398,7 +400,7 @@ public class CertificateManagerImpl implements CertificateManager
      * @return The certificate details
      */
     // called by getCertificateList to retrieve details about a certificate
-    public CertificateInformation getServerCertificateInformation(String fileName)
+    public CertificateInformation getServerCertificateInformation(@SafeCheckParam(SafeType.FILENAME) String fileName)
     {
         CertificateInformation certInfo = new CertificateInformation();
         FileInputStream certStream;
@@ -569,7 +571,7 @@ public class CertificateManagerImpl implements CertificateManager
      * 
      * @return The CA root certificate details
      */
-    public CertificateInformation getRootCertificateInformation(String fileName)
+    public CertificateInformation getRootCertificateInformation(@SafeCheckParam(SafeType.FILENAME) String fileName)
     {
         CertificateInformation certInfo = new CertificateInformation();
         X509Certificate certObject;
@@ -603,7 +605,8 @@ public class CertificateManagerImpl implements CertificateManager
      *        The subject for the new CA root certificate
      * @return True
      */
-    public boolean generateCertificateAuthority(String commonName, String certSubject)
+    public boolean generateCertificateAuthority(@SafeCheckParam(SafeType.SIMPLE_TEXT) String commonName,
+                                                @SafeCheckParam(SafeType.CERT_SUBJECT) String certSubject)
     {
         try {
             rejectSuspiciousCharacter(commonName, "commonName");
@@ -641,7 +644,8 @@ public class CertificateManagerImpl implements CertificateManager
      *        The subject alternative names for the new certificate
      * @return True
      */
-    public boolean generateServerCertificate(String certSubject, String altNames)
+    public boolean generateServerCertificate(@SafeCheckParam(SafeType.CERT_SUBJECT) String certSubject,
+                                             @SafeCheckParam(SafeType.SAN_LIST)    String altNames)
     {
         try {
             rejectSuspiciousCharacter(altNames, "altNames");
@@ -732,7 +736,10 @@ public class CertificateManagerImpl implements CertificateManager
      *        Optional intermediate certificates
      * @return The result of the operation
      */
-    public ExecManagerResult uploadCertificate(String certMode, String certData, String keyData, String extraData)
+    public ExecManagerResult uploadCertificate(@SafeCheckParam(SafeType.ALPHANUM) String certMode,
+                                               @SafeCheckParam(SafeType.PEM)      String certData,
+                                               @SafeCheckParam(SafeType.PEM)      String keyData,
+                                               @SafeCheckParam(SafeType.PEM)      String extraData)
     {
         String baseName = Long.toString(System.currentTimeMillis() / 1000l);
         int certLen = 0;
@@ -832,7 +839,8 @@ public class CertificateManagerImpl implements CertificateManager
      *        Optional intermediate certificates
      * @return The result of the operation
      */
-    public ExecManagerResult importSignedRequest(String certData, String extraData)
+    public ExecManagerResult importSignedRequest(@SafeCheckParam(SafeType.PEM) String certData,
+                                                 @SafeCheckParam(SafeType.PEM) String extraData)
     {
         String baseName = Long.toString(System.currentTimeMillis() / 1000l);
         FileOutputStream fileStream = null;
@@ -901,7 +909,8 @@ public class CertificateManagerImpl implements CertificateManager
      * @param fileName
      *        The certificate file to delete
      */
-    public void removeCertificate(String type, String fileName)
+    public void removeCertificate(@SafeCheckParam(SafeType.ALPHANUM) String type,
+                                  @SafeCheckParam(SafeType.FILENAME) String fileName)
     {
         String fileBase;
         int dotLocation;

--- a/uvm/impl/com/untangle/uvm/CloudManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CloudManagerImpl.java
@@ -29,6 +29,9 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 
+import com.untangle.uvm.util.SafeCheckParam;
+import com.untangle.uvm.util.SafeType;
+
 /**
  * The cloud manager
  */
@@ -76,7 +79,8 @@ public class CloudManagerImpl implements CloudManager
      * @return The login result
      * @throws Exception
      */
-    public JSONObject accountLogin(String email, String password) throws Exception
+    public JSONObject accountLogin(@SafeCheckParam(SafeType.EMAIL)         String email,
+                                   @SafeCheckParam(SafeType.OPAQUE_SECRET) String password) throws Exception
     {
         return accountLogin(email, password, UvmContextImpl.getInstance().getServerUID(), "", "", "");
     }
@@ -99,7 +103,12 @@ public class CloudManagerImpl implements CloudManager
      * @return The login result
      * @throws Exception
      */
-    public JSONObject accountLogin(String email, String password, String uid, String applianceModel, String majorVersion, String installType) throws Exception
+    public JSONObject accountLogin(@SafeCheckParam(SafeType.EMAIL)         String email,
+                                   @SafeCheckParam(SafeType.OPAQUE_SECRET) String password,
+                                   @SafeCheckParam(SafeType.ALPHANUM)      String uid,
+                                   @SafeCheckParam(SafeType.ALPHANUM)      String applianceModel,
+                                   @SafeCheckParam(SafeType.ALPHANUM)      String majorVersion,
+                                   @SafeCheckParam(SafeType.ALPHANUM)      String installType) throws Exception
     {
         try {
             CloseableHttpClient httpClient = HttpClients.custom().build();
@@ -159,7 +168,15 @@ public class CloudManagerImpl implements CloudManager
      * @return The create account result
      * @throws Exception
      */
-    public JSONObject accountCreate(String email, String password, String firstName, String lastName, String companyName, String uid, String applianceModel, String majorVersion, String installType) throws Exception
+    public JSONObject accountCreate(@SafeCheckParam(SafeType.EMAIL)         String email,
+                                    @SafeCheckParam(SafeType.OPAQUE_SECRET) String password,
+                                    @SafeCheckParam(SafeType.SIMPLE_TEXT)   String firstName,
+                                    @SafeCheckParam(SafeType.SIMPLE_TEXT)   String lastName,
+                                    @SafeCheckParam(SafeType.SIMPLE_TEXT)   String companyName,
+                                    @SafeCheckParam(SafeType.ALPHANUM)      String uid,
+                                    @SafeCheckParam(SafeType.ALPHANUM)      String applianceModel,
+                                    @SafeCheckParam(SafeType.ALPHANUM)      String majorVersion,
+                                    @SafeCheckParam(SafeType.ALPHANUM)      String installType) throws Exception
     {
         try {
             CloseableHttpClient httpClient = HttpClients.custom().build();

--- a/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
@@ -11,6 +11,8 @@ import com.untangle.uvm.network.DhcpStaticEntry;
 import com.untangle.uvm.network.DeviceStatus;
 import com.untangle.uvm.event.EventSettings;
 import com.untangle.uvm.app.Reporting;
+import com.untangle.uvm.util.SafeCheckParam;
+import com.untangle.uvm.util.SafeType;
 
 import java.text.SimpleDateFormat;
 import java.util.LinkedList;
@@ -236,7 +238,7 @@ public class ConfigManagerImpl implements ConfigManager
      *        The new host name
      * @return A JSON object with the old and new hostname
      */
-    public JSONObject setHostName(String argName)
+    public JSONObject setHostName(@SafeCheckParam(SafeType.HOSTNAME) String argName)
     {
         logger.info("CMAN_HIST setHostName() = {}", argName);
 
@@ -273,7 +275,7 @@ public class ConfigManagerImpl implements ConfigManager
      *        The new domain name
      * @return A JSON object with the old and new domain name
      */
-    public JSONObject setDomainName(String argName)
+    public JSONObject setDomainName(@SafeCheckParam(SafeType.HOSTNAME) String argName)
     {
         logger.info("CMAN_HIST setDomainName() = {}", argName);
 
@@ -759,7 +761,8 @@ public class ConfigManagerImpl implements ConfigManager
      *        should not be replaced by content in the backup.
      * @return A JSON object with the result code and message
      */
-    public Object restoreSystemBackup(String argFileName, String maintainRegex)
+    public Object restoreSystemBackup(@SafeCheckParam(SafeType.FILE_PATH)     String argFileName,
+                                      @SafeCheckParam(SafeType.REGEX_PATTERN) String maintainRegex)
     {
         logger.info("CMAN_HIST restoreSystemBackup() = {}|{}", argFileName , maintainRegex);
 

--- a/uvm/impl/com/untangle/uvm/EventManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/EventManagerImpl.java
@@ -17,6 +17,8 @@ import com.untangle.uvm.event.TriggerRule;
 import com.untangle.uvm.logging.LogEvent;
 import com.untangle.uvm.util.Constants;
 import com.untangle.uvm.util.I18nUtil;
+import com.untangle.uvm.util.SafeCheckParam;
+import com.untangle.uvm.util.SafeType;
 import com.untangle.uvm.util.StringUtil;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
@@ -372,7 +374,10 @@ public class EventManagerImpl implements EventManager
      * @param  convert         If true, pass convert to human readable.  Otherwise, don't.
      * @return                 Map containing emailSubject and emailBody.
      */
-    public Map<String, String> emailAlertFormatPreview(AlertRule rule, LogEvent event, String subjectTemplate, String bodyTemplate, boolean convert){
+    public Map<String, String> emailAlertFormatPreview(AlertRule rule, LogEvent event,
+                                                       @SafeCheckParam(SafeType.EMAIL_TEMPLATE) String subjectTemplate,
+                                                       @SafeCheckParam(SafeType.EMAIL_TEMPLATE) String bodyTemplate,
+                                                       boolean convert){
         if(mostRecentPreviewEvent != null){
             event = mostRecentPreviewEvent;
         }

--- a/uvm/impl/com/untangle/uvm/GoogleManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/GoogleManagerImpl.java
@@ -10,6 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 
 import com.untangle.uvm.util.Pulse;
+import com.untangle.uvm.util.SafeCheckParam;
+import com.untangle.uvm.util.SafeType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -314,7 +316,7 @@ public class GoogleManagerImpl implements GoogleManager
      * @return
      */
     @Override
-    public String getAppSpecificGoogleDrivePath(String appDirectory) {
+    public String getAppSpecificGoogleDrivePath(@SafeCheckParam(SafeType.ALPHANUM) String appDirectory) {
         if (getSettings() == null)
             return null;
 
@@ -334,7 +336,8 @@ public class GoogleManagerImpl implements GoogleManager
      * @param windowLocation domain/hostname
      * @return Built URL
      */
-    public String getAuthorizationUrl( String windowProtocol, String windowLocation )
+    public String getAuthorizationUrl( @SafeCheckParam(SafeType.SIMPLE_TEXT) String windowProtocol,
+                                       @SafeCheckParam(SafeType.SIMPLE_TEXT) String windowLocation )
     {
         try {
             URIBuilder builder = new URIBuilder(this.cloudOAuth2App.getAuthUri());
@@ -396,7 +399,7 @@ public class GoogleManagerImpl implements GoogleManager
      * @param code the code to send.
      * @return null on success or the error string
      */
-    public String provideDriveCode( String code )
+    public String provideDriveCode( @SafeCheckParam(SafeType.SIMPLE_TEXT) String code )
     {
         logger.info("Providing code [{}] to exchange for the access token", code);
 
@@ -687,7 +690,8 @@ public class GoogleManagerImpl implements GoogleManager
      * @throws GoogleDriveOperationFailedException
      */
     @Override
-    public int uploadToDrive(String filePath, String parentFolder) throws GoogleDriveOperationFailedException {
+    public int uploadToDrive(@SafeCheckParam(SafeType.FILE_PATH) String filePath,
+                             @SafeCheckParam(SafeType.SIMPLE_TEXT) String parentFolder) throws GoogleDriveOperationFailedException {
         if (StringUtils.isBlank(filePath)) {
             throw new GoogleDriveOperationFailedException("File path not present, not uploading");
         }

--- a/uvm/impl/com/untangle/uvm/MailSenderImpl.java
+++ b/uvm/impl/com/untangle/uvm/MailSenderImpl.java
@@ -53,6 +53,8 @@ import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.MailSettings.SendMethod;
 import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.util.I18nUtil;
+import com.untangle.uvm.util.SafeCheckParam;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * Note that this class is designed to be used <b>BOTH</b> inside the UVM and as
@@ -421,7 +423,7 @@ public class MailSenderImpl implements MailSender
      *        The recipient
      * @return The send result
      */
-    public String sendTestMessage(String recipient)
+    public String sendTestMessage(@SafeCheckParam(SafeType.EMAIL) String recipient)
     {
         UvmContext context = UvmContextFactory.context();
         Map<String, String> i18nMap = context.languageManager().getTranslations("untangle");

--- a/uvm/servlets/admin/src/com/untangle/uvm/admin/jabsorb/UtCallbackController.java
+++ b/uvm/servlets/admin/src/com/untangle/uvm/admin/jabsorb/UtCallbackController.java
@@ -4,11 +4,13 @@
 package com.untangle.uvm.admin.jabsorb;
 
 import java.io.Serializable;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 import org.jabsorb.JSONRPCBridge;
 import org.jabsorb.callback.CallbackController;
 
+import com.untangle.uvm.util.SafeCheckParam;
 import com.untangle.uvm.util.SafeCheckValidator;
 
 /**
@@ -38,8 +40,21 @@ public class UtCallbackController extends CallbackController
     @Override
     public void preInvokeCallback(Object context, Object instance, Method method, Object[] arguments)
     {
-        if (arguments != null) {
-            for (Object arg : arguments) {
+        if (arguments == null) return;
+        Annotation[][] paramAnns = method.getParameterAnnotations();
+        String mLabel = method.getDeclaringClass().getSimpleName() + "." + method.getName();
+        for (int i = 0; i < arguments.length; i++) {
+            Object arg = arguments[i];
+            if (arg instanceof String) {
+                String s = (String) arg;
+                for (Annotation a : paramAnns[i]) {
+                    if (a instanceof SafeCheckParam) {
+                        SafeCheckParam scp = (SafeCheckParam) a;
+                        SafeCheckValidator.validate(s, scp.value(), scp.errorMessage(),
+                            mLabel + "(arg " + i + ")");
+                    }
+                }
+            } else {
                 SafeCheckValidator.validateAll(arg);
             }
         }

--- a/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/SetupContextImpl.java
+++ b/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/SetupContextImpl.java
@@ -27,6 +27,8 @@ import com.untangle.uvm.SystemSettings;
 import com.untangle.uvm.WizardSettings;
 import com.untangle.uvm.network.InterfaceSettings;
 import com.untangle.uvm.AdminUserSettings;
+import com.untangle.uvm.util.SafeCheckParam;
+import com.untangle.uvm.util.SafeType;
 /** SetupContextImpl */
 public class SetupContextImpl implements UtJsonRpcServlet.SetupContext
 {
@@ -52,7 +54,8 @@ public class SetupContextImpl implements UtJsonRpcServlet.SetupContext
      * @param language
      * @param source
      */
-    public void setLanguage( String language, String source )
+    public void setLanguage( @SafeCheckParam(SafeType.ALPHANUM) String language,
+                             @SafeCheckParam(SafeType.ALPHANUM) String source )
     {
         LanguageManager lm = this.context.languageManager();
         LanguageSettings ls = lm.getLanguageSettings();
@@ -68,7 +71,9 @@ public class SetupContextImpl implements UtJsonRpcServlet.SetupContext
      * @param installType
      * @throws TransactionRolledbackException
      */
-    public void setAdminPassword( String password, String email, String installType ) throws TransactionRolledbackException
+    public void setAdminPassword( @SafeCheckParam(SafeType.OPAQUE_SECRET) String password,
+                                  @SafeCheckParam(SafeType.EMAIL)         String email,
+                                  @SafeCheckParam(SafeType.ALPHANUM)      String installType ) throws TransactionRolledbackException
     {
         AdminSettings adminSettings = this.context.adminManager().getSettings();
         SystemSettings systemSettings = this.context.systemManager().getSettings();

--- a/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/UtCallbackController.java
+++ b/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/UtCallbackController.java
@@ -4,11 +4,13 @@
 package com.untangle.uvm.setup.jabsorb;
 
 import java.io.Serializable;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 import org.jabsorb.JSONRPCBridge;
 import org.jabsorb.callback.CallbackController;
 
+import com.untangle.uvm.util.SafeCheckParam;
 import com.untangle.uvm.util.SafeCheckValidator;
 
 /**
@@ -38,8 +40,21 @@ public class UtCallbackController extends CallbackController
     @Override
     public void preInvokeCallback( Object context, Object instance, Method method, Object[] arguments )
     {
-        if (arguments != null) {
-            for (Object arg : arguments) {
+        if (arguments == null) return;
+        Annotation[][] paramAnns = method.getParameterAnnotations();
+        String mLabel = method.getDeclaringClass().getSimpleName() + "." + method.getName();
+        for (int i = 0; i < arguments.length; i++) {
+            Object arg = arguments[i];
+            if (arg instanceof String) {
+                String s = (String) arg;
+                for (Annotation a : paramAnns[i]) {
+                    if (a instanceof SafeCheckParam) {
+                        SafeCheckParam scp = (SafeCheckParam) a;
+                        SafeCheckValidator.validate(s, scp.value(), scp.errorMessage(),
+                            mLabel + "(arg " + i + ")");
+                    }
+                }
+            } else {
                 SafeCheckValidator.validateAll(arg);
             }
         }


### PR DESCRIPTION
<html><head></head><body><p>Implemented parameter-level SafeCheck validation for Jabsorb service methods.</p><h3>Architecture</h3><ul><li><p>Added <code inline="">@SafeCheckParam</code> annotation for <code inline="">PARAMETER</code> targets with OR-semantics across <code inline="">SafeType[]</code> and optional custom error messages that never echo rejected input.</p></li><li><p>Added <code inline="">SafeCheckValidator.validate(String, SafeType[], String, String)</code> as a dedicated parameter-validation entry point independent from existing field validation flow.</p></li><li><p>Updated Jabsorb callback controllers (<code inline="">admin</code>, <code inline="">setup</code>, <code inline="">reports</code>) to inspect <code inline="">method.getParameterAnnotations()</code> during <code inline="">preInvokeCallback</code>; annotated <code inline="">String</code> args use <code inline="">validate()</code>, while non-String args continue through <code inline="">validateAll(arg)</code>.</p></li><li><p>Validation failures now throw <code inline="">SafeCheckValidationException</code>, surfaced to the UI as JSON-RPC errors.</p></li><li><p>Added new <code inline="">SafeType</code> values: <code inline="">EMAIL</code>, <code inline="">EMAIL_TEMPLATE</code>, <code inline="">PEM</code>, <code inline="">CERT_SUBJECT</code>, <code inline="">SAN_LIST</code>, <code inline="">REGEX_PATTERN</code>, <code inline="">FILE_PATH</code>.</p></li><li><p>Expanded <code inline="">SIMPLE_TEXT</code> to allow apostrophes (<code inline="">'</code>) for natural names/paths like <code inline="">O'Brien</code> and <code inline="">John's Folder</code>.</p></li></ul><h3>Annotation Coverage &amp; Sink Reasoning</h3>
<img width="1303" height="745" alt="Screenshot from 2026-05-18 19-59-43" src="https://github.com/user-attachments/assets/864d36eb-d8b6-486d-99b8-7ad147d1b7ea" />
