### PR TITLE
ngfw-15776 Port forward rule action port should be optional

### DIFF
--- a/uvm/api/com/untangle/uvm/generic/RuleGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/RuleGeneric.java
@@ -17,6 +17,7 @@ import com.untangle.uvm.network.UpnpRule;
 import com.untangle.uvm.network.UpnpRuleCondition;
 import com.untangle.uvm.util.Constants;
 import com.untangle.uvm.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.json.JSONString;
 
@@ -126,7 +127,7 @@ public class RuleGeneric implements JSONString, Serializable {
         if(ruleGeneric.getAction() != null) {
             portForwardRule.setNewDestination(ruleGeneric.getAction().getDnat_address());
             String dnatPort = ruleGeneric.getAction().getDnat_port();
-            portForwardRule.setNewPort((dnatPort != null && !dnatPort.trim().isEmpty())
+            portForwardRule.setNewPort(StringUtils.isNotBlank(dnatPort)
                 ? StringUtil.getInstance().parseInt(dnatPort, 80)
                 : null);
         }

--- a/uvm/api/com/untangle/uvm/generic/RuleGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/RuleGeneric.java
@@ -125,7 +125,10 @@ public class RuleGeneric implements JSONString, Serializable {
         // Transform Action
         if(ruleGeneric.getAction() != null) {
             portForwardRule.setNewDestination(ruleGeneric.getAction().getDnat_address());
-            portForwardRule.setNewPort(StringUtil.getInstance().parseInt(ruleGeneric.getAction().getDnat_port(), 80));
+            String dnatPort = ruleGeneric.getAction().getDnat_port();
+            portForwardRule.setNewPort((dnatPort != null && !dnatPort.trim().isEmpty())
+                ? StringUtil.getInstance().parseInt(dnatPort, 80)
+                : null);
         }
 
         // Transform Conditions


### PR DESCRIPTION
## Summary

Fixes a bug where Port Forward rules automatically set the destination port to **80** when the optional "New Destination Port" field is left blank by the user.

## Problem

When creating a Port Forward rule under **Config > Network > Port Forward**, the "Port" field in the New Destination section is optional. Leaving it blank is intended to mean _"forward traffic on whichever port it was received on"_ — i.e., no port translation.

Instead, the saved rule always showed `<IP>:80` and forwarded all traffic to port 80 on the destination host.

## Root Cause

In `RuleGeneric.transformPortForwardRule()`, the conversion from the generic Vue API rule format to the legacy `PortForwardRule` object used:

```java
portForwardRule.setNewPort(StringUtil.getInstance().parseInt(ruleGeneric.getAction().getDnat_port(), 80));
```

`StringUtil.parseInt()` returns its `defaultValue` argument whenever the string is `null` or unparseable. When the user leaves the port field blank, the frontend correctly omits `dnat_port` (sends `null`). However, `parseInt(null, 80)` silently returned `80`, which was then saved as the redirect port.

`PortForwardRule.newPort` is typed as `Integer` (nullable), where `null` is the correct representation of "no port translation".


## Testing

- [x] Port forward rule with blank destination port saves and displays without `:80`
- [x] Port forward rule with an explicit destination port (e.g. `443`) still saves and forwards correctly
- [x] Multiple rules mixing blank and explicit destination ports all round-trip correctly
- [x] Existing port forward rules are unaffected after upgrade
