### PR TITLE
  NGFW-15767 - Fix RCE and path-traversal gaps in the NGFW-15765 Safe…

### DIFF
--- a/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/UtCallbackController.java
+++ b/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/UtCallbackController.java
@@ -49,10 +49,25 @@ public class UtCallbackController extends CallbackController
                                   Object[] arguments)
     {
         if (arguments == null) return;
-        Annotation[][] paramAnns = method.getParameterAnnotations();
+
+        // Jabsorb hands us the *interface* Method (registerObject was called
+        // with the interface class). Java does not inherit parameter annotations
+        // from an impl method back to the interface method, so reading
+        // @SafeCheckParam off `method` returns nothing. Resolve the matching
+        // method on the actual impl class instead.
+        Method annotated = method;
+        try {
+            annotated = instance.getClass().getMethod(method.getName(), method.getParameterTypes());
+        } catch (NoSuchMethodException ignored) {
+            // instance must implement the dispatched method; fall back to the
+            // interface method (no annotations available).
+        }
+        Annotation[][] paramAnns = annotated.getParameterAnnotations();
+
         String mLabel = method.getDeclaringClass().getSimpleName() + "." + method.getName();
         for (int i = 0; i < arguments.length; i++) {
             Object arg = arguments[i];
+            if (i >= paramAnns.length) { SafeCheckValidator.validateAll(arg); continue; }
             if (arg instanceof String) {
                 String s = (String) arg;
                 for (Annotation a : paramAnns[i]) {

--- a/uvm/api/com/untangle/uvm/util/SafeType.java
+++ b/uvm/api/com/untangle/uvm/util/SafeType.java
@@ -108,23 +108,26 @@ public enum SafeType
 
     /**
      * Permissive text for descriptions, contact strings, system locations,
-     * and natural-language names like {@code O'Brien} or {@code John's Folder}.
-     * Allows Unicode letters, digits, whitespace, the safe punctuation
-     * set [. _ - @ : , / + ( )], and the apostrophe ['].
-     * Excludes shell metacharacters ({@code $ & ` ; | < > \n \r "}).
+     * and natural-language names like {@code O'Brien}, {@code John's Folder},
+     * or {@code Smith &amp; Co}. Allows Unicode letters, digits, whitespace,
+     * the safe punctuation set [. _ - @ : , / + ( )], the apostrophe ['],
+     * and the ampersand [&amp;]. Excludes the remaining shell metacharacters
+     * ({@code $ ` ; | < > \n \r "}).
      *
-     * <p>The apostrophe is permitted because every current sink consumes
-     * {@code SIMPLE_TEXT} values either argv-form (e.g. openssl), URL-encoded
-     * (URIBuilder), or as JSON HTTP-body content - none string-concatenate
-     * the value into a shell command line. Future sinks that do shell
-     * interpolation must quote with {@code shlex.quote(...)} (Python) or
-     * {@code execCommand(List.of(...))} (Java); this is the same contract
-     * already required for {@link #OPAQUE_SECRET}.</p>
+     * <p>The apostrophe and ampersand are permitted because every current
+     * sink consumes {@code SIMPLE_TEXT} values either argv-form (e.g.
+     * openssl), URL-encoded (URIBuilder), or as JSON HTTP-body content -
+     * none string-concatenate the value into a shell command line.
+     * URL-encoders turn {@code &amp;} into {@code %26}; JSON bodies treat
+     * it as a literal; argv vectors do not re-tokenize. Future sinks that
+     * do shell interpolation must quote with {@code shlex.quote(...)}
+     * (Python) or {@code execCommand(List.of(...))} (Java); this is the
+     * same contract already required for {@link #OPAQUE_SECRET}.</p>
      */
     SIMPLE_TEXT(
-        Pattern.compile("^[\\p{L}\\p{N}\\p{Zs}._@:,/+()-]{1,256}$"),
+        Pattern.compile("^[\\p{L}\\p{N}\\p{Zs}._@:,/+()&-]{1,256}$"),
         256,
-        "must contain only letters, digits, spaces, and the safe punctuation . _ - @ : , / + ( ) (max 256)"),
+        "must contain only letters, digits, spaces, and the safe punctuation . _ - @ : , / + ( ) & (max 256)"),
 
     /**
      * IPv4/IPv6 literal address (no DNS lookup) with optional CIDR prefix.
@@ -226,32 +229,80 @@ public enum SafeType
      *
      * <p>Validated programmatically: requires at least one
      * {@code -----BEGIN <LABEL>-----} ... {@code -----END <LABEL>-----}
-     * envelope; permits multiple concatenated blocks separated by
-     * whitespace (legal for cert chains). Body characters between the
-     * BEGIN/END markers are restricted to the base64 alphabet plus
-     * whitespace. Cryptographic validity is <b>not</b> checked here -
-     * the OpenSSL sink layer handles that.</p>
+     * envelope with matching label, and rejects control characters
+     * other than {@code \r}, {@code \n}, {@code \t}. The body is
+     * <i>not</i> constrained to a strict base64 alphabet, so real-world
+     * exports work: openssl's {@code x509 -text} preamble, PKCS12
+     * {@code Bag Attributes:} headers, encrypted-key
+     * {@code Proc-Type:}/{@code DEK-Info:} headers, and benign
+     * commentary between blocks are all accepted.</p>
+     *
+     * <p><b>RCE contract:</b> the PEM payload is written to a file
+     * with {@code FileOutputStream} and then read by openssl - it is
+     * never interpolated into a shell command line, so body characters
+     * have no path to a shell. The control-char check still blocks NUL
+     * (which truncates C strings) and the BEL/ESC class that can
+     * corrupt downstream log handling. Cryptographic validity is left
+     * to the openssl sink.</p>
      */
     PEM(
         null, // validated programmatically, see validate()
         16384,
-        "must be a PEM block bounded by -----BEGIN ...----- and -----END ...----- markers with a base64 body (max 16 KB)"),
+        "must contain at least one -----BEGIN ...----- / -----END ...----- envelope with matching label and no control characters other than CR/LF/TAB (max 16 KB)"),
 
     /**
      * X.500 distinguished name as composed by the certificate UI:
      * {@code /CN=Foo/C=US/ST=CA/L=City/O=Org} etc. Each RDN is a 1-4
      * letter type label, an {@code =}, and a value drawn from the
-     * conservative subset {@code [A-Za-z0-9 ._@:+()*-]}. No quoted
-     * RDNs, no embedded slashes inside values - both legal in X.500
-     * but neither used by the UI dialog. {@code *} is permitted to
-     * support wildcard CNs (e.g. {@code /CN=*.example.com}); this is
-     * safe because the value is passed argv-form to openssl and never
-     * interpreted by a shell. Length capped at 512.
+     * subset {@code [\p{L}\p{N} ._@:+()*'&,-]} - Unicode letters and
+     * digits, spaces, and the safe punctuation needed by real-world
+     * subjects ({@code O'Brien}, {@code Smith & Co}, {@code Foo, Inc.},
+     * names with accented characters). No quoted RDNs and no embedded
+     * slashes inside values - both legal in X.500 but neither used by
+     * the UI dialog. {@code *} is permitted to support wildcard CNs
+     * (e.g. {@code /CN=*.example.com}); apostrophe, ampersand and
+     * comma are safe because the value is passed argv-form to openssl
+     * and the helper script uses {@code "$2"}-quoted parameter
+     * expansion, neither of which re-interprets these as shell metas.
+     * Shell metacharacters {@code $ ` ; | < > " \\} and newlines remain
+     * rejected. Length capped at 512.
      */
     CERT_SUBJECT(
-        Pattern.compile("^/[A-Za-z]{1,4}=[A-Za-z0-9 ._@:+()*-]+(/[A-Za-z]{1,4}=[A-Za-z0-9 ._@:+()*-]+)*$"),
+        Pattern.compile("^/[A-Za-z]{1,4}=[\\p{L}\\p{N} ._@:+()*'&,-]+(/[A-Za-z]{1,4}=[\\p{L}\\p{N} ._@:+()*'&,-]+)*$"),
         512,
-        "each field in the certificate subject must be non-empty and use only letters, digits, spaces, or . _ @ : + ( ) * - (e.g. /CN=Host/C=US/ST=California/L=City/O=Org or /CN=*.example.com; max 512 chars)"),
+        "each field in the certificate subject must be non-empty and use only letters, digits, spaces, or . _ @ : + ( ) * ' & , - (e.g. /CN=Host/C=US/ST=California/L=City/O=Org or /CN=*.example.com; max 512 chars)"),
+
+    /**
+     * Natural-language proper name - a person's name, an organization name,
+     * a CA common name, or any other single-segment free-form name field
+     * that needs to accommodate real-world punctuation. Examples:
+     * {@code O'Brien}, {@code Smith & Co}, {@code Foo, Inc.},
+     * {@code Sao Paulo Org}, {@code Acme Root CA}.
+     *
+     * <p>Charset: Unicode letters/digits, spaces, and the safe punctuation
+     * {@code . _ - @ : + ( ) * ' & ,}. Shell metacharacters
+     * ({@code $ ; | < > " \ ` }) and newlines remain rejected. The path
+     * separator {@code /} is intentionally <i>not</i> in the charset:
+     * NATURAL_NAME values are single segments (one CA name, one person's
+     * name) and several sinks ({@code ut-rootgen}, cert-store directory
+     * layout) use the value as a single filesystem path component.
+     * Path traversal sequences ({@code ..}) are also rejected
+     * programmatically - see {@link #validate(String)}.</p>
+     *
+     * <p><b>Sink contract:</b> safe wherever the value is consumed
+     * argv-form (openssl, exec arrays), URL-encoded (URIBuilder), or as
+     * JSON HTTP-body content. If the value is interpolated into a shell
+     * command - even argv-passed and then re-expanded inside a script -
+     * <b>the receiving shell variable must be double-quoted</b>
+     * ({@code "$VAR"}), otherwise the allowed {@code &amp;}, {@code *},
+     * space, and {@code (} {@code )} characters become shell-active.
+     * This is the contract that {@code ut-rootgen} satisfies for the CA
+     * directory name.</p>
+     */
+    NATURAL_NAME(
+        Pattern.compile("^[\\p{L}\\p{N} ._@:+()*'&,-]{1,256}$"),
+        256,
+        "must contain only letters, digits, spaces, and the safe punctuation . _ - @ : + ( ) * ' & , (no '..' or '/'; max 256 chars)"),
 
     /**
      * X.509 Subject Alternative Name list as composed by the certificate
@@ -300,6 +351,33 @@ public enum SafeType
         null,  // validated programmatically, see validate()
         1024,
         "must be a regular expression up to 1024 characters; control characters (NUL, ESC, BEL, CR, LF) are not allowed"),
+
+    /**
+     * OAuth 2.0 authorization code / token shape. Used for values received
+     * from third-party identity providers (Google Drive, etc.) that are
+     * then submitted back to the provider's token endpoint as
+     * {@code application/x-www-form-urlencoded} body content.
+     *
+     * <p>Real-world codes include the base64url alphabet
+     * ({@code A-Z a-z 0-9 _ -}), the standard-base64 alphabet
+     * ({@code / + =} padding), the JWT segment separator {@code .},
+     * and occasionally {@code %} from upstream percent-encoding. Length
+     * cap 4096 covers JWT-shaped responses and long Google "4/..." codes
+     * with margin.</p>
+     *
+     * <p><b>Leading-char rule:</b> first character is restricted to
+     * {@code [A-Za-z0-9]} (no leading {@code -} or {@code /}) to close
+     * argv-option-injection in case any future sink shells the value.</p>
+     *
+     * <p><b>Sink contract:</b> the value is URL-encoded into a form body
+     * and POSTed to the provider - it never reaches a shell. The
+     * allowlist still blocks NUL / CR / LF and other control bytes that
+     * could smuggle header lines into a downstream HTTP client.</p>
+     */
+    OAUTH_CODE(
+        Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._\\-/=+%]*$"),
+        4096,
+        "must be an OAuth code/token (letters, digits, '.', '_', '-', '/', '=', '+', '%'; first char alphanumeric; max 4096 chars)"),
 
     /**
      * Absolute filesystem path for a server-controlled file (e.g. a
@@ -435,6 +513,15 @@ public enum SafeType
                 }
                 return pattern.matcher(value).matches();
             case FILE_PATH:
+                if (value.contains("..")) {
+                    return false;
+                }
+                return pattern.matcher(value).matches();
+            case NATURAL_NAME:
+                // Block path-traversal sequences. The charset does not
+                // include '/', but ".." in a single segment must still be
+                // rejected because sinks like ut-rootgen use the value as
+                // a filesystem path component.
                 if (value.contains("..")) {
                     return false;
                 }
@@ -660,57 +747,49 @@ public enum SafeType
     private static final Pattern PEM_BEGIN = Pattern.compile("-----BEGIN ([A-Z0-9 ]+)-----");
     private static final Pattern PEM_END   = Pattern.compile("-----END ([A-Z0-9 ]+)-----");
 
-    /** Base64 alphabet plus PEM line-wrap whitespace. */
-    private static final Pattern PEM_BODY_CHARS = Pattern.compile("^[A-Za-z0-9+/=\\s]*$");
-
     /**
      * PEM envelope check. Requires at least one
      * {@code -----BEGIN <LABEL>-----} ... {@code -----END <LABEL>-----}
-     * pair with matching label and a base64-only body. Permits multiple
-     * concatenated blocks (cert chain) separated by whitespace. Rejects
-     * any character outside the base64 alphabet within a block - this
-     * blocks shell metacharacter smuggling between BEGIN/END markers.
+     * pair with matching label, and rejects control characters other
+     * than CR/LF/TAB anywhere in the input. The body and inter-block
+     * regions are otherwise unrestricted so real-world exports work
+     * (openssl preambles, PKCS12 {@code Bag Attributes:} headers,
+     * encrypted-key headers, benign commentary).
      *
-     * <p>Cryptographic validity is not checked - the OpenSSL sink
-     * parses the PEM for real before use.</p>
+     * <p>This is intentionally permissive: the payload is written to a
+     * file and parsed by openssl - it never reaches a shell. The
+     * control-character check still blocks NUL / BEL / ESC and similar
+     * vectors. Cryptographic validity is left to the openssl sink.</p>
      *
      * @param value the candidate PEM string; assumed non-null and non-empty.
-     * @return {@code true} if at least one well-formed envelope is present
-     *         and the entire input parses as a sequence of envelopes.
+     * @return {@code true} if at least one well-formed envelope (matching
+     *         BEGIN/END labels) is present and no disallowed control
+     *         characters appear.
      */
     private static boolean validatePem(String value)
     {
+        // Reject control chars except CR/LF/TAB. NUL truncates C strings;
+        // BEL/ESC corrupt downstream log handling. Everything printable
+        // is fine - openssl is the real parser.
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\r' || c == '\n' || c == '\t') continue;
+            if (Character.getType(c) == Character.CONTROL) return false;
+        }
+
+        // Require at least one BEGIN/END pair with matching label.
         java.util.regex.Matcher beginM = PEM_BEGIN.matcher(value);
         java.util.regex.Matcher endM   = PEM_END.matcher(value);
         int pos = 0;
         int blocks = 0;
         while (beginM.find(pos)) {
-            int beginStart = beginM.start();
-            int beginEnd   = beginM.end();
-            String label   = beginM.group(1);
-
-            // Anything between pos and beginStart must be whitespace
-            // (blank lines or stray newlines between blocks are legal;
-            // shell metacharacters / commentary are not).
-            for (int i = pos; i < beginStart; i++) {
-                if (!Character.isWhitespace(value.charAt(i))) return false;
-            }
-
+            int beginEnd = beginM.end();
+            String label = beginM.group(1);
             if (!endM.find(beginEnd)) return false;
-            if (!label.equals(endM.group(1))) return false; // mismatched label
-
-            String body = value.substring(beginEnd, endM.start());
-            if (!PEM_BODY_CHARS.matcher(body).matches()) return false;
-
+            if (!label.equals(endM.group(1))) return false;
             pos = endM.end();
             blocks++;
         }
-        if (blocks == 0) return false;
-
-        // Trailing whitespace (only) after the last END marker is OK.
-        for (int i = pos; i < value.length(); i++) {
-            if (!Character.isWhitespace(value.charAt(i))) return false;
-        }
-        return true;
+        return blocks > 0;
     }
 }

--- a/uvm/hier/usr/share/untangle/bin/ut-rootgen
+++ b/uvm/hier/usr/share/untangle/bin/ut-rootgen
@@ -41,25 +41,25 @@ echo " "
 }
 
 # The first argument should be a unique name for us to identify the root CA
-if [ -z $1 ]; then
+if [ -z "$1" ]; then
     show_usage
     exit 1
 fi
 
 # The second argument is the subject field for the root CA
-if [ -z $2 ]; then
+if [ -z "$2" ]; then
     show_usage
     exit 1
 fi
 
 # first we make sure the root CA directory exists
-if [ ! -d $UT_ROOT_PATH ]; then
-    mkdir -p $UT_ROOT_PATH
+if [ ! -d "$UT_ROOT_PATH" ]; then
+    mkdir -p "$UT_ROOT_PATH"
 fi
 
 # next we make sure the cert directory exists
-if [ ! -d $CERT_PATH ]; then
-    mkdir -p $CERT_PATH
+if [ ! -d "$CERT_PATH" ]; then
+    mkdir -p "$CERT_PATH"
 fi
 
 # if they pass anything other than DEFAULT for name ($1) then we use the provided name
@@ -72,27 +72,32 @@ if [ "$2" != "DEFAULT" ]; then
     SUBJECT="$2"
 fi
 
-# next cleanup any existing files
-rm -f $UT_ROOT_PATH/untangle.crt
-rm -f $UT_ROOT_PATH/untangle.key
-rm -f $UT_ROOT_PATH/index*
-rm -f $UT_ROOT_PATH/serial*
-rm -f $UT_ROOT_PATH/$CA_NAME/untangle.crt
-rm -f $UT_ROOT_PATH/$CA_NAME/untangle.key
-rm -f $UT_ROOT_PATH/$CA_NAME/index*
-rm -f $UT_ROOT_PATH/$CA_NAME/serial*
+# next cleanup any existing files. $CA_NAME comes from the UI / JSON-RPC client
+# and is validated upstream with SafeType.NATURAL_NAME (no '..', no shell-metas
+# outside the documented allowlist), but it can still contain '&', '*', '(' ')'
+# and whitespace - so every expansion is double-quoted to keep the shell from
+# re-tokenizing those characters. The trailing glob (e.g. /serial*) is left
+# outside the quotes so the filesystem glob still matches.
+rm -f "$UT_ROOT_PATH/untangle.crt"
+rm -f "$UT_ROOT_PATH/untangle.key"
+rm -f "$UT_ROOT_PATH"/index*
+rm -f "$UT_ROOT_PATH"/serial*
+rm -f "$UT_ROOT_PATH/$CA_NAME/untangle.crt"
+rm -f "$UT_ROOT_PATH/$CA_NAME/untangle.key"
+rm -f "$UT_ROOT_PATH/$CA_NAME"/index*
+rm -f "$UT_ROOT_PATH/$CA_NAME"/serial*
 
 # create the CA_NAME directory
-mkdir -p $UT_ROOT_PATH/$CA_NAME/
+mkdir -p "$UT_ROOT_PATH/$CA_NAME/"
 
 # create the initial serial using the current epoch time plus six extra digits
-date +%s000000 > $UT_ROOT_PATH/$CA_NAME/serial.txt
+date +%s000000 > "$UT_ROOT_PATH/$CA_NAME/serial.txt"
 
 # create the certificate index file
-touch $UT_ROOT_PATH/$CA_NAME/index.txt
+touch "$UT_ROOT_PATH/$CA_NAME/index.txt"
 
 # create the CA certificate and key
-$OPENSSL_TOOL req -batch -nodes -config $OPENSSL_CONF -new -x509 -extensions v3_root -newkey rsa:2048 -keyout $UT_ROOT_PATH/$CA_NAME/untangle.key -out $UT_ROOT_PATH/$CA_NAME/untangle.crt -days 7305 -subj "$SUBJECT"
+"$OPENSSL_TOOL" req -batch -nodes -config "$OPENSSL_CONF" -new -x509 -extensions v3_root -newkey rsa:2048 -keyout "$UT_ROOT_PATH/$CA_NAME/untangle.key" -out "$UT_ROOT_PATH/$CA_NAME/untangle.crt" -days 7305 -subj "$SUBJECT"
 
 # only root should have access to the key
-chmod 600 $UT_ROOT_PATH/$CA_NAME/untangle.key
+chmod 600 "$UT_ROOT_PATH/$CA_NAME/untangle.key"

--- a/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
@@ -609,7 +609,7 @@ public class CertificateManagerImpl implements CertificateManager
      *        The subject for the new CA root certificate
      * @return True
      */
-    public boolean generateCertificateAuthority(@SafeCheckParam(SafeType.SIMPLE_TEXT) String commonName,
+    public boolean generateCertificateAuthority(@SafeCheckParam(SafeType.NATURAL_NAME) String commonName,
                                                 @SafeCheckParam(SafeType.CERT_SUBJECT) String certSubject)
     {
         try {
@@ -674,43 +674,61 @@ public class CertificateManagerImpl implements CertificateManager
      * setActiveRootCertificate will set a specific root CA to the active root certificate
      * @param fileName
      */
-    public void setActiveRootCertificate(String fileName) { 
+    public void setActiveRootCertificate(String fileName) {
         if (fileName == null || fileName.isEmpty()) {
             logger.warn("setActiveRootCertificate: null or empty fileName rejected");
             return;
         }
 
-        // Resolve canonical path to prevent directory traversal
+        String certParent = validateCertStoreSubdirPath(fileName, "setActiveRootCertificate");
+        if (certParent == null) return;
+
+        // Use symlink function to replace CERT_STORE_PATH root certs
+        symlinkRootCerts(CERT_STORE_PATH, certParent + "/", false);
+    }
+
+    /**
+     * Validates that {@code fileName} canonicalizes to a .crt file inside a
+     * subdirectory of CERT_STORE_PATH. Returns the canonical parent directory
+     * on success, or {@code null} (with a warning logged) on any rejection.
+     *
+     * Resolves symlinks on the CERT_STORE_PATH prefix too so the comparison
+     * is apples-to-apples even when settings/ or untangle-certificates/
+     * themselves are symlinks (common in dev).
+     *
+     * @param fileName  the candidate certificate file path to validate
+     * @param callerTag short label identifying the caller, used in log messages
+     * @return the canonical parent directory path on success, or {@code null} if validation fails
+     */
+    private String validateCertStoreSubdirPath(String fileName, String callerTag) {
         String canonicalPath;
         try {
             canonicalPath = new File(fileName).getCanonicalPath();
         } catch (IOException e) {
-            logger.warn("setActiveRootCertificate: could not resolve canonical path for {}", fileName, e);
-            return;
+            logger.warn("{}: could not resolve canonical path for {}", callerTag, fileName, e);
+            return null;
         }
-
-        // Must be a .crt file
         if (!canonicalPath.endsWith(".crt")) {
-            logger.warn("setActiveRootCertificate: non-.crt file rejected: {}", canonicalPath);
-            return;
+            logger.warn("{}: non-.crt file rejected: {}", callerTag, canonicalPath);
+            return null;
         }
-
-        // Must reside inside CERT_STORE_PATH
-        String certStorePrefix = new File(CERT_STORE_PATH).getAbsolutePath();
+        String certStorePrefix;
+        try {
+            certStorePrefix = new File(CERT_STORE_PATH).getCanonicalPath();
+        } catch (IOException e) {
+            logger.warn("{}: could not resolve canonical CERT_STORE_PATH", callerTag, e);
+            return null;
+        }
         if (!canonicalPath.startsWith(certStorePrefix + "/")) {
-            logger.warn("setActiveRootCertificate: path outside CERT_STORE_PATH rejected: {}", canonicalPath);
-            return;
+            logger.warn("{}: path outside CERT_STORE_PATH rejected: {}", callerTag, canonicalPath);
+            return null;
         }
-
-        // Must be in a subdirectory of CERT_STORE_PATH, not at the top level
         String certParent = new File(canonicalPath).getParent();
-        if (certParent.equals(certStorePrefix)) {
-            logger.warn("setActiveRootCertificate: file must be in a CERT_STORE_PATH subdirectory: {}", canonicalPath);
-            return;
+        if (certParent == null || certParent.equals(certStorePrefix)) {
+            logger.warn("{}: file must be in a CERT_STORE_PATH subdirectory: {}", callerTag, canonicalPath);
+            return null;
         }
-
-        // Use symlink function to replace CERT_STORE_PATH root certs
-        symlinkRootCerts(CERT_STORE_PATH, certParent + "/", false);
+        return certParent;
     }
 
     /**
@@ -914,11 +932,13 @@ public class CertificateManagerImpl implements CertificateManager
      *        The certificate file to delete
      */
     public void removeCertificate(@SafeCheckParam(SafeType.ALPHANUM) String type,
-                                  @SafeCheckParam(SafeType.FILENAME) String fileName)
+                                  String fileName)
     {
         String fileBase;
         int dotLocation;
         File killFile;
+
+        if (fileName == null || fileName.isEmpty()) return;
 
         // don't let them delete the original system certificate
         if (fileName.equals("apache.pem")) return;
@@ -930,6 +950,14 @@ public class CertificateManagerImpl implements CertificateManager
         if (fileName.equals(UvmContextFactory.context().systemManager().getSettings().getRadiusCertificate())) return;
 
         if(type.equalsIgnoreCase("SERVER")){
+            // SERVER deletion takes a bare filename like "apache.pem".
+            // Validate at the FILENAME boundary here (the parameter is unannotated
+            // because the ROOT branch needs a path containing '/').
+            if (!SafeType.FILENAME.validate(fileName)) {
+                logger.warn("removeCertificate(SERVER): rejecting fileName {}", fileName);
+                return;
+            }
+
             // extract the file name without the extension
             dotLocation = fileName.indexOf('.');
             if (dotLocation < 0) return;
@@ -947,22 +975,20 @@ public class CertificateManagerImpl implements CertificateManager
             killFile = new File(CERT_STORE_PATH + fileBase + ".pfx");
             killFile.delete();
         } else if(type.equalsIgnoreCase("ROOT")) {
-            // Use filename to get the parent dir
-            File rootCert = new File(fileName);
-            var certParent = rootCert.getParent();
+            // ROOT deletion takes an absolute path to a .crt in a CERT_STORE_PATH subdirectory.
+            // Validate via canonicalization so we cannot be tricked into deleting
+            // arbitrary directories.
+            String certParent = validateCertStoreSubdirPath(fileName, "removeCertificate(ROOT)");
+            if (certParent == null) return;
 
-            // verify dotLocation is not top level
-            if(!certParent.equalsIgnoreCase(CERT_STORE_PATH)) {
-                File parentFile = new File(certParent);
-
-                // rm the index, crt, key, serial files in here
-                for(File child : parentFile.listFiles()) {
+            File parentFile = new File(certParent);
+            File[] children = parentFile.listFiles();
+            if (children != null) {
+                for (File child : children) {
                     child.delete();
                 }
-                
-                // rm the directory
-                parentFile.delete();
             }
+            parentFile.delete();
         }
     }
 

--- a/uvm/impl/com/untangle/uvm/CloudManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CloudManagerImpl.java
@@ -106,7 +106,7 @@ public class CloudManagerImpl implements CloudManager
     public JSONObject accountLogin(@SafeCheckParam(SafeType.EMAIL)         String email,
                                    @SafeCheckParam(SafeType.OPAQUE_SECRET) String password,
                                    @SafeCheckParam(SafeType.ALPHANUM)      String uid,
-                                   @SafeCheckParam(SafeType.ALPHANUM)      String applianceModel,
+                                   @SafeCheckParam(SafeType.SIMPLE_TEXT)   String applianceModel,
                                    @SafeCheckParam(SafeType.ALPHANUM)      String majorVersion,
                                    @SafeCheckParam(SafeType.ALPHANUM)      String installType) throws Exception
     {
@@ -174,7 +174,7 @@ public class CloudManagerImpl implements CloudManager
                                     @SafeCheckParam(SafeType.SIMPLE_TEXT)   String lastName,
                                     @SafeCheckParam(SafeType.SIMPLE_TEXT)   String companyName,
                                     @SafeCheckParam(SafeType.ALPHANUM)      String uid,
-                                    @SafeCheckParam(SafeType.ALPHANUM)      String applianceModel,
+                                    @SafeCheckParam(SafeType.SIMPLE_TEXT)   String applianceModel,
                                     @SafeCheckParam(SafeType.ALPHANUM)      String majorVersion,
                                     @SafeCheckParam(SafeType.ALPHANUM)      String installType) throws Exception
     {

--- a/uvm/impl/com/untangle/uvm/GoogleManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/GoogleManagerImpl.java
@@ -316,7 +316,7 @@ public class GoogleManagerImpl implements GoogleManager
      * @return
      */
     @Override
-    public String getAppSpecificGoogleDrivePath(@SafeCheckParam(SafeType.ALPHANUM) String appDirectory) {
+    public String getAppSpecificGoogleDrivePath(@SafeCheckParam(SafeType.SIMPLE_TEXT) String appDirectory) {
         if (getSettings() == null)
             return null;
 
@@ -399,7 +399,7 @@ public class GoogleManagerImpl implements GoogleManager
      * @param code the code to send.
      * @return null on success or the error string
      */
-    public String provideDriveCode( @SafeCheckParam(SafeType.SIMPLE_TEXT) String code )
+    public String provideDriveCode( @SafeCheckParam(SafeType.OAUTH_CODE) String code )
     {
         logger.info("Providing code [{}] to exchange for the access token", code);
 

--- a/uvm/servlets/admin/src/com/untangle/uvm/admin/jabsorb/UtCallbackController.java
+++ b/uvm/servlets/admin/src/com/untangle/uvm/admin/jabsorb/UtCallbackController.java
@@ -41,10 +41,25 @@ public class UtCallbackController extends CallbackController
     public void preInvokeCallback(Object context, Object instance, Method method, Object[] arguments)
     {
         if (arguments == null) return;
-        Annotation[][] paramAnns = method.getParameterAnnotations();
+
+        // Jabsorb hands us the *interface* Method (registerObject was called
+        // with the interface class). Java does not inherit parameter annotations
+        // from an impl method back to the interface method, so reading
+        // @SafeCheckParam off `method` returns nothing. Resolve the matching
+        // method on the actual impl class instead.
+        Method annotated = method;
+        try {
+            annotated = instance.getClass().getMethod(method.getName(), method.getParameterTypes());
+        } catch (NoSuchMethodException ignored) {
+            // instance must implement the dispatched method; fall back to the
+            // interface method (no annotations available).
+        }
+        Annotation[][] paramAnns = annotated.getParameterAnnotations();
+
         String mLabel = method.getDeclaringClass().getSimpleName() + "." + method.getName();
         for (int i = 0; i < arguments.length; i++) {
             Object arg = arguments[i];
+            if (i >= paramAnns.length) { SafeCheckValidator.validateAll(arg); continue; }
             if (arg instanceof String) {
                 String s = (String) arg;
                 for (Annotation a : paramAnns[i]) {

--- a/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/UtCallbackController.java
+++ b/uvm/servlets/setup/src/com/untangle/uvm/setup/jabsorb/UtCallbackController.java
@@ -41,10 +41,25 @@ public class UtCallbackController extends CallbackController
     public void preInvokeCallback( Object context, Object instance, Method method, Object[] arguments )
     {
         if (arguments == null) return;
-        Annotation[][] paramAnns = method.getParameterAnnotations();
+
+        // Jabsorb hands us the *interface* Method (registerObject was called
+        // with the interface class). Java does not inherit parameter annotations
+        // from an impl method back to the interface method, so reading
+        // @SafeCheckParam off `method` returns nothing. Resolve the matching
+        // method on the actual impl class instead.
+        Method annotated = method;
+        try {
+            annotated = instance.getClass().getMethod(method.getName(), method.getParameterTypes());
+        } catch (NoSuchMethodException ignored) {
+            // instance must implement the dispatched method; fall back to the
+            // interface method (no annotations available).
+        }
+        Annotation[][] paramAnns = annotated.getParameterAnnotations(); 
+
         String mLabel = method.getDeclaringClass().getSimpleName() + "." + method.getName();
         for (int i = 0; i < arguments.length; i++) {
             Object arg = arguments[i];
+            if (i >= paramAnns.length) { SafeCheckValidator.validateAll(arg); continue; }
             if (arg instanceof String) {
                 String s = (String) arg;
                 for (Annotation a : paramAnns[i]) {


### PR DESCRIPTION
### Background
PR #1192 (NGFW-15765/15766) introduced @SafeCheckParam on JSON-RPC method parameters and a Jabsorb preInvokeCallback interceptor ([UtCallbackController.java](vscode-webview://1nmcf78ff5nhlv087u5es5c73oeked7m7mfsruj11sn8ornajifi/uvm/servlets/admin/src/com/untangle/uvm/admin/jabsorb/UtCallbackController.java), plus the reports/ and setup/ copies) that was supposed to read those annotations and reject shell-meta payloads before they ever reached a sink. All of the prior sanitization PRs in this train (NGFW-15675, 15700–15705, 15741, 15743) rely on that interceptor to actually run.

### The actual bug (silent total bypass)
Jabsorb registers services by their interface class, so the Method it hands to preInvokeCallback is the interface method, not the impl method. Java does not inherit parameter annotations from an impl back to its interface declaration — so method.getParameterAnnotations() returned a 2-D array of empty Annotation[]s for every call. The interceptor's for (Annotation a : paramAnns[i]) loop body therefore never executed, and every JSON-RPC parameter went through unvalidated.

Net effect: with #1192 merged, the platform looked like it had defense-in-depth validation but actually had none. Any authenticated admin (or anyone who could reach the admin / setup / reports JSON-RPC endpoints) could send the exact shell-meta payloads NGFW-15675/15700/15701/15702/15703/15705/15741/15743 had patched out — command injection / RCE in CertificateManager, NetworkManager, WanFailoverApp, StaticRoute, the SNMP / SSL-inspector exec sites, etc.

### Fix in this PR

1. Resolve the impl-class Method before reading annotations , applied to all three copies — admin, reports, setup). Annotations now actually surface; the rest of the validator layer becomes load-bearing for the first time.
2.  Sink hardening for cert-management RCE paths exposed once validation turned on:

- [CertificateManagerImpl.setActiveRootCertificate / removeCertificate(ROOT)]: fileName here is an absolute path, not a basename — @SafeCheckParam(FILENAME) cannot cover it. Added validateCertStoreSubdirPath() which canonicalizes both the input and CERT_STORE_PATH, enforces .crt extension and "must live in a subdirectory of CERT_STORE_PATH". Without this, a JSON-RPC caller could pass a traversal path and have removeCertificate(ROOT) listFiles().delete() an arbitrary directory tree (effectively rm -rf as root).
-  [removeCertificate(SERVER)]keeps its FILENAME validation but now applied at the branch boundary, since the fileName parameter must stay unannotated for the ROOT branch.
-  [ut-rootgen]: $CA_NAME and $SUBJECT were unquoted in every rm/mkdir/openssl expansion. Even with upstream @SafeCheckParam validation, allowed characters like space, &, *, (, ) would re-tokenize and re-glob inside the script — turning a CA name like Smith & Co into shell-active text. All variable expansions are now double-quoted; trailing globs (/serial*, /index*) kept outside the quotes so filesystem matching still works.

3. SafeType charset corrections for real-world inputs that were rejected once validation went live :

- New NATURAL_NAME — for proper-name fields used as filesystem path components (CA commonName consumed by ut-rootgen). Allows O'Brien, Smith & Co, Foo, Inc., Unicode letters; rejects / and .. programmatically. generateCertificateAuthority(commonName, ...) switched from SIMPLE_TEXT → NATURAL_NAME.
-  New OAUTH_CODE — Google OAuth 4/... codes contain /, ., =, +, base64url chars. SIMPLE_TEXT rejected them, breaking GoogleManagerImpl.provideDriveCode. Leading char restricted to [A-Za-z0-9] to close argv-option-injection if any sink ever shells the value.
- SIMPLE_TEXT and CERT_SUBJECT widened to accept & (and for CERT_SUBJECT also ', ,, and Unicode letters/digits) — real CA subjects like /O=Smith & Co, Inc./CN=O'Brien were being rejected. Safe because every current sink consumes these argv-form, URL-encoded, or as JSON bodies — none string-concatenate into a shell.
-  PEM validator rewritten: previous strict "base64-only between BEGIN/END, whitespace-only between blocks" rejected legitimate exports — openssl x509 -text preambles, PKCS12 Bag Attributes: headers, encrypted-key Proc-Type:/DEK-Info: headers. New contract: require ≥1 matching BEGIN/END envelope and reject control chars other than CR/LF/TAB. Safe because the PEM is written to a file and parsed by openssl — it never reaches a shell.
- CloudManagerImpl.accountLogin/accountCreate: applianceModel switched ALPHANUM → SIMPLE_TEXT (real model strings have hyphens). GoogleManagerImpl.getAppSpecificGoogleDrivePath: appDirectory switched ALPHANUM → SIMPLE_TEXT.