### PR TITLE
Ngfw 15792

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -97,13 +97,25 @@ def update():
     return p.returncode
 
 def check_upgrade():
+    """
+    Simulate dist-upgrade.
+    Returns:
+      0  = clean, ok to proceed
+      1  = packages kept back (caller decides whether to abort)
+      >1 = apt-get -s returned a real error
+    """
     p = subprocess.Popen(["sh","-c","apt-get -s dist-upgrade %s 2>&1" % UPGRADE_OPTS], stdout=subprocess.PIPE, text=True)
+    kept_back = False
     for line in iter(p.stdout.readline, ''):
         if re.search('.*been kept back.*', line):
             log( "Packages have been kept back.\n" )
-            return 1
+            kept_back = True
     p.wait()
-    return p.returncode
+    if p.returncode != 0:
+        return p.returncode if p.returncode > 1 else 2
+    if kept_back:
+        return 1
+    return 0
 
 def upgrade():
     log("apt-get dist-upgrade %s" % UPGRADE_OPTS)
@@ -329,6 +341,192 @@ def post_upgrade_fixups():
         except:
             pass
 
+# ---- Trixie upgrade helpers ---- #
+
+def is_trixie_upgrade():
+    """
+    Detect if apt sources point to trixie while the system is still on
+    bookworm kernel (6.1.x) — or just rebooted into trixie kernel (6.12.x)
+    with post-upgrade fixups not yet completed.
+    Returns True only when the upgrade target is trixie and fixups are needed.
+    """
+    sources_have_trixie = False
+    sources_dirs = ["/etc/apt/sources.list.d/"]
+    sources_files = ["/etc/apt/sources.list"]
+    for d in sources_dirs:
+        if os.path.isdir(d):
+            for f in os.listdir(d):
+                fp = os.path.join(d, f)
+                if os.path.isfile(fp):
+                    sources_files.append(fp)
+    for sf in sources_files:
+        try:
+            with open(sf) as fh:
+                for line in fh:
+                    if 'trixie' in line and not line.strip().startswith('#'):
+                        sources_have_trixie = True
+                        break
+        except:
+            pass
+        if sources_have_trixie:
+            break
+
+    if not sources_have_trixie:
+        return False
+
+    # Pre-reboot: bookworm 6.1.x kernel still running, dist-upgrade needed
+    running_kernel = platform.release()
+    if running_kernel.startswith("6.1.") or running_kernel.startswith("5.") or running_kernel.startswith("4."):
+        log("Trixie upgrade detected: sources point to trixie, running kernel %s" % running_kernel)
+        return True
+
+    # Post-reboot: trixie 6.12.x kernel active, check whether fixups already ran
+    fixup_done_flag = "/var/lib/untangle-vm/.trixie-upgrade-fixups-done"
+    if not os.path.exists(fixup_done_flag):
+        log("Trixie post-upgrade fixups needed: flag file missing on kernel %s" % running_kernel)
+        return True
+
+    log("Trixie upgrade: system appears fully migrated on kernel %s" % running_kernel)
+    return False
+
+def pre_upgrade_cleanup_trixie():
+    """
+    Pre-upgrade fixups for bookworm->trixie:
+    - Pre-install openjdk-21-jre-headless. trixie untangle-vm needs JDK21 for
+      SSL Inspector compat (NGFW-15749 afe4c8650a) but untangle-vm's Depends
+      doesn't hard-pull it in, so apt would otherwise keep stale openjdk-17.
+    - Preserve wizard-complete flag so the setup wizard doesn't re-appear.
+    """
+    log("Pre-upgrade: Trixie target detected -- installing prerequisites")
+
+    log("Pre-upgrade: pre-installing openjdk-21-jre-headless (required for SSL Inspector JDK21 compat)")
+    cmd_to_log("apt-get install -y --no-install-recommends openjdk-21-jre-headless")
+
+    wizard_flag = "/usr/share/untangle/conf/wizard-complete"
+    if os.path.exists(wizard_flag):
+        log("Pre-upgrade: wizard-complete flag exists, will be preserved")
+    else:
+        log("Pre-upgrade: creating wizard-complete flag")
+        try:
+            os.makedirs(os.path.dirname(wizard_flag), exist_ok=True)
+            with open(wizard_flag, "w") as f:
+                f.write("upgrade\n")
+        except:
+            log("Pre-upgrade: WARNING - could not create wizard-complete flag")
+
+def post_upgrade_fixups_trixie():
+    """
+    Post-upgrade fixups for bookworm->trixie:
+    - dpkg --configure -a to finish any half-installed packages.
+    - sync-settings to regenerate trixie-specific configs.
+    - Wait for deferred postinst daemon-reload cascade to settle (~30s).
+      Multiple package postinsts each invoke `systemctl daemon-reload`,
+      and the cumulative effect auto-restarts untangle-vm. That restart
+      hits a JDK21+jabsorb parallel-load race where MarshallingModeContext.pop()
+      throws NoSuchElementException and ~3 apps fail to init (observed:
+      tunnel-vpn, intrusion-prevention). A clean stop+start cures it.
+    - Mark fixups done so subsequent ut-upgrade.py runs skip them.
+    """
+    log("Post-upgrade: Trixie runtime configuration")
+
+    log("Post-upgrade: configuring pending packages")
+    cmd_to_log("dpkg --configure -a")
+
+    log("Post-upgrade: regenerating runtime configs via sync-settings")
+    cmd_to_log("sync-settings || true")
+
+    log("Post-upgrade: refreshing PG collation metadata (glibc 2.36 -> 2.41 on trixie changes collation version)")
+    # Ensure PostgreSQL is up before REFRESH. dpkg --configure / sync-settings can transition
+    # postgresql.service through stop/start during trixie postinst; if we hit it mid-restart the
+    # psql calls fail with "connection to server on socket failed: No such file or directory".
+    cmd_to_log("systemctl start postgresql || true")
+    cmd_to_log("for i in $(seq 1 30); do pg_isready -q && break; sleep 1; done")
+    cmd_to_log("su - postgres -c \"psql -d uvm -c 'REINDEX DATABASE uvm;'\" 2>&1 | tail -5 || true")
+    cmd_to_log("su - postgres -c \"psql -d uvm -c 'ALTER DATABASE uvm REFRESH COLLATION VERSION;'\" 2>&1 | tail -3 || true")
+    cmd_to_log("su - postgres -c \"psql -d postgres -c 'ALTER DATABASE postgres REFRESH COLLATION VERSION;'\" 2>&1 | tail -3 || true")
+    cmd_to_log("su - postgres -c \"psql -d template1 -c 'ALTER DATABASE template1 REFRESH COLLATION VERSION;'\" 2>&1 | tail -3 || true")
+
+    log("Post-upgrade: waiting 30s for systemd postinst cascade to settle")
+    time.sleep(30)
+
+    log("Post-upgrade: clean restart of untangle-vm to clear JDK21/jabsorb parallel-load race")
+    cmd_to_log("systemctl stop untangle-vm")
+    time.sleep(5)
+    cmd_to_log("systemctl start untangle-vm")
+
+    fixup_done_flag = "/var/lib/untangle-vm/.trixie-upgrade-fixups-done"
+    try:
+        os.makedirs(os.path.dirname(fixup_done_flag), exist_ok=True)
+        with open(fixup_done_flag, "w") as f:
+            f.write("trixie upgrade fixups completed at %s\n" % time.strftime("%Y-%m-%d %H:%M:%S"))
+        log("Post-upgrade: marked fixups complete at %s" % fixup_done_flag)
+    except:
+        log("Post-upgrade: WARNING - could not write fixup done flag")
+
+    log("Post-upgrade: Trixie fixups complete")
+
+def protect_untangle_packages_from_autoremove():
+    """
+    Mark untangle-* and related runtime-required packages as manually installed
+    BEFORE running autoremove. Defense against autoremove sweeping packages that
+    have no formal Debian dependency from a manually-installed package but ARE
+    invoked at runtime by NGFW scripts and tooling.
+
+    Two failure modes this protects against:
+
+    1. NGFW package anchor missing: When the meta-package that normally anchors
+       all untangle-* (untangle-gateway) is missing or has lost its
+       manual-install marker, autoremove flags every untangle-* as an orphan.
+       Observed 2026-05-22 during bullseye->trixie attempt on .175: dist-upgrade
+       installed untangle-vm-1trixie cleanly, then autoremove --purge flagged
+       501 packages (untangle-vm, all untangle-app-*, untangle-libuvm*, etc.)
+       and destroyed them.
+
+    2. Runtime tools not formally declared as Depends: NGFW shell scripts call
+       binaries like smartctl (disk health check inside this very script), dig,
+       wg, etc. that have no formal Debian package dependency from any
+       untangle-* package. They were installed historically as recommended
+       packages or by other Untangle releases. Autoremove will sweep them when
+       the recommending package goes away.
+
+    apt-mark manual on already-manual or already-installed packages is a no-op,
+    so safe to run unconditionally on every ut-upgrade.py invocation.
+    """
+    log("Pre-autoremove: marking untangle-* + critical runtime packages as manually installed (anti-sweep)")
+
+    # Anchor untangle-gateway + untangle-vm explicitly (these are normally the
+    # manually-installed roots; re-anchor in case markers got scrambled)
+    cmd_to_log("apt-mark manual untangle-vm untangle-gateway 2>&1 | tail -5 || true")
+
+    # Mark ALL currently-installed untangle-* as manual so autoremove won't
+    # touch them if the gateway anchor is missing
+    cmd_to_log("dpkg -l 'untangle-*' 2>/dev/null | awk '/^ii/ {print $2}' | xargs -r apt-mark manual 2>&1 | tail -10 || true")
+
+    # Runtime tools NGFW scripts invoke but don't formally depend on. apt-mark
+    # only marks packages that are actually installed; missing packages are
+    # silently skipped.
+    runtime_tools = [
+        "smartmontools",     # smartctl used by ut-upgrade.py check_disk_health
+        "wireguard-tools",   # wg, wg-quick for WireGuard VPN userland
+        "lsb-release",       # /usr/bin/lsb_release used by various NGFW scripts
+        "dnsutils",          # bullseye name for dig/host/nslookup
+        "bind9-dnsutils",    # bookworm/trixie name for same
+        "tcpdump",           # network capture (support diagnostics)
+        "traceroute",        # routing diagnostics
+        "iproute2",          # ip command (used everywhere)
+        "bridge-utils",      # brctl (legacy bridge tooling)
+        "ethtool",           # NIC inspection
+        "iputils-ping",      # ping binary
+        "rsyslog",           # logging
+        "logrotate",         # log rotation
+        "cron",              # scheduled jobs
+        "openssh-server",    # SSH access
+        "sudo",              # privilege escalation
+    ]
+    # Note: mtr-tiny intentionally excluded — not in Untangle's curated trixie
+    # mirror as of 2026-05-22. If the mirror later adds it, add back here.
+    cmd_to_log("apt-mark manual %s 2>&1 | tail -10 || true" % " ".join(runtime_tools))
+
 # ---- Main flow ---- #
 
 log_date( os.path.basename( sys.argv[0]) )
@@ -349,8 +547,9 @@ if "2.6.32" in platform.platform():
 log_date("")
 log("")
 
-# Detect if this is a Bookworm major version upgrade
+# Detect major version upgrade target (bookworm or trixie)
 bookworm_upgrade = is_bookworm_upgrade()
+trixie_upgrade = is_trixie_upgrade()
 
 if bookworm_upgrade:
     log("")
@@ -360,11 +559,28 @@ if bookworm_upgrade:
     log("")
     pre_upgrade_cleanup()
     log("")
+elif trixie_upgrade:
+    log("")
+    log("=" * 60)
+    log("MAJOR VERSION UPGRADE: Bookworm -> Trixie detected")
+    log("=" * 60)
+    log("")
+    pre_upgrade_cleanup_trixie()
+    log("")
 
 r = check_upgrade();
-if r != 0:
+if r > 1:
     log("apt-get -s dist-upgrade returned an error (%i). Abort." % r)
     sys.exit(1)
+if r == 1:
+    # Packages kept back. Tolerate for trixie major-version upgrade where
+    # a transitional library (e.g. libmanette-0.2-0) commonly can't be
+    # reconciled by apt's resolver mid-hop; abort otherwise.
+    if trixie_upgrade:
+        log("Packages kept back during trixie upgrade -- proceeding anyway (may need manual install post-upgrade)")
+    else:
+        log("Packages have been kept back. Abort.")
+        sys.exit(1)
 
 r = upgrade()
 
@@ -381,6 +597,7 @@ if r != 0:
         log("dist-upgrade retry also failed (%i). Check upgrade.log for details." % r)
         # Continue anyway — autoremove/depmod may still help
 
+protect_untangle_packages_from_autoremove()
 autoremove()
 
 log_date("")
@@ -388,6 +605,9 @@ log("")
 
 if bookworm_upgrade:
     post_upgrade_fixups()
+    log("")
+elif trixie_upgrade:
+    post_upgrade_fixups_trixie()
     log("")
 
 clean()

--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -442,9 +442,28 @@ def post_upgrade_fixups_trixie():
     cmd_to_log("systemctl start postgresql || true")
     cmd_to_log("for i in $(seq 1 30); do pg_isready -q && break; sleep 1; done")
     cmd_to_log("su - postgres -c \"psql -d uvm -c 'REINDEX DATABASE uvm;'\" 2>&1 | tail -5 || true")
-    cmd_to_log("su - postgres -c \"psql -d uvm -c 'ALTER DATABASE uvm REFRESH COLLATION VERSION;'\" 2>&1 | tail -3 || true")
-    cmd_to_log("su - postgres -c \"psql -d postgres -c 'ALTER DATABASE postgres REFRESH COLLATION VERSION;'\" 2>&1 | tail -3 || true")
-    cmd_to_log("su - postgres -c \"psql -d template1 -c 'ALTER DATABASE template1 REFRESH COLLATION VERSION;'\" 2>&1 | tail -3 || true")
+
+    # REFRESH COLLATION VERSION is PG15+ syntax. On a direct bullseye->trixie
+    # upgrade PG13 may still be serving (PG17 package installed but cluster
+    # not auto-created when PG13 owns 5432), and PG13/14 syntax-error on these
+    # ALTERs. Gate to avoid harmless but noisy errors in the upgrade log.
+    pg_server_version_num = 0
+    try:
+        r = subprocess.run(
+            ["su", "-", "postgres", "-c",
+             "psql -tAc \"SELECT current_setting('server_version_num')::int\""],
+            capture_output=True, text=True, timeout=10)
+        pg_server_version_num = int(r.stdout.strip())
+    except Exception:
+        pass
+
+    if pg_server_version_num >= 150000:
+        log("Post-upgrade: PG server_version_num=%d, running REFRESH COLLATION VERSION" % pg_server_version_num)
+        cmd_to_log("su - postgres -c \"psql -d uvm -c 'ALTER DATABASE uvm REFRESH COLLATION VERSION;'\" 2>&1 | tail -3 || true")
+        cmd_to_log("su - postgres -c \"psql -d postgres -c 'ALTER DATABASE postgres REFRESH COLLATION VERSION;'\" 2>&1 | tail -3 || true")
+        cmd_to_log("su - postgres -c \"psql -d template1 -c 'ALTER DATABASE template1 REFRESH COLLATION VERSION;'\" 2>&1 | tail -3 || true")
+    else:
+        log("Post-upgrade: PG server_version_num=%d (<150000), skipping REFRESH COLLATION VERSION (PG15+ only)" % pg_server_version_num)
 
     log("Post-upgrade: waiting 30s for systemd postinst cascade to settle")
     time.sleep(30)


### PR DESCRIPTION
Added:

1. Detection helpers
     is_bookworm_upgrade() — apt sources mention bookworm AND running kernel is 5.x (or fixup-flag missing).
     is_trixie_upgrade() — apt sources mention trixie AND running kernel is pre-6.12 (or fixup-flag missing).
       Both return False on routine same-distro updates, so no behavior change for non-upgrading customers.
2.check_upgrade() refactor
       Return distinguishable codes (0=clean, 1=kept-back, ≥2=real apt error). Trixie path tolerates kept-back (transitional   packages such as libmanette-0.2-0); Bookworm path retains strict abort.
3. protect_untangle_packages_from_autoremove()
        apt-mark manual all installed untangle-* packages before each autoremove invocation. Idempotent — safe on every run,    prevents the 501-package sweep on Bullseye → Trixie direct.
4. pre_upgrade_cleanup_trixie()
        Install openjdk-21-jre-headless before dist-upgrade to ensure SSL Inspector v3→v4 migration runs on JDK21.
5.post_upgrade_fixups_trixie()
        dpkg --configure -a
        sync-settings
        Wait for pg_isready before any psql commands.
        REINDEX DATABASE uvm.
        REFRESH COLLATION VERSION on uvm/postgres/template1 databases, gated behind server_version_num >= 150000 so PG13 (still serving on direct Bullseye → Trixie path) does not log syntax errors.
30s sleep for systemd postinst cascade quiescence, then clean systemctl stop+start untangle-vm (cures JDK21/jabsorb parallel-load race).
       Write idempotency flag at /var/lib/untangle-vm/.trixie-upgrade-fixups-done.