### PR TITLE
ngfw-15778 updated accepted backup versions for release 17.5

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-restore.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-restore.sh
@@ -11,7 +11,7 @@ WORKING_DIR=""
 TARBALL_FILE=""
 VERSION_FILE=""
 # To support multiple versions, separate with pipe character like:
-ACCEPTED_PREVIOUS_VERSION="17.3"
+ACCEPTED_PREVIOUS_VERSION="17.4"
 
 function debug() {
   if [ "true" == $VERBOSE ]; then


### PR DESCRIPTION
## Problem

Restoring a backup from a device running **17.4.x** to a device running **17.5** fails with:

> `supported versions = 17.3 and 17.5`

## Root Cause

`ut-restore.sh` validates the backup version against `ACCEPTED_PREVIOUS_VERSION` before restoring. For the 17.5 release, this value was not updated from `17.3` to `17.4`, causing 17.4 backups to be rejected.

## Testing

- [x] Restore a **17.4.x** backup on a **17.5** device — should succeed
- [x] Restore a **17.5** backup on a **17.5** device — should succeed
- [x] Restore a backup older than **17.4** on a **17.5** device — should be rejected
