### PR TITLE
ngfw-15778 updated accepted backup restore versions for release 18.0

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-restore.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-restore.sh
@@ -11,7 +11,7 @@ WORKING_DIR=""
 TARBALL_FILE=""
 VERSION_FILE=""
 # To support multiple versions, separate with pipe character like:
-ACCEPTED_PREVIOUS_VERSION="17.3"
+ACCEPTED_PREVIOUS_VERSION="17.5"
 
 function debug() {
   if [ "true" == $VERBOSE ]; then


### PR DESCRIPTION
## Summary

Proactive release maintenance for **18.0.0** — updated `ACCEPTED_PREVIOUS_VERSION` in `ut-restore.sh` to accept backups taken from devices running **17.5.x**.

This ensures users upgrading from **17.5** to **18.0.0** can restore their backups without a version mismatch error.

## Testing

- [x] Restore a **17.5** backup on an **18.0.0** device — should succeed
- [x] Restore an **18.0.0** backup on an **18.0.0** device — should succeed
- [x] Restore a backup older than **17.5** on an **18.0.0** device — should be rejected
