### PR TITLE
ngfw-15743: Exec To ExecCommand Migration for reported RCE

### DIFF
--- a/ipsec-vpn/hier/usr/share/untangle/bin/ipsec-tunnel-status
+++ b/ipsec-vpn/hier/usr/share/untangle/bin/ipsec-tunnel-status
@@ -15,7 +15,7 @@ if (len(sys.argv) < 2):
     raise Exception("Invalid number of arguments")
 work_name = sys.argv[1]
 
-status_proc = subprocess.Popen("/usr/sbin/ipsec statusall " + work_name, stdout=subprocess.PIPE, shell=True, text=True)
+status_proc = subprocess.Popen(["/usr/sbin/ipsec", "statusall", work_name], stdout=subprocess.PIPE, shell=False, text=True)
 (status_out,status_err) = status_proc.communicate()
 
 wordlist = status_out.split()

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
@@ -536,7 +536,8 @@ public class IpsecVpnApp extends AppBase
 
         for (VirtualUserEntry entry : virtualUserTable.buildUserList()) {
             logger.info("Disconnecting L2TP client " + entry.getClientUsername() + " address " + entry.getClientAddress().getHostAddress());
-            IpsecVpnApp.execManager().exec("kill -HUP " + entry.getNetProcess());
+            IpsecVpnApp.execManager().execCommand(
+                "/bin/kill", List.of("-HUP", entry.getNetProcess()));
             counter++;
         }
 
@@ -770,13 +771,13 @@ public class IpsecVpnApp extends AppBase
 
         if (entry.getClientProtocol().equals("L2TP")) {
             // for L2TP clients we send a HUP signal to the pppd process
-            IpsecVpnApp.execManager().exec("kill -HUP " + entry.getNetProcess());
+            IpsecVpnApp.execManager().execCommand("/bin/kill", List.of("-HUP", entry.getNetProcess()));
         }else if (entry.getClientProtocol().equals("XAUTH")) {
             // for Xauth clients we call ipsec down using the connection and unique id
-            IpsecVpnApp.execManager().exec("ipsec down " + entry.getNetInterface() + "[" + entry.getNetProcess() + "]");
+            IpsecVpnApp.execManager().execCommand("/sbin/ipsec", List.of("down", entry.getNetInterface() + "[" + entry.getNetProcess() + "]"));
         }else if (entry.getClientProtocol().equals("IKEv2")) {
             // for IKEv2 clients we call ipsec down using the connection and unique id
-            IpsecVpnApp.execManager().exec("ipsec down " + entry.getNetInterface() + "[" + entry.getNetProcess() + "]");
+            IpsecVpnApp.execManager().execCommand("/sbin/ipsec", List.of("down", entry.getNetInterface() + "[" + entry.getNetProcess() + "]"));
         }else{
             logger.warn("Unknown protocol " + entry.getClientProtocol());
         }
@@ -865,7 +866,7 @@ public class IpsecVpnApp extends AppBase
 
 // THIS IS FOR ECLIPSE - @formatter:on
 
-        String result = IpsecVpnApp.execManager().execOutput(GRAB_TUNNEL_STATUS_SCRIPT + " " + tunnel.getWorkName());
+        String result = IpsecVpnApp.execManager().execCommand(GRAB_TUNNEL_STATUS_SCRIPT, List.of(tunnel.getWorkName())).getOutput();
 
         /*
          * If the tunnel is active, update the mode and continue parsing.

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnDataTimer.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnDataTimer.java
@@ -5,6 +5,7 @@
 package com.untangle.app.ipsec_vpn;
 
 import java.util.LinkedList;
+import java.util.List;
 import java.util.TimerTask;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -154,7 +155,9 @@ public class IpsecVpnDataTimer extends TimerTask
          * the script should return the tunnel status in the following format:
          * | TUNNNEL:tunnel_name LOCAL:1.2.3.4 REMOTE:5.6.7.8 STATE:active IN:123 OUT:456 |
          */
-        result = IpsecVpnApp.execManager().execOutput(TUNNEL_STATUS_SCRIPT + " " + watcher.tunnelName);
+        result = IpsecVpnApp.execManager().execCommand(
+            TUNNEL_STATUS_SCRIPT, List.of(watcher.tunnelName)
+        ).getOutput();
 
 // THIS IS FOR ECLIPSE - @formatter:on
 

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnManager.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnManager.java
@@ -182,7 +182,8 @@ public class IpsecVpnManager
             tunnel = tunnelList.get(x);
             if (tunnel.getActive() != true) continue;
             if (tunnel.getRunmode().equals("start") && tunnel.getAllSubnetNegotation() == false) {
-                UvmContextFactory.context().execManager().exec("ipsec route " + tunnel.getWorkName());
+                UvmContextFactory.context().execManager().execCommand(
+                    IPSEC_APP, List.of("route", tunnel.getWorkName()));
             }
         }
     }

--- a/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
+++ b/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
@@ -43,7 +43,19 @@ ALLOWED_EXECUTABLES = {
     "/bin/kill",
     "/bin/ping",
     "/bin/rm",
-    "/usr/share/untangle/bin/ut-notification-helpers.sh"
+    "/usr/share/untangle/bin/ut-notification-helpers.sh",
+    "/usr/bin/net",
+    "/usr/sbin/ipset",
+    "/usr/bin/openssl",
+    "/sbin/ip",
+    "/usr/bin/pgrep",
+    "/usr/sbin/exim4",
+    "/bin/cat",
+    "/usr/bin/wg",
+    "/usr/share/untangle/bin/ut-radius-proxy",
+    "/usr/share/untangle/bin/ipsec-tunnel-status",
+    "/usr/share/untangle/bin/wan-failover-pingable-hosts.sh",
+    "/usr/share/untangle/bin/ut-wireguard-helpers.sh"
 
 }
 

--- a/uvm/hier/usr/share/untangle/bin/ut-radius-proxy
+++ b/uvm/hier/usr/share/untangle/bin/ut-radius-proxy
@@ -40,9 +40,9 @@ if len(sys.argv) < 3:
     print("ERROR: You must provide the AD username and password")
     sys.exit(1)
 
-netcmd = "/usr/bin/net ads status -U %s%%%s" % (sys.argv[1], sys.argv[2])
+netcmd = ["/usr/bin/net", "ads", "status", "-U", "%s%%%s" % (sys.argv[1], sys.argv[2])]
 
-status_proc = subprocess.Popen(netcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
+status_proc = subprocess.Popen(netcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False, text=True)
 (status_out,status_err) = status_proc.communicate()
 status_txt = parse_output(status_out)
 

--- a/uvm/hier/usr/share/untangle/bin/ut-wireguard-helpers.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-wireguard-helpers.sh
@@ -5,7 +5,7 @@
 
 showPublicKey()
 {
-    echo $2 | $3 pubkey
+    echo "$2" | "$3" pubkey
 }
 
 $1 "$@"

--- a/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
@@ -163,7 +163,11 @@ public class CertificateManagerImpl implements CertificateManager
         // apache cert.  If they don't match we copy the configured cert to
         // the apache directory and restart the server to activate the cert. 
         String apacheFingerprint = UvmContextFactory.context().execManager().execOutput("openssl x509 -noout -fingerprint -in " + APACHE_PEM_FILE);
-        String configFingerprint = UvmContextFactory.context().execManager().execOutput("openssl x509 -noout -fingerprint -in " + CERT_STORE_PATH + UvmContextFactory.context().systemManager().getSettings().getWebCertificate());
+        String webCertFile = CERT_STORE_PATH + UvmContextFactory.context().systemManager().getSettings().getWebCertificate();
+        String configFingerprint = UvmContextFactory.context().execManager().execCommand(
+            "/usr/bin/openssl",
+            List.of("x509", "-noout", "-fingerprint", "-in", webCertFile)
+        ).getOutput();
         if (apacheFingerprint.equals(configFingerprint) == false) {
             logger.info("Replacing existing apache certificate [" + apacheFingerprint + "] with configured certificate [" + configFingerprint + "]");
             UvmContextFactory.context().systemManager().activateApacheCertificate();

--- a/uvm/impl/com/untangle/uvm/ConnectivityTesterImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConnectivityTesterImpl.java
@@ -86,8 +86,14 @@ public class ConnectivityTesterImpl implements ConnectivityTester
 
         domainName = UvmContextFactory.context().uriManager().getSettings().getDnsTestHost();
 
-        if (primaryServer != null && UvmContextFactory.context().execManager().execCommand(DNS_TEST_SCRIPT, List.of(primaryServer, domainName)).getResult() != 0) isWorking = false;
-        if (secondaryServer != null && UvmContextFactory.context().execManager().execCommand(DNS_TEST_SCRIPT, List.of(secondaryServer, domainName)).getResult() != 0) isWorking = false;
+        if (primaryServer != null) {
+            Integer rc = UvmContextFactory.context().execManager().execCommand(DNS_TEST_SCRIPT, List.of(primaryServer, domainName)).getResult();
+            if (rc == null || rc != 0) isWorking = false;
+        }
+        if (secondaryServer != null) {
+            Integer rc = UvmContextFactory.context().execManager().execCommand(DNS_TEST_SCRIPT, List.of(secondaryServer, domainName)).getResult();
+            if (rc == null || rc != 0) isWorking = false;
+        }
 
         return isWorking;
     }

--- a/uvm/impl/com/untangle/uvm/DaemonManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/DaemonManagerImpl.java
@@ -4,6 +4,7 @@
 
 package com.untangle.uvm;
 
+import java.util.List;
 import java.util.TimerTask;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
@@ -325,9 +326,14 @@ public class DaemonManagerImpl extends TimerTask implements DaemonManager
 
         String daemonSearchString = ( (daemonObject.monitorType == MonitorType.DAEMON && daemonObject.searchString != null) ? daemonObject.searchString : daemonName);
         daemonSearchString = "[" + daemonSearchString.substring(0,1) + "]" + daemonSearchString.substring(1);
-        
-        int result = UvmContextFactory.context().execManager().execResult("pgrep -x " + daemonSearchString);
-        return ( result == 1 ) ? true : false;
+
+        // Argv-form passes the search string as a single argument so shell
+        // metacharacters in daemonName cannot escape. Comparison preserved
+        // verbatim from the prior shell-form implementation.
+        Integer result = UvmContextFactory.context().execManager().execCommand(
+            "/usr/bin/pgrep", List.of("-x", daemonSearchString)
+        ).getResult();
+        return ( result != null && result == 1 ) ? true : false;
     }
 
     /**
@@ -363,9 +369,15 @@ public class DaemonManagerImpl extends TimerTask implements DaemonManager
      */
     private void execDaemonControlEvil(String daemonName, String command)
     {
-        String cmd = (daemonName == null ? command : "systemctl " + command + " " + daemonName);
         try {
-            ExecManagerResultReader reader = UvmContextFactory.context().execManager().execEvil(cmd);
+            ExecManagerResultReader reader;
+            if (daemonName == null) {
+                // raw extraRestartCommand path - preserved by API contract
+                reader = UvmContextFactory.context().execManager().execEvil(command);
+            } else {
+                reader = UvmContextFactory.context().execManager().execEvil(
+                    new String[] { "/usr/bin/systemctl", command, daemonName });
+            }
             reader.waitFor();
         } catch (Exception exn) {
             logger.warn("Failed to run command: " + command, exn);
@@ -405,13 +417,23 @@ public class DaemonManagerImpl extends TimerTask implements DaemonManager
      */
     private String execDaemonControlSafe(String daemonName, String command, boolean log)
     {
-        String cmd = (daemonName == null ? command : "systemctl " + command + " " + daemonName);
-        String output = UvmContextFactory.context().execManager().execOutput(cmd);
-        if(log){
+        String output;
+        String cmdLabel;
+        if (daemonName == null) {
+            // raw extraRestartCommand path - preserved by API contract
+            cmdLabel = command;
+            output = UvmContextFactory.context().execManager().execOutput(command);
+        } else {
+            cmdLabel = "systemctl " + command + " " + daemonName;
+            output = UvmContextFactory.context().execManager().execCommand(
+                "/usr/bin/systemctl", List.of(command, daemonName)
+            ).getOutput();
+        }
+        if (log) {
             try {
                 String lines[] = output.split("\\r?\\n");
                 for (String line : lines)
-                    logger.info(cmd + ": " + line);
+                    logger.info(cmdLabel + ": " + line);
             } catch (Exception exn) {
             }
         }
@@ -428,8 +450,15 @@ public class DaemonManagerImpl extends TimerTask implements DaemonManager
     private void handleDaemonCheck(DaemonObject object)
     {
         synchronized (object) {
-            // run a spiffy command to count the number of process instances
-            int count = UvmContextFactory.context().execManager().execOutput("pgrep " + object.searchString).split("\r\n|\r|\n").length;
+            // run a spiffy command to count the number of process instances.
+            // Argv-form prevents shell metachar escape via searchString; the
+            // split-length semantics (empty output = length 1) are preserved
+            // verbatim from the prior shell-form implementation.
+            String pgrepOutput = UvmContextFactory.context().execManager().execCommand(
+                "/usr/bin/pgrep", List.of(object.searchString)
+            ).getOutput();
+            if (pgrepOutput == null) pgrepOutput = "";
+            int count = pgrepOutput.split("\r\n|\r|\n").length;
 
             logger.debug("Found " + count + " instances of daemon/search: \"" + object.searchString + "\"");
 

--- a/uvm/impl/com/untangle/uvm/HostTableImpl.java
+++ b/uvm/impl/com/untangle/uvm/HostTableImpl.java
@@ -10,6 +10,7 @@ import java.util.LinkedList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.HashSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Iterator;
 import java.util.Comparator;
@@ -1142,19 +1143,27 @@ public class HostTableImpl implements HostTable
                 if (currentIps == null) {
                     currentIps = new HashSet<>();
                     currentIpSets.put(tagName, currentIps);
-                    output = UvmContextFactory.context().execManager().execOutput("ipset create tag-" + tagName + " iphash");
-                    lines = output.split("\\r?\\n");
-                    for (String line : lines)
-                        logger.info("ipset create: " + line);
+                    output = UvmContextFactory.context().execManager().execCommand(
+                        "/usr/sbin/ipset", List.of("create", "tag-" + tagName, "iphash")
+                    ).getOutput();
+                    if (output != null) {
+                        lines = output.split("\\r?\\n");
+                        for (String line : lines)
+                            logger.info("ipset create: " + line);
+                    }
                 }
 
                 if (!currentIps.contains(address)) {
                     logger.info("Tag " + tagName + " added to " + entry.getAddress().getHostAddress());
                     currentIps.add(address);
-                    output = UvmContextFactory.context().execManager().execOutput("ipset add tag-" + tagName + " " + address);
-                    lines = output.split("\\r?\\n");
-                    for (String line : lines)
-                        logger.info("ipset add: " + line);
+                    output = UvmContextFactory.context().execManager().execCommand(
+                        "/usr/sbin/ipset", List.of("add", "tag-" + tagName, address)
+                    ).getOutput();
+                    if (output != null) {
+                        lines = output.split("\\r?\\n");
+                        for (String line : lines)
+                            logger.info("ipset add: " + line);
+                    }
                 }
             } catch (Exception e) {
                 logger.warn("Exception", e);
@@ -1221,10 +1230,14 @@ public class HostTableImpl implements HostTable
 
                 if (currentIps.contains(address)) {
                     currentIps.remove(address);
-                    output = UvmContextFactory.context().execManager().execOutput("ipset del tag-" + tagName + " " + entry.getAddress().getHostAddress());
-                    lines = output.split("\\r?\\n");
-                    for (String line : lines)
-                        logger.info("ipset del: " + line);
+                    output = UvmContextFactory.context().execManager().execCommand(
+                        "/usr/sbin/ipset", List.of("del", "tag-" + tagName, entry.getAddress().getHostAddress())
+                    ).getOutput();
+                    if (output != null) {
+                        lines = output.split("\\r?\\n");
+                        for (String line : lines)
+                            logger.info("ipset del: " + line);
+                    }
                 }
             } catch (Exception e) {
                 logger.warn("Exception", e);

--- a/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
+++ b/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
@@ -96,9 +96,11 @@ public class LocalDirectoryImpl implements LocalDirectory
             logger.error("Exception occured while fetching original password", exn);
             return "Unable to decrypt the encrypted password for AD server" + systemSettings.getRadiusProxyServer();
         }
-        String command = String.format("%s \"%s\" \"%s\"", FREERADIUS_PROXY_SCRIPT, systemSettings.getRadiusProxyUsername(), userPassword);
-
-        return UvmContextFactory.context().execManager().execOutput(false, command);
+        String output = UvmContextFactory.context().execManager().execCommand(
+            FREERADIUS_PROXY_SCRIPT,
+            List.of(systemSettings.getRadiusProxyUsername(), userPassword)
+        ).getOutput();
+        return output != null ? output : "";
     }
 
     /**
@@ -133,19 +135,23 @@ public class LocalDirectoryImpl implements LocalDirectory
             logger.error("Exception occured while fetching original password", exn);
             return new ExecManagerResult(1, "Unable to decrypt the encrypted password of AD server " + systemSettings.getRadiusProxyServer());
         }
-        String command = ("/usr/bin/net ads --no-dns-updates join");
-        command += String.format(" -U \"%s%%%s\"", systemSettings.getRadiusProxyUsername(), userPassword);
-        command += (" -S " + systemSettings.getRadiusProxyServer());
-        command += (" osName=\"Untangle NG Firewall\"");
-        command += (" osVer=\"" + UvmContextFactory.context().getFullVersion() + "\"");
-
-        ExecManagerResult result =  UvmContextFactory.context().execManager().exec(command, false, false, false);
+        ExecManagerResult result = UvmContextFactory.context().execManager().execCommand(
+            "/usr/bin/net",
+            List.of(
+                "ads", "--no-dns-updates", "join",
+                "-U", systemSettings.getRadiusProxyUsername() + "%" + userPassword,
+                "-S", systemSettings.getRadiusProxyServer(),
+                "osName=Untangle NG Firewall",
+                "osVer=" + UvmContextFactory.context().getFullVersion()
+            )
+        );
 
         // NGFW-13595 The winbind service must be restarted after we create
         // the computer account because it requires the SID that gets created
         // by the "net ads" call we made above.
-        if (result.result == 0) {
-            UvmContextFactory.context().execManager().exec("systemctl restart winbind.service");
+        if (result.getResult() != null && result.getResult() == 0) {
+            UvmContextFactory.context().execManager().execCommand(
+                "/usr/bin/systemctl", List.of("restart", "winbind.service"));
         }
 
         return result;
@@ -196,7 +202,8 @@ public class LocalDirectoryImpl implements LocalDirectory
         args.add("--username=" + userName);
         args.add("--password=" + userPass);
 
-        return UvmContextFactory.context().execManager().execCommand(FREERADIUS_NTLM_CMD,args).getOutput();
+        String output = UvmContextFactory.context().execManager().execCommand(FREERADIUS_NTLM_CMD, args).getOutput();
+        return output != null ? output : "";
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/MailSenderImpl.java
+++ b/uvm/impl/com/untangle/uvm/MailSenderImpl.java
@@ -474,7 +474,9 @@ public class MailSenderImpl implements MailSender
 
             //force sending of this email now (if previous emails failed for this host, 
             //the email is currently queued waiting for a timeout)
-            String strM = UvmContextFactory.context().execManager().execOutput("exim -M " + logId);
+            String strM = UvmContextFactory.context().execManager().execCommand(
+                "/usr/sbin/exim4", List.of("-M", logId)
+            ).getOutput();
 
             //String log = UvmContextFactory.context().execManager().execOutput("exim -Mvl "+logId);
             //now read the rest of the logs

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -862,13 +862,15 @@ public class NetworkManagerImpl implements NetworkManager
             return false;
         }
 
-        String command = "ip add list " + intfSettings.getSymbolicDev() + " | grep '" + vrrpAddress.getHostAddress() + "/'";
-        int retCode = UvmContextFactory.context().execManager().execResult( command );
-
-        if ( retCode == 0 )
-            return true;
-        else
-            return false;
+        String output = UvmContextFactory.context().execManager().execCommand(
+            "/sbin/ip", List.of("add", "list", intfSettings.getSymbolicDev())
+        ).getOutput();
+        String needle = vrrpAddress.getHostAddress() + "/";
+        if (output == null) return false;
+        for (String line : output.split("\\R")) {
+            if (line.contains(needle)) return true;
+        }
+        return false;
     }
         
     /**

--- a/wan-failover/src/com/untangle/app/wan_failover/WanFailoverApp.java
+++ b/wan-failover/src/com/untangle/app/wan_failover/WanFailoverApp.java
@@ -124,7 +124,10 @@ public class WanFailoverApp extends AppBase
             throw new RuntimeException("Invalid interface id: " + uplinkID);
         }
 
-        String output = UvmContextFactory.context().execManager().execOutput(PINGABLE_HOSTS_SCRIPT + " " + uplinkID + " " + intfSettings.getSymbolicDev());
+        String output = UvmContextFactory.context().execManager().execCommand(
+            PINGABLE_HOSTS_SCRIPT,
+            List.of(String.valueOf(uplinkID), intfSettings.getSymbolicDev())
+        ).getOutput();
 
         if (output.trim().length() == 0) {
             throw new RuntimeException("Unable to determine pingable hosts.");

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnManager.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnManager.java
@@ -158,7 +158,6 @@ public class WireGuardVpnManager
             return;
         }
 
-        ArrayList<String> commands = new ArrayList<String>();
         ArrayList<String> allowedIps = new ArrayList<String>();
         // Make sure we have our peer address in allowed list.
         allowedIps.add(addTunnel.getPeerAddress().getHostAddress() + "/32");
@@ -169,21 +168,21 @@ public class WireGuardVpnManager
             allowedIps.add(networks[x].trim());
         }
         // Add tunnel to WireGuard
-        commands.add(
-            WIREGUARD_APP +
-            " set wg0 peer " + publicKey +
-            ( addTunnel.getEndpointDynamic() != true
-                ? " endpoint " + addTunnel.getEndpointHostname() + ":" + addTunnel.getEndpointPort()
-                : ""
-            ) +
-            " persistent-keepalive " + app.getSettings().getKeepaliveInterval() +
-            " allowed-ips " + String.join(",", allowedIps)
-        );
-        for(String allowedIp :allowedIps){
-            commands.add("ip -4 route add " + allowedIp + " dev wg0");
+        ArrayList<String> wgArgs = new ArrayList<String>(List.of("set", "wg0", "peer", publicKey));
+        if (addTunnel.getEndpointDynamic() != true) {
+            wgArgs.add("endpoint");
+            wgArgs.add(addTunnel.getEndpointHostname() + ":" + addTunnel.getEndpointPort());
         }
-        for ( String cmd: commands ) 
-            this.wireguardCommand(cmd);
+        wgArgs.add("persistent-keepalive");
+        wgArgs.add(String.valueOf(app.getSettings().getKeepaliveInterval()));
+        wgArgs.add("allowed-ips");
+        wgArgs.add(String.join(",", allowedIps));
+        this.wireguardCommand(WIREGUARD_APP, wgArgs);
+
+        for (String allowedIp : allowedIps) {
+            this.wireguardCommand("/sbin/ip",
+                List.of("-4", "route", "add", allowedIp, "dev", "wg0"));
+        }
     }
 
     /**
@@ -205,17 +204,18 @@ public class WireGuardVpnManager
                 networks = removeTunnel.getNetworks().split("\\n");
             }
         }
-        ArrayList<String> commands = new ArrayList<String>();
-        if(removeTunnel != null){
+        if (removeTunnel != null) {
             for (int index = 0; index < networks.length; index++) {
                 if (networks[index].trim().length() == 0) continue;
-                commands.add("ip -4 route delete " + networks[index].trim() + " dev wg0");
+                this.wireguardCommand("/sbin/ip",
+                    List.of("-4", "route", "delete", networks[index].trim(), "dev", "wg0"));
             }
-            commands.add("ip -4 route delete " + removeTunnel.getPeerAddress().getHostAddress() + "/32" + " dev wg0");
+            this.wireguardCommand("/sbin/ip",
+                List.of("-4", "route", "delete",
+                    removeTunnel.getPeerAddress().getHostAddress() + "/32", "dev", "wg0"));
         }
-        commands.add(WIREGUARD_APP + " set wg0 peer " + publicKey + " remove");
-        for ( String cmd: commands ) 
-            this.wireguardCommand(cmd);
+        this.wireguardCommand(WIREGUARD_APP,
+            List.of("set", "wg0", "peer", publicKey, "remove"));
     }
 
     /**
@@ -272,7 +272,7 @@ public class WireGuardVpnManager
      */
     public String createPrivateKey()
     {
-        return wireguardCommand(WIREGUARD_APP + " genkey");
+        return wireguardCommand(WIREGUARD_APP, List.of("genkey"));
     }
 
     /**
@@ -288,7 +288,9 @@ public class WireGuardVpnManager
             return "";
 
         } 
-        String result = wireguardCommand(System.getProperty("uvm.bin.dir") + "/ut-wireguard-helpers.sh showPublicKey " + privateKey + " " + WIREGUARD_APP );
+        String result = wireguardCommand(
+            System.getProperty("uvm.bin.dir") + "/ut-wireguard-helpers.sh",
+            List.of("showPublicKey", privateKey, WIREGUARD_APP));
         return result;
     }
 
@@ -304,7 +306,10 @@ public class WireGuardVpnManager
 
         }
         File file = getRemoteConfigFile(publicKey);
-        return (file != null) ? wireguardCommand("/usr/bin/qrencode -t SVG -o - -r " + file.getAbsolutePath())  : "";
+        return (file != null)
+            ? wireguardCommand("/usr/bin/qrencode",
+                List.of("-t", "SVG", "-o", "-", "-r", file.getAbsolutePath()))
+            : "";
     }
 
     /**
@@ -314,7 +319,9 @@ public class WireGuardVpnManager
      */
     public String getConfig(String publicKey){
         File file = getRemoteConfigFile(publicKey);
-        return (file != null) ? wireguardCommand("/bin/cat " + file.getAbsolutePath()) : "";
+        return (file != null)
+            ? wireguardCommand("/bin/cat", List.of(file.getAbsolutePath()))
+            : "";
     }
 
     /**
@@ -336,13 +343,14 @@ public class WireGuardVpnManager
 
     /**
      * Call wireguard and get output
-     * @param command String of command to pass to wg
-     * @return String of result of call to wg.
+     * @param executable Absolute path of executable to invoke.
+     * @param args Argument list passed verbatim (no shell interpretation).
+     * @return String of result of call.
      */
-    private String wireguardCommand(String command)
+    private String wireguardCommand(String executable, List<String> args)
     {
         String wireguardResult = "";
-        ExecManagerResult result = UvmContextFactory.context().execManager().exec(command);
+        ExecManagerResult result = UvmContextFactory.context().execManager().execCommand(executable, args);
         try {
             wireguardResult = result.getOutput();
         } catch (Exception e) {


### PR DESCRIPTION
### **Issue** 
Multiple shell-form exec() / execOutput() / execResult() call sites pass user/config-derived strings concatenated directly into a shell command. Because the underlying ExecManager.exec(String) runs through /bin/sh -c, any value containing shell metacharacters (;, |, `, $(...), newlines, etc.) is interpreted by the shell, enabling command injection as the UVM process user (root). The same pattern exists in two Python helpers (subprocess.Popen(..., shell=True)) and one Bash helper that uses unquoted positional expansions.

This PR migrates every vulnerable sink to the argv-form execCommand(executable, List<String> args) (or Popen([...], shell=False)) so arguments are passed verbatim to execve(2) and never re-parsed by a shell. Absolute paths are used for every executable, and /usr/share/untangle/bin/ut-exec-safe-launcher's allow-list is widened to cover the newly-routed binaries.

### **Fix**

**ipsec-vpn/hier/usr/share/untangle/bin/ipsec-tunnel-status**

- Convert subprocess.Popen from shell=True string-form to argv-list shell=False, so work_name (argv[1]) cannot inject shell metacharacters into the ipsec statusall call.

**ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java**

- Replace four `execManager().exec("kill -HUP " + …) / "ipsec down " + … / execOutput(GRAB_TUNNEL_STATUS_SCRIPT + " " + …)` sites with `execCommand("/bin/kill", …), execCommand("/sbin/ipsec", …), and execCommand(GRAB_TUNNEL_STATUS_SCRIPT, …). entry.getNetProcess(), getNetInterface(), and tunnel.getWorkName()` flow from VPN session/config state and previously concatenated unescaped into a shell string.


**ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnDataTimer.java**

- Migrate the `TUNNEL_STATUS_SCRIPT + " " + watcher.tunnelName` call to argv-form `execCommand(TUNNEL_STATUS_SCRIPT, List.of(watcher.tunnelName))` so the tunnel name cannot break out of the shell argument.
- Add java.util.List import.

**ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnManager.java**

- Convert `exec("ipsec route " + tunnel.getWorkName()) `to `execCommand(IPSEC_APP, List.of("route", tunnel.getWorkName())) `— same getWorkName() taint path as above.

**uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher**

- Extend the ALLOWED_EXECUTABLES allow-list with the absolute paths newly routed through the safe launcher: `net, ipset, openssl, ip, pgrep, exim4, cat, wg, ut-radius-proxy, ipsec-tunnel-status, wan-failover-pingable-hosts.sh, ut-wireguard-helpers.sh. `Without these the migrated Java sites would be rejected by the launcher's whitelist.


**uvm/hier/usr/share/untangle/bin/ut-radius-proxy**

- Switch subprocess.Popen to `argv-list shell=False,` so the AD username/password (sys.argv[1]/[2]) reach net ads status -U … as a single argument instead of being expanded by /bin/sh.

**uvm/hier/usr/share/untangle/bin/ut-wireguard-helpers.sh**

- Quote "$2" and "$3" in the showPublicKey helper so the private-key value and the wg binary path are not subject to word-splitting / glob expansion when piped to … pubkey.


**uvm/impl/com/untangle/uvm/CertificateManagerImpl.java**

- Replace execOutput("openssl x509 … -in " + CERT_STORE_PATH + getWebCertificate()) with `execCommand("/usr/bin/openssl", List.of("x509","-noout","-fingerprint","-in", webCertFile))`. The web-certificate filename comes from settings and previously concatenated unescaped into a shell command.


**uvm/impl/com/untangle/uvm/ConnectivityTesterImpl.java**

- The existing calls were already argv-form, but getResult() can return null; harden by null-checking rc before comparing to 0, so a missing return code is treated as "not working" instead of NPE-ing. Logic split into explicit if blocks for clarity.


**uvm/impl/com/untangle/uvm/DaemonManagerImpl.java**

- **isDaemonRunning**: migrate `execResult("pgrep -x " + daemonSearchString) `→ `execCommand("/usr/bin/pgrep", List.of("-x", daemonSearchString))`. Daemon search string can contain config-derived characters; argv-form prevents shell escape. Null-safe Integer comparison preserves the original result == 1 semantics.
- **execDaemonControlEvil**: stop building the "systemctl " + command + " " + daemonName" string; call execEvil(new String[]{"/usr/bin/systemctl", command, daemonName}) when a daemonName is given. The daemonName == null branch (raw extraRestartCommand) is preserved by API contract.
- **execDaemonControlSafe:** same pattern — argv-form execCommand("/usr/bin/systemctl", List.of(command, daemonName)), but keep a cmdLabel string for the existing per-line logger.info output so log format is unchanged. Raw-command path preserved.
- **handleDaemonCheck**: replace `execOutput("pgrep " + object.searchString).split(...) `with argv-form `execCommand("/usr/bin/pgrep", List.of(object.searchString)).` Null-guard output so empty result still yields length == 1 matching prior semantics.
- Add java.util.List import.


**uvm/impl/com/untangle/uvm/HostTableImpl.java**

- Three `execOutput("ipset create|add|del tag-" + tagName + " " + address)` sites → `execCommand("/usr/sbin/ipset", List.of(…))`. tagName comes from user-defined tag strings and address from host-table entries; both were concatenated into shell strings. Null-guard the captured output before splitting/logging.
- Add java.util.List import.

**uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java**

- **getRadiusProxyStatus:** replace String.format("%s \"%s\" \"%s\"", FREERADIUS_PROXY_SCRIPT, username, password) (which only quoted with shell-level double-quotes — broken if the password contains ", \, $, `) with execCommand(FREERADIUS_PROXY_SCRIPT, List.of(username, userPassword)). Argv-form removes any need for shell quoting and closes the password-injection vector.
- **addComputerAccount:** replace the multi-segment string-concat that built /usr/bin/net ads … join -U "u%p" -S srv osName="…" with a single execCommand("/usr/bin/net", List.of(…)) invocation. The username/password and AD server name previously flowed unescaped into a shell command. The follow-on systemctl restart winbind.service is also migrated to argv-form, and the success check uses null-safe getResult() accessors.
- **getNtlmHash:** trivial null-guard on the captured execCommand(...).getOutput() so callers always get a non-null String.


**uvm/impl/com/untangle/uvm/MailSenderImpl.java**

- Replace `execOutput("exim -M " + logId)` with `execCommand("/usr/sbin/exim4", List.of("-M", logId)).` logId is a mail-queue identifier that could contain characters; argv-form prevents any shell interpretation.


**uvm/impl/com/untangle/uvm/NetworkManagerImpl.java**

- The VRRP check used `execResult("ip add list " + symbolicDev + " | grep '" + vrrpAddress + "/'")`. Both the interface symbolic name and the IP address were concatenated into a shell pipeline with grep — a classic injection sink and also fragile (the grep ran inside the shell). Replaced with argv-form `execCommand("/sbin/ip", List.of("add","list", symbolicDev))` and Java-side String.contains over the output for the address/ needle, eliminating both the shell and the external grep process.

**wan-failover/src/com/untangle/app/wan_failover/WanFailoverApp.java**

- Replace `execOutput(PINGABLE_HOSTS_SCRIPT + " " + uplinkID + " " + symbolicDev) `with `execCommand(PINGABLE_HOSTS_SCRIPT, List.of(String.valueOf(uplinkID), symbolicDev))`. symbolicDev is interface-config derived and previously concatenated into a shell string.

**wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnManager.java**

- **addTunnel:** stop building a single wg set wg0 peer <key> [endpoint host:port] persistent-keepalive N allowed-ips a,b,c shell string. Build an ArrayList<String> of argv pieces, conditionally appending endpoint host/port, and dispatch via the new argv-form wireguardCommand(WIREGUARD_APP, wgArgs). The companion ip -4 route add <ip> dev wg0 calls are also migrated to argv-form. publicKey, endpointHostname, and allowedIps (each derived from tunnel config) previously flowed unescaped into a shell string.
- **removeTunnel:** same migration — each ip -4 route delete … and the final wg … peer <key> remove becomes an argv-form wireguardCommand call.
- createPrivateKey, getPublicKey, getQrCodeBase64, getConfig: each of these one-liners (wg genkey, ut-wireguard-helpers.sh showPublicKey …, qrencode -t SVG -o - -r <file>, cat <file>) is converted to argv-form. The QR / config file paths and the private key were the taint sources.
- **wireguardCommand helper:** signature changed from (String command) (shell-form) to (String executable, List<String> args) (argv-form); internally calls execManager().execCommand(executable, args). Javadoc updated.