### PR TITLE
ngfw-15794: Relocate logo-upload extension test to branding_manager and fix WireGuard tunnel network conflict

### DIFF
--- a/branding-manager/hier/usr/lib/python3/dist-packages/tests/test_branding_manager.py
+++ b/branding-manager/hier/usr/lib/python3/dist-packages/tests/test_branding_manager.py
@@ -1,12 +1,19 @@
 """branding_manager tests"""
+import json
 import re
 import unittest
+import urllib.error
+import urllib.request
 import pytest
 
 from tests.common import NGFWTestCase
+import runtests.overrides as overrides
 import runtests.remote_control as remote_control
 import runtests.test_registry as test_registry
 import tests.global_functions as global_functions
+
+Login_username = overrides.get("Login_username", default="admin")
+Login_password = overrides.get("Login_password", default="passwd")
 
 app = None
 appWeb = None
@@ -134,6 +141,42 @@ class BrandingManagerTests(NGFWTestCase):
         myRegex = re.compile('.*A regulation banner requirement containing a mix of text including <b>html</b> and<br/>multiple<br/>lines.*', re.DOTALL|re.MULTILINE)
         assert(not re.match(myRegex, result))
         
+    def test_129_logo_upload_zip_extension_blocked(self):
+        """
+        Verify the v1 upload servlet's per-handler extension allowlist drops a
+        wrong-extension upload.
+
+        Posts a logo upload with filename='evil.zip'. The Logo handler's
+        allowlist is {gif,png,jpg,jpeg}, so SafeUpload.safeUploadName collapses
+        the basename to 'upload' (no extension survives). The handler's
+        endsWith() checks then fail and it throws
+        "Branding logo extension must be one of: .gif, .jpeg, .jpg, .png".
+        """
+        opener = global_functions.build_admin_http_opener(Login_username, Login_password)
+        boundary, body = global_functions.build_upload_multipart_body(
+            "logo", "", b"x" * 16, filename="evil.zip")
+
+        req = urllib.request.Request(
+            "http://localhost/admin/upload",
+            data=body,
+            headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        )
+        try:
+            response = opener.open(req)
+            response_text = response.read().decode()
+        except urllib.error.HTTPError as e:
+            response_text = e.read().decode()
+
+        response_json = json.loads(response_text)
+        assert response_json.get("success") == False, \
+            f"Expected logo .zip rejected, got: {response_text}"
+        msg = response_json.get("msg") or ""
+        assert "extension must be one of" in msg, \
+            f"Expected LogoUploadHandler extension rejection, got: {msg}"
+        msg_upper = msg.upper()
+        assert all(ext in msg_upper for ext in (".GIF", ".PNG", ".JPG", ".JPEG")), \
+            f"Expected allowlist {{gif,png,jpg,jpeg}} in rejection, got: {msg}"
+
     @classmethod
     def final_extra_tear_down(cls):
         global appWeb

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -1279,38 +1279,6 @@ class UvmTests(NGFWTestCase):
         assert not os.path.exists(poc_file), \
             "Path traversal succeeded via /admin/upload Content-Disposition filename (file was created at /tmp/poc.zip)"
 
-    def test_129_logo_upload_zip_extension_blocked(self):
-        """
-        Verify the v1 upload servlet's per-handler extension allowlist drops a
-        wrong-extension upload.
-
-        Posts a logo upload with filename='evil.zip'. The Logo handler's
-        allowlist is {gif,png,jpg,jpeg}, so the wrapper exposes getName() ==
-        'upload' (no extension survives). The handler's endsWith() checks fail
-        and it throws "Branding logo must be GIF, PNG, or JPG".
-        """
-        opener = global_functions.build_admin_http_opener(Login_username, Login_password)
-        boundary, body = global_functions.build_upload_multipart_body(
-            "logo", "", b"x" * 16, filename="evil.zip")
-
-        req = urllib.request.Request(
-            "http://localhost/admin/upload",
-            data=body,
-            headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
-        )
-        try:
-            response = opener.open(req)
-            response_text = response.read().decode()
-        except urllib.error.HTTPError as e:
-            response_text = e.read().decode()
-
-        response_json = json.loads(response_text)
-        assert response_json.get("success") == False, \
-            f"Expected logo .zip rejected, got: {response_text}"
-        msg = (response_json.get("msg") or "").upper()
-        assert ("GIF" in msg) or ("PNG" in msg) or ("JPG" in msg), \
-            f"Expected handler rejection mentioning GIF/PNG/JPG, got: {response_json.get('msg')}"
-
     def test_123_connectivity_tester_dns_injection_blocked(self):
         """
         Verify that shell metacharacters in UriManagerSettings.dnsTestHost are

--- a/wireguard-vpn/hier/usr/lib/python3/dist-packages/tests/test_wireguardvpn.py
+++ b/wireguard-vpn/hier/usr/lib/python3/dist-packages/tests/test_wireguardvpn.py
@@ -823,7 +823,7 @@ class WireGuardVpnTests(NGFWTestCase):
             positive_tunnel = build_wireguard_tunnel()
             positive_tunnel["description"]      = "Office VPN"
             positive_tunnel["endpointHostname"] = "vpn.example.com"
-            positive_tunnel["networks"]         = "192.168.10.0/24, 192.168.11.0/24"
+            positive_tunnel["networks"]         = "192.168.235.0/24, 192.168.236.0/24"
             positive_tunnel["routedNetworks"]   = "10.0.0.0/8"
             positive_tunnel["publicKey"]        = WG_REMOTE["publicKey"]  # known-valid 44-char base64
             positive_tunnel["privateKey"]       = ""  # blank is allowed by validator (null/empty pass)


### PR DESCRIPTION
**FIXED :**

**branding-manager/test_branding_manager.py:** 
Added test_129_logo_upload_zip_extension_blocked, which posts a multipart upload to /admin/upload with filename=evil.zip and asserts the LogoUploadHandler's per-handler allowlist rejects it with "extension must be one of: .gif, .jpeg, .jpg, .png". Pulled in the supporting imports (json, urllib.request, urllib.error, runtests.overrides) and Login_username/Login_password overrides.

**uvm/test_uvm.py:** 
Removed the older copy of test_129_logo_upload_zip_extension_blocked (test now lives with the feature it exercises, and the loose GIF/PNG/JPG substring check was superseded by the stricter allowlist assertion in the branding_manager version).

**wireguard-vpn/test_wireguardvpn.py:**
In test_080_safecheck_tunnel_and_settings_fields, changed the positive tunnel networks from 192.168.10.0/24, 192.168.11.0/24 to 192.168.235.0/24, 192.168.236.0/24 to stop colliding with the test box's LAN static-address (the 192.168.235.0/24 range is already proven safe via WG_REMOTE.networks elsewhere in the file).