### PR TITLE
ngfw-15777 Remove hardcoded cloud auth UUID from public source

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -355,7 +355,7 @@ Description: Captive Portal
 
 Package: untangle-base-virus-blocker
 Architecture: all
-Depends: ${misc:Depends}, untangle-vm, untangle-app-http, untangle-app-smtp
+Depends: ${misc:Depends}, untangle-vm, untangle-app-http, untangle-app-smtp, untangle-cloud-auth-credentials
 Description: Virus Blocker Base
  The Virus Blocker Base.
 
@@ -395,6 +395,7 @@ Depends: ${misc:Depends},
 	 untangle-python3-runtests,
          untangle-python3-support-diagnostics,
          untangle-vue-ui,
+         untangle-cloud-auth-credentials,
 	 unzip,
          zip
 Description: UVM Platform

--- a/uvm/api/com/untangle/uvm/CloudAuthCredentialsUtil.java
+++ b/uvm/api/com/untangle/uvm/CloudAuthCredentialsUtil.java
@@ -1,0 +1,53 @@
+/**
+ * $Id$
+ */
+package com.untangle.uvm;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+/**
+ * Reads the NGFW cloud auth request token from the credentials file shipped
+ * by the untangle-cloud-auth-credentials package. The file holds the token
+ * encrypted; this util shells out to the helper to extract the field, then
+ * decrypts via PasswordUtil. Result is cached for the JVM lifetime.
+ */
+public class CloudAuthCredentialsUtil
+{
+    private static final String CLOUD_AUTH_PATH = "/var/lib/untangle-cloud-auth/";
+    private static final String UVM_BIN_DIR = "uvm.bin.dir";
+
+    private static final Logger logger = LogManager.getLogger(CloudAuthCredentialsUtil.class);
+
+    private static volatile String cachedAuthRequestToken = null;
+
+    /**
+     * Gets the NGFW cloud auth request token, reading and decrypting from the credentials file if not already cached.
+     * @return The decrypted cloud auth request token.
+     * @throws PasswordUtil.CryptoProcessException If there is an error reading or decrypting the token.
+     */
+    public static String getAuthRequestToken() throws PasswordUtil.CryptoProcessException
+    {
+        String token = cachedAuthRequestToken;
+        if (token != null) {
+            return token;
+        }
+        synchronized (CloudAuthCredentialsUtil.class) {
+            if (cachedAuthRequestToken != null) {
+                return cachedAuthRequestToken;
+            }
+            String helper = System.getProperty(UVM_BIN_DIR) + "/ut-cloud-auth-helper.sh";
+            String encrypted = UvmContextFactory.context().execManager().execOutput(helper + " encryptedAuthRequest " + CLOUD_AUTH_PATH);
+            if (StringUtils.isBlank(encrypted)) {
+                throw new PasswordUtil.CryptoProcessException("Failed to read encrypted cloud auth token from " + CLOUD_AUTH_PATH);
+            }
+            String decrypted = PasswordUtil.getDecryptPassword(encrypted.trim());
+            if (decrypted == null) {
+                throw new PasswordUtil.CryptoProcessException("Failed to decrypt cloud auth token");
+            }
+            cachedAuthRequestToken = decrypted;
+            return cachedAuthRequestToken;
+        }
+    }
+}

--- a/uvm/hier/usr/lib/python3/dist-packages/unit_tests/test_token_validation.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/unit_tests/test_token_validation.py
@@ -11,8 +11,11 @@ class TestTokenValid(unittest.TestCase):
     def __do_token_run(self, isValid):
         token_value = 'token'
         uid = 'uid'
-        with patch('uvm.login_tools.getuid') as mock_getuid:
+        auth_request_token = 'TEST-AUTH-REQUEST-TOKEN'
+        with patch('uvm.login_tools.getuid') as mock_getuid, \
+                patch('uvm.login_tools.get_auth_request_token') as mock_get_token:
             mock_getuid.return_value = uid
+            mock_get_token.return_value = auth_request_token
             if isValid:
                 self.assertTrue(login_tools.valid_token(token_value))
             else:
@@ -25,7 +28,7 @@ class TestTokenValid(unittest.TestCase):
             headers={
                 "Content-Type": 'application/json',
                 'Accept': 'application/json',
-                'AuthRequest': login_tools.AUTH_REQUEST_HEADER_TOKEN})
+                'AuthRequest': auth_request_token})
 
     @patch('requests.post')
     def test_token_validity(self, mock_post):

--- a/uvm/hier/usr/lib/python3/dist-packages/uvm/login_tools.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/uvm/login_tools.py
@@ -259,7 +259,14 @@ def getuid():
     return uid
 
 
-AUTH_REQUEST_HEADER_TOKEN = 'B132C885-962B-4D63-8B2F-441B7A43CD93'
+CLOUD_AUTH_CREDENTIALS_PATH = '/var/lib/untangle-cloud-auth/credentials.json'
+
+
+def get_auth_request_token():
+    with open(CLOUD_AUTH_CREDENTIALS_PATH) as f:
+        encrypted = json.load(f)['cloud']['encrypted_auth_request']
+    from sync import EncryptionUtil
+    return EncryptionUtil.execute_password_manager('-d', encrypted)
 
 
 def valid_token(token):
@@ -277,7 +284,7 @@ def valid_token(token):
             headers={
                 "Content-Type": 'application/json',
                 'Accept': 'application/json',
-                'AuthRequest': AUTH_REQUEST_HEADER_TOKEN})
+                'AuthRequest': get_auth_request_token()})
         response.raise_for_status()
         value = response.json()
         return value

--- a/uvm/hier/usr/share/untangle/bin/ut-cloud-auth-helper.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-cloud-auth-helper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script extracts encrypted fields from the cloud auth credentials JSON
+# shipped by the untangle-cloud-auth-credentials package.
+
+get_json_value() {
+  local json_key=$1
+  # Remove , space \n and \t
+  python3 -m simplejson.tool $2 | grep "$json_key" | awk '{print $2}' | sed 's/[",[:space:]]//g' | tr -d '\t' | tr -d '\n'
+}
+
+encryptedAuthRequest()
+{
+    shift
+    get_json_value "encrypted_auth_request" "$1credentials.json"
+}
+
+$1 "$@"

--- a/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/DeviceTableImpl.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 public class DeviceTableImpl implements DeviceTable
 {
     private static final String CLOUD_LOOKUP_URL = UvmContextFactory.context().uriManager().getUri("https://labs.edge.arista.com/Utility/v1/mac");
-    private static final String CLOUD_LOOKUP_KEY = "B132C885-962B-4D63-8B2F-441B7A43CD93";
     private static final String CONTENT_LENGTH = "Content-length";
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String CONTENT_TYPE_VALUE = "application/json";
@@ -318,7 +317,7 @@ public class DeviceTableImpl implements DeviceTable
                 mycon.setRequestProperty(CONTENT_LENGTH, String.valueOf(body.length()));
                 mycon.setRequestProperty(CONTENT_TYPE, CONTENT_TYPE_VALUE);
                 mycon.setRequestProperty(USER_AGENT, USER_AGENT_VALUE);
-                mycon.setRequestProperty(AUTH_REQUEST, CLOUD_LOOKUP_KEY);
+                mycon.setRequestProperty(AUTH_REQUEST, CloudAuthCredentialsUtil.getAuthRequestToken());
                 mycon.setDoOutput(true);
                 mycon.setDoInput(true);
 

--- a/virus-blocker-base/src/com/untangle/app/virus_blocker/VirusCloudFeedback.java
+++ b/virus-blocker-base/src/com/untangle/app/virus_blocker/VirusCloudFeedback.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.json.JSONObject;
 
 import com.untangle.uvm.UvmContextFactory;
+import com.untangle.uvm.CloudAuthCredentialsUtil;
 import com.untangle.uvm.vnet.AppSession;
 
 /**
@@ -24,7 +25,6 @@ public class VirusCloudFeedback extends Thread
     private final Logger logger = LogManager.getLogger(VirusBlockerBaseApp.class);
 
     private static final String CLOUD_FEEDBACK_URL = UvmContextFactory.context().uriManager().getUri("https://telemetry.edge.arista.com/ngfw/v1/infection");
-    private static final String CLOUD_SCANNER_KEY = "B132C885-962B-4D63-8B2F-441B7A43CD93";
 
     VirusBlockerState virusState = null;
     long fileLength = 0;
@@ -113,7 +113,7 @@ public class VirusCloudFeedback extends Thread
             mycon.setRequestProperty("Content-length", String.valueOf(feedback.length()));
             mycon.setRequestProperty("User-Agent", "Untangle NGFW Virus Blocker");
             mycon.setRequestProperty("UID", UvmContextFactory.context().getServerUID());
-            mycon.setRequestProperty("AuthRequest", CLOUD_SCANNER_KEY);
+            mycon.setRequestProperty("AuthRequest", CloudAuthCredentialsUtil.getAuthRequestToken());
             mycon.setDoOutput(true);
             mycon.setDoInput(true);
 

--- a/virus-blocker-base/src/com/untangle/app/virus_blocker/VirusCloudScanner.java
+++ b/virus-blocker-base/src/com/untangle/app/virus_blocker/VirusCloudScanner.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.json.JSONObject;
 
 import com.untangle.uvm.UvmContextFactory;
+import com.untangle.uvm.CloudAuthCredentialsUtil;
 
 /**
  * Implements a cloud based virus scanner
@@ -24,7 +25,6 @@ public class VirusCloudScanner extends Thread
     private final Logger logger = LogManager.getLogger(VirusBlockerBaseApp.class);
 
     private static final String CLOUD_SCANNER_URL = "https://classify.edge.arista.com/v1/md5s";
-    private static final String CLOUD_SCANNER_KEY = "B132C885-962B-4D63-8B2F-441B7A43CD93";
     private static final String EICAR_TEST_MD5 = "44d88612fea8a8f36de82e1278abb02f";
 
     VirusCloudResult cloudResult = null;
@@ -90,7 +90,7 @@ public class VirusCloudScanner extends Thread
             mycon.setRequestProperty("Content-Type", "application/json");
             mycon.setRequestProperty("User-Agent", "Untangle NGFW Virus Blocker");
             mycon.setRequestProperty("UID", UvmContextFactory.context().getServerUID());
-            mycon.setRequestProperty("AuthRequest", CLOUD_SCANNER_KEY);
+            mycon.setRequestProperty("AuthRequest", CloudAuthCredentialsUtil.getAuthRequestToken());
             mycon.setDoOutput(true);
             mycon.setDoInput(true);
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes introduced by this PR and why they are being made. -->
Removes the hardcoded NGFW cloud auth token from all 4 locations in this public
repository and replaces each with a runtime read from the private
`untangle-cloud-auth-credentials` package shipped by the linked `ngfw_upstream` PR.

After this PR, `grep` for the token value in `ngfw_src` returns **zero matches**.

## Context
<!-- Why is this change being made? -->
An Arista Cybersecurity scan (2026-05-07) flagged the NGFW cloud auth token as a leaked
production secret hardcoded in this public repository (finding #9, parent ticket
NGFW-15757). It was present in 4 files across `uvm/` and `virus-blocker-base/` and is
the sole enforced `AuthRequest:` HTTP header for every appliance call to 5 Arista cloud
backends — confirmed by live probe on 2026-05-08.

The token cannot be simply deleted: removing it breaks Cloud SSO (`login_tools.valid_token`),
cloud AV verdicts (`VirusCloudScanner`), virus telemetry (`VirusCloudFeedback`), and
MAC vendor lookup (`DeviceTableImpl`). The fix reads the token at runtime from the private
credentials package, decrypting via the existing `PasswordUtil.getDecryptPassword()` /
`sync.EncryptionUtil` infrastructure — the same approach used for the Google Drive Picker
secrets.

## Changes

**New files**
- `uvm/api/com/untangle/uvm/CloudAuthCredentialsUtil.java` — shared Java accessor
  `getAuthRequestToken()` that shells out to the bash helper, decrypts via
  `PasswordUtil.getDecryptPassword()`, and caches the result for the JVM lifetime.
- `uvm/hier/usr/share/untangle/bin/ut-cloud-auth-helper.sh` — reads
  `encrypted_auth_request` from the credentials file. Mirrors `ut-google-drive-helper.sh`.

**Modified files**
- `uvm/impl/com/untangle/uvm/DeviceTableImpl.java` — removed hardcoded constant; call
  site uses `CloudAuthCredentialsUtil.getAuthRequestToken()`.
- `virus-blocker-base/.../VirusCloudScanner.java` — same.
- `virus-blocker-base/.../VirusCloudFeedback.java` — same.
- `uvm/hier/.../uvm/login_tools.py` — removed module-level constant; replaced with
  `get_auth_request_token()` reading and decrypting from the credentials file.
  `valid_token()` call site updated accordingly.
- `uvm/hier/.../unit_tests/test_token_validation.py` — updated to mock
  `get_auth_request_token` instead of the removed constant.
- `debian/control` — added `untangle-cloud-auth-credentials` to `Depends` of
  `untangle-vm` and `untangle-base-virus-blocker`.
