### PR TITLE
Ngfw 15783 v2 apis web filter

### DIFF
--- a/uvm/api/com/untangle/uvm/generic/RuleActionGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/RuleActionGeneric.java
@@ -34,7 +34,7 @@ public class RuleActionGeneric implements JSONString, Serializable {
     public Type getType() { return type; }
     public void setType(Type type) { this.type = type; }
 
-    // Required for Web Filter Rules — indicates the rule should flag matching traffic
+    // Required for Web Filter Rules indicates the rule should flag matching traffic
     private Boolean flagged;
 
     public Boolean getFlagged() { return flagged; }

--- a/uvm/api/com/untangle/uvm/generic/RuleActionGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/RuleActionGeneric.java
@@ -20,7 +20,7 @@ public class RuleActionGeneric implements JSONString, Serializable {
      * DNAT - Required for Port Forward Rules
      * SNAT, MASQUERADE - Required for NAT Rules
      * BYPASS, PROCESS - Required for Bypass Rules
-     * ACCEPT, REJECT - Required for Filter, Access and UPnP Rules
+     * ACCEPT, REJECT - Required for Filter, Access, UPnP and Web Filter Rules
      * PRIORITY - Required for QoS Rules
      * SCAN, PASS - Required for Shield Rules
      * TARGET_POLICY - Required for Policy Manager
@@ -33,6 +33,12 @@ public class RuleActionGeneric implements JSONString, Serializable {
 
     public Type getType() { return type; }
     public void setType(Type type) { this.type = type; }
+
+    // Required for Web Filter Rules — indicates the rule should flag matching traffic
+    private Boolean flagged;
+
+    public Boolean getFlagged() { return flagged; }
+    public void setFlagged(Boolean flagged) { this.flagged = flagged; }
 
     // Required for Port Forward Rules
     private InetAddress dnat_address;

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilter.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilter.java
@@ -40,14 +40,14 @@ public interface WebFilter extends App
     /**
      * Get the settings in V2 (generic) format for the Vue UI.
      *
-     * @return {@link WebFilterSettingsGeneric} populated from the current V1 settings
+     * @return WebFilterSettingsGeneric
      */
     WebFilterSettingsGeneric getSettingsV2();
 
     /**
-     * Set the settings from a V2 (generic) payload coming from the Vue UI.
+     * Set the settings from a V2 (generic) format payload coming from the Vue UI.
      *
-     * @param newSettings V2 generic settings from the Vue UI
+     * @param newSettings WebFilterSettingsGeneric
      */
     void setSettingsV2(WebFilterSettingsGeneric newSettings);
 

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilter.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilter.java
@@ -5,6 +5,7 @@ package com.untangle.app.web_filter;
 
 import java.util.List;
 
+import com.untangle.app.web_filter.generic.WebFilterSettingsGeneric;
 import com.untangle.uvm.app.GenericRule;
 import com.untangle.uvm.app.App;
 
@@ -35,6 +36,20 @@ public interface WebFilter extends App
      *        The new settings
      */
     void setSettings(WebFilterSettings settings);
+
+    /**
+     * Get the settings in V2 (generic) format for the Vue UI.
+     *
+     * @return {@link WebFilterSettingsGeneric} populated from the current V1 settings
+     */
+    WebFilterSettingsGeneric getSettingsV2();
+
+    /**
+     * Set the settings from a V2 (generic) payload coming from the Vue UI.
+     *
+     * @param newSettings V2 generic settings from the Vue UI
+     */
+    void setSettingsV2(WebFilterSettingsGeneric newSettings);
 
     /**
      * Load the global settings

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterBase.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterBase.java
@@ -565,14 +565,9 @@ public abstract class WebFilterBase extends AppBase implements WebFilter
     }
 
     /**
-     * Get the application settings in V2 (generic) format for the Vue UI.
+     * Get the settings in V2 (generic) format for the Vue UI.
      *
-     * <p>Delegates to {@link WebFilterSettings#transformWebFilterSettingsToGeneric()}
-     * which copies all scalar fields and converts the {@code filterRules} list
-     * from {@link WebFilterRule} to the shared {@link com.untangle.uvm.generic.RuleGeneric}
-     * shape.  Returns an empty generic settings object if no settings are loaded yet.
-     *
-     * @return {@link WebFilterSettingsGeneric} populated from the current V1 settings
+     * @return WebFilterSettingsGeneric
      */
     public WebFilterSettingsGeneric getSettingsV2() {
         if (this.getSettings() != null)
@@ -581,17 +576,11 @@ public abstract class WebFilterBase extends AppBase implements WebFilter
     }
 
     /**
-     * Set the application settings from a V2 (generic) payload coming from
-     * the Vue UI.
+     * Set the settings from a V2 (generic) format payload coming from the Vue UI.
+     * Deep-clones the current V1 settings so V1-only fields (version,
+     * blockedMimeTypes, blockedExtensions) are preserved.
      *
-     * <p>Deep-clones the current V1 settings so V1-only fields are preserved through
-     * the round-trip. The clone is then mutated by
-     * {@link WebFilterSettingsGeneric#transformGenericToWebFilterSettings} and
-     * passed to the existing {@link #setSettings(WebFilterSettings)} which
-     * handles ID reassignment, flagged/blocked enforcement, persistence, and
-     * decision-engine reconfiguration.
-     *
-     * @param newSettings V2 generic settings payload from the Vue UI
+     * @param newSettings WebFilterSettingsGeneric
      */
     public void setSettingsV2(WebFilterSettingsGeneric newSettings)
     {

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterBase.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterBase.java
@@ -27,6 +27,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.hc.core5.net.URIBuilder;
 import org.apache.commons.codec.digest.Crypt;
 
+import org.apache.commons.lang3.SerializationUtils;
+
+import com.untangle.app.web_filter.generic.WebFilterSettingsGeneric;
 import com.untangle.uvm.AdminSettings;
 import com.untangle.uvm.AdminUserSettings;
 import com.untangle.uvm.SettingsManager;
@@ -559,6 +562,44 @@ public abstract class WebFilterBase extends AppBase implements WebFilter
     public void setSettings(WebFilterSettings settings)
     {
         _setSettings(settings);
+    }
+
+    /**
+     * Get the application settings in V2 (generic) format for the Vue UI.
+     *
+     * <p>Delegates to {@link WebFilterSettings#transformWebFilterSettingsToGeneric()}
+     * which copies all scalar fields and converts the {@code filterRules} list
+     * from {@link WebFilterRule} to the shared {@link com.untangle.uvm.generic.RuleGeneric}
+     * shape.  Returns an empty generic settings object if no settings are loaded yet.
+     *
+     * @return {@link WebFilterSettingsGeneric} populated from the current V1 settings
+     */
+    public WebFilterSettingsGeneric getSettingsV2() {
+        if (this.getSettings() != null)
+            return this.getSettings().transformWebFilterSettingsToGeneric();
+        return new WebFilterSettingsGeneric();
+    }
+
+    /**
+     * Set the application settings from a V2 (generic) payload coming from
+     * the Vue UI.
+     *
+     * <p>Deep-clones the current V1 settings so V1-only fields are preserved through
+     * the round-trip. The clone is then mutated by
+     * {@link WebFilterSettingsGeneric#transformGenericToWebFilterSettings} and
+     * passed to the existing {@link #setSettings(WebFilterSettings)} which
+     * handles ID reassignment, flagged/blocked enforcement, persistence, and
+     * decision-engine reconfiguration.
+     *
+     * @param newSettings V2 generic settings payload from the Vue UI
+     */
+    public void setSettingsV2(WebFilterSettingsGeneric newSettings)
+    {
+        if (this.getSettings() != null) {
+            WebFilterSettings cloned = SerializationUtils.clone(this.getSettings());
+            newSettings.transformGenericToWebFilterSettings(cloned);
+            this.setSettings(cloned);
+        }
     }
 
     /**

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterRule.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterRule.java
@@ -4,13 +4,23 @@
 
 package com.untangle.app.web_filter;
 
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.io.Serializable;
 import org.json.JSONObject;
 import org.json.JSONString;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.untangle.uvm.app.RuleCondition;
+import com.untangle.uvm.generic.RuleActionGeneric;
+import com.untangle.uvm.generic.RuleConditionGeneric;
+import com.untangle.uvm.generic.RuleGeneric;
+import com.untangle.uvm.util.Constants;
+import com.untangle.uvm.util.StringUtil;
 import com.untangle.uvm.vnet.AppSession;
 
 /**
@@ -62,6 +72,159 @@ public class WebFilterRule implements JSONString, Serializable
     {
         JSONObject jO = new JSONObject(this);
         return jO.toString();
+    }
+
+    /**
+     * Transforms a list of V1 {@link WebFilterRule} objects into the generic
+     * {@link RuleGeneric} shape consumed by the Vue UI (V2 API).
+     *
+     * <p>Action type mapping:
+     * <ul>
+     *   <li>{@code blocked=true}  &rarr; {@link RuleActionGeneric.Type#REJECT},
+     *       {@code action.flagged=true} (blocked implies flagged)</li>
+     *   <li>{@code blocked=false} &rarr; {@link RuleActionGeneric.Type#ACCEPT},
+     *       {@code action.flagged} reflects the V1 {@code flagged} value</li>
+     * </ul>
+     * The {@code flagged} property is carried as a dedicated field on
+     * {@link RuleActionGeneric} rather than being encoded in the action type,
+     * keeping it independent and directly readable by the Vue UI.
+     *
+     * @param v1Rules V1 filter rule list; returns an empty list if {@code null}
+     * @return LinkedList of RuleGeneric
+     */
+    public static LinkedList<RuleGeneric> transformWebFilterRulesToGeneric(List<WebFilterRule> v1Rules)
+    {
+        LinkedList<RuleGeneric> out = new LinkedList<>();
+        if (v1Rules == null) return out;
+        for (WebFilterRule rule : v1Rules) {
+            out.add(toGeneric(rule));
+        }
+        return out;
+    }
+
+    /**
+     * Transforms a single V1 {@link WebFilterRule} into its {@link RuleGeneric}
+     * representation for the V2 API.
+     *
+     * <p>Action type is {@code REJECT} when the rule blocks traffic, {@code ACCEPT}
+     * otherwise. The {@code flagged} property on the action carries the V1
+     * {@code flagged} boolean independently of the block/pass decision.
+     *
+     * @param v1 the V1 rule to convert
+     * @return a new RuleGeneric populated from {@code v1}
+     */
+    private static RuleGeneric toGeneric(WebFilterRule v1)
+    {
+        String ruleId = String.valueOf(v1.getRuleId());
+
+        RuleActionGeneric action = new RuleActionGeneric();
+        action.setType(v1.getBlocked() ? RuleActionGeneric.Type.REJECT : RuleActionGeneric.Type.ACCEPT);
+        // flagged is stored as a dedicated field on the action, independent of type
+        action.setFlagged(v1.getFlagged());
+
+        LinkedList<RuleConditionGeneric> conds = new LinkedList<>();
+        if (v1.getConditions() != null) {
+            for (WebFilterRuleCondition c : v1.getConditions()) {
+                String op = Boolean.TRUE.equals(c.getInvert())
+                        ? Constants.IS_NOT_EQUALS_TO
+                        : Constants.IS_EQUALS_TO;
+                conds.add(new RuleConditionGeneric(op, c.getConditionType(), c.getValue()));
+            }
+        }
+
+        RuleGeneric g = new RuleGeneric(v1.getEnabled(), v1.getDescription(), ruleId);
+        g.setAction(action);
+        g.setConditions(conds);
+        return g;
+    }
+
+    /**
+     * Transforms a list of V2 {@link RuleGeneric} objects back into V1
+     * {@link WebFilterRule} objects, preserving existing V1 rule state by
+     * ruleId and removing orphaned rules that were deleted in the UI.
+     *
+     * <p>Action type mapping (reverse of {@link #transformWebFilterRulesToGeneric}):
+     * <ul>
+     *   <li>{@link RuleActionGeneric.Type#REJECT} &rarr; {@code blocked=true}</li>
+     *   <li>{@link RuleActionGeneric.Type#ACCEPT} &rarr; {@code blocked=false}</li>
+     *   <li>{@code action.flagged}                &rarr; {@code flagged} (read directly)</li>
+     * </ul>
+     * Note: {@code _setSettings()} enforces {@code flagged=true} whenever
+     * {@code blocked=true}, so that invariant is guaranteed on save regardless
+     * of the value sent from the UI.
+     *
+     * <p>New rules sent from the UI carry a UUID string as their ruleId;
+     * {@code _setSettings()} re-assigns sequential integer IDs on save.
+     *
+     * @param genRules    V2 rule list from the Vue UI
+     * @param legacyRules current V1 rule list used for orphan detection and state preservation
+     * @return list of updated/preserved V1 WebFilterRule objects
+     */
+    public static List<WebFilterRule> transformGenericToWebFilterRules(
+            LinkedList<RuleGeneric> genRules, List<WebFilterRule> legacyRules)
+    {
+        if (legacyRules == null) legacyRules = new LinkedList<>();
+
+        // Remove rules deleted in the UI from the legacy list
+        RuleGeneric.deleteOrphanRules(
+                genRules, legacyRules,
+                RuleGeneric::getRuleId,
+                r -> String.valueOf(r.getRuleId()));
+
+        // Map for O(1) lookup of existing rules by ruleId
+        Map<Integer, WebFilterRule> rulesMap = legacyRules.stream()
+                .collect(Collectors.toMap(WebFilterRule::getRuleId, Function.identity()));
+
+        List<WebFilterRule> out = new LinkedList<>();
+        for (RuleGeneric g : genRules) {
+            WebFilterRule existing = rulesMap.get(StringUtil.getInstance().parseInt(g.getRuleId(), 0));
+            out.add(toLegacy(g, existing));
+        }
+        return out;
+    }
+
+    /**
+     * Transforms a single {@link RuleGeneric} back into a V1
+     * {@link WebFilterRule}, mutating the passed-in existing rule (or
+     * creating a new one if {@code null}).
+     *
+     * <p>{@code blocked} is derived from the action type ({@code REJECT} → true,
+     * {@code ACCEPT} → false). {@code flagged} is read directly from
+     * {@link RuleActionGeneric#getFlagged()}; if absent it defaults to
+     * {@code false} ({@code _setSettings()} will force it to {@code true}
+     * whenever {@code blocked} is {@code true}).
+     *
+     * @param g        the V2 generic rule from the UI
+     * @param existing the matching V1 rule to update, or {@code null} for a new rule
+     * @return the populated V1 WebFilterRule
+     */
+    private static WebFilterRule toLegacy(RuleGeneric g, WebFilterRule existing)
+    {
+        if (existing == null) existing = new WebFilterRule();
+        existing.setEnabled(g.isEnabled());
+        existing.setDescription(g.getDescription());
+        // New rules from the UI carry a UUID string as ruleId;
+        // _setSettings() will assign a real integer ID on save.
+        existing.setRuleId(StringUtil.getInstance().parseInt(g.getRuleId(), -1));
+
+        if (g.getAction() != null) {
+            existing.setBlocked(g.getAction().getType() == RuleActionGeneric.Type.REJECT);
+            // flagged is stored as a dedicated field on the action; default false if absent
+            existing.setFlagged(Boolean.TRUE.equals(g.getAction().getFlagged()));
+        }
+
+        List<WebFilterRuleCondition> conds = new LinkedList<>();
+        if (g.getConditions() != null) {
+            for (RuleConditionGeneric gc : g.getConditions()) {
+                WebFilterRuleCondition c = new WebFilterRuleCondition();
+                c.setInvert(Constants.IS_NOT_EQUALS_TO.equals(gc.getOp()));
+                c.setConditionType(gc.getType());
+                c.setValue(gc.getValue());
+                conds.add(c);
+            }
+        }
+        existing.setConditions(conds);
+        return existing;
     }
 
     public boolean matches(AppSession sess)

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterRule.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterRule.java
@@ -75,21 +75,10 @@ public class WebFilterRule implements JSONString, Serializable
     }
 
     /**
-     * Transforms a list of V1 {@link WebFilterRule} objects into the generic
-     * {@link RuleGeneric} shape consumed by the Vue UI (V2 API).
+     * Transforms a list of WebFilterRule into the generic RuleGeneric form for
+     * the V2 API. Used by getSettingsV2().
      *
-     * <p>Action type mapping:
-     * <ul>
-     *   <li>{@code blocked=true}  &rarr; {@link RuleActionGeneric.Type#REJECT},
-     *       {@code action.flagged=true} (blocked implies flagged)</li>
-     *   <li>{@code blocked=false} &rarr; {@link RuleActionGeneric.Type#ACCEPT},
-     *       {@code action.flagged} reflects the V1 {@code flagged} value</li>
-     * </ul>
-     * The {@code flagged} property is carried as a dedicated field on
-     * {@link RuleActionGeneric} rather than being encoded in the action type,
-     * keeping it independent and directly readable by the Vue UI.
-     *
-     * @param v1Rules V1 filter rule list; returns an empty list if {@code null}
+     * @param v1Rules list of V1 WebFilterRule objects
      * @return LinkedList of RuleGeneric
      */
     public static LinkedList<RuleGeneric> transformWebFilterRulesToGeneric(List<WebFilterRule> v1Rules)
@@ -103,15 +92,7 @@ public class WebFilterRule implements JSONString, Serializable
     }
 
     /**
-     * Transforms a single V1 {@link WebFilterRule} into its {@link RuleGeneric}
-     * representation for the V2 API.
-     *
-     * <p>Action type is {@code REJECT} when the rule blocks traffic, {@code ACCEPT}
-     * otherwise. The {@code flagged} property on the action carries the V1
-     * {@code flagged} boolean independently of the block/pass decision.
-     *
-     * @param v1 the V1 rule to convert
-     * @return a new RuleGeneric populated from {@code v1}
+     * Transforms a single WebFilterRule into its RuleGeneric representation.
      */
     private static RuleGeneric toGeneric(WebFilterRule v1)
     {
@@ -139,25 +120,13 @@ public class WebFilterRule implements JSONString, Serializable
     }
 
     /**
-     * Transforms a list of V2 {@link RuleGeneric} objects back into V1
-     * {@link WebFilterRule} objects, preserving existing V1 rule state by
-     * ruleId and removing orphaned rules that were deleted in the UI.
+     * Transforms a list of generic RuleGeneric into V1 WebFilterRule, preserving
+     * existing V1 rule objects (matched by ruleId) and removing orphaned rules.
+     * Used by setSettingsV2().
      *
-     * <p>Action type mapping (reverse of {@link #transformWebFilterRulesToGeneric}):
-     * <ul>
-     *   <li>{@link RuleActionGeneric.Type#REJECT} &rarr; {@code blocked=true}</li>
-     *   <li>{@link RuleActionGeneric.Type#ACCEPT} &rarr; {@code blocked=false}</li>
-     *   <li>{@code action.flagged}                &rarr; {@code flagged} (read directly)</li>
-     * </ul>
-     * Note: {@code _setSettings()} enforces {@code flagged=true} whenever
-     * {@code blocked=true}, so that invariant is guaranteed on save regardless
-     * of the value sent from the UI.
-     *
-     * <p>New rules sent from the UI carry a UUID string as their ruleId;
-     * {@code _setSettings()} re-assigns sequential integer IDs on save.
-     *
-     * @param genRules    V2 rule list from the Vue UI
-     * @param legacyRules current V1 rule list used for orphan detection and state preservation
+     * @param genRules    list of V2 RuleGeneric objects from the UI
+     * @param legacyRules current V1 WebFilterRule list (to preserve internal state
+     *                    on update and detect deletions)
      * @return list of updated/preserved V1 WebFilterRule objects
      */
     public static List<WebFilterRule> transformGenericToWebFilterRules(
@@ -184,19 +153,8 @@ public class WebFilterRule implements JSONString, Serializable
     }
 
     /**
-     * Transforms a single {@link RuleGeneric} back into a V1
-     * {@link WebFilterRule}, mutating the passed-in existing rule (or
-     * creating a new one if {@code null}).
-     *
-     * <p>{@code blocked} is derived from the action type ({@code REJECT} → true,
-     * {@code ACCEPT} → false). {@code flagged} is read directly from
-     * {@link RuleActionGeneric#getFlagged()}; if absent it defaults to
-     * {@code false} ({@code _setSettings()} will force it to {@code true}
-     * whenever {@code blocked} is {@code true}).
-     *
-     * @param g        the V2 generic rule from the UI
-     * @param existing the matching V1 rule to update, or {@code null} for a new rule
-     * @return the populated V1 WebFilterRule
+     * Transforms a single RuleGeneric back into a V1 WebFilterRule, mutating the
+     * passed-in existing rule (or creating a new one if null).
      */
     private static WebFilterRule toLegacy(RuleGeneric g, WebFilterRule existing)
     {

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterSettings.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterSettings.java
@@ -177,16 +177,9 @@ public class WebFilterSettings implements Serializable, JSONString
 
     /**
      * Transforms this V1 settings object into its generic V2 representation
-     * for the Vue UI.
+     * for the Vue UI. Used by getSettingsV2().
      *
-     * <p>All scalar fields are copied directly. The {@code filterRules} list
-     * is structurally transformed from {@link WebFilterRule} to
-     * {@link com.untangle.uvm.generic.RuleGeneric} via
-     * {@link WebFilterRule#transformWebFilterRulesToGeneric}.  GenericRule-typed
-     * lists (passedClients, passedUrls, blockedUrls, categories, searchTerms)
-     * are assigned directly — they share the same type in both V1 and V2.
-     *
-     * @return a new {@link WebFilterSettingsGeneric} populated from this V1 object
+     * @return WebFilterSettingsGeneric populated from this V1 object
      */
     public WebFilterSettingsGeneric transformWebFilterSettingsToGeneric()
     {

--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterSettings.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterSettings.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.json.JSONObject;
 import org.json.JSONString;
 
+import com.untangle.app.web_filter.generic.WebFilterSettingsGeneric;
 import com.untangle.uvm.app.GenericRule;
 
 /**
@@ -172,5 +173,57 @@ public class WebFilterSettings implements Serializable, JSONString
     {
         JSONObject jO = new JSONObject(this);
         return jO.toString();
+    }
+
+    /**
+     * Transforms this V1 settings object into its generic V2 representation
+     * for the Vue UI.
+     *
+     * <p>All scalar fields are copied directly. The {@code filterRules} list
+     * is structurally transformed from {@link WebFilterRule} to
+     * {@link com.untangle.uvm.generic.RuleGeneric} via
+     * {@link WebFilterRule#transformWebFilterRulesToGeneric}.  GenericRule-typed
+     * lists (passedClients, passedUrls, blockedUrls, categories, searchTerms)
+     * are assigned directly — they share the same type in both V1 and V2.
+     *
+     * @return a new {@link WebFilterSettingsGeneric} populated from this V1 object
+     */
+    public WebFilterSettingsGeneric transformWebFilterSettingsToGeneric()
+    {
+        WebFilterSettingsGeneric g = new WebFilterSettingsGeneric();
+
+        g.setEnableHttpsSni(this.enableHttpsSni);
+        g.setEnableHttpsSniCertFallback(this.enableHttpsSniCertFallback);
+        g.setEnableHttpsSniIpFallback(this.enableHttpsSniIpFallback);
+        g.setUnblockPasswordEnabled(this.unblockPasswordEnabled);
+        g.setUnblockPasswordAdmin(this.unblockPasswordAdmin);
+        g.setUnblockPassword(this.unblockPassword);
+        g.setUnblockMode(this.unblockMode);
+        g.setUnblockTimeout(this.unblockTimeout);
+        g.setEnforceSafeSearch(this.enforceSafeSearch);
+        g.setForceKidFriendly(this.forceKidFriendly);
+        g.setRestrictYoutube(this.restrictYoutube);
+        g.setBlockQuic(this.blockQuic);
+        g.setLogQuic(this.logQuic);
+        g.setBlockAllIpHosts(this.blockAllIpHosts);
+        g.setPassReferers(this.passReferers);
+        g.setRestrictGoogleApps(this.restrictGoogleApps);
+        g.setRestrictGoogleAppsDomain(this.restrictGoogleAppsDomain);
+        g.setBlockECH(this.blockECH);
+        g.setCustomBlockPageEnabled(this.customBlockPageEnabled);
+        g.setCustomBlockPageUrl(this.customBlockPageUrl);
+        g.setCloseHttpsBlockEnabled(this.closeHttpsBlockEnabled);
+
+        // GenericRule lists - shared type, copy to avoid aliasing; always set (empty list when null)
+        g.setPassedClients(this.passedClients != null ? new LinkedList<>(this.passedClients) : new LinkedList<>());
+        g.setPassedUrls(this.passedUrls != null       ? new LinkedList<>(this.passedUrls)    : new LinkedList<>());
+        g.setBlockedUrls(this.blockedUrls != null     ? new LinkedList<>(this.blockedUrls)   : new LinkedList<>());
+        g.setCategories(this.categories != null       ? new LinkedList<>(this.categories)    : new LinkedList<>());
+        g.setSearchTerms(this.searchTerms != null     ? new LinkedList<>(this.searchTerms)   : new LinkedList<>());
+
+        // filterRules - the ONE structural transformation; returns empty list when null
+        g.setFilterRules(WebFilterRule.transformWebFilterRulesToGeneric(this.filterRules));
+
+        return g;
     }
 }

--- a/web-filter-base/src/com/untangle/app/web_filter/generic/WebFilterSettingsGeneric.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/generic/WebFilterSettingsGeneric.java
@@ -1,0 +1,203 @@
+package com.untangle.app.web_filter.generic;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.untangle.app.web_filter.WebFilterRule;
+import com.untangle.app.web_filter.WebFilterSettings;
+import com.untangle.uvm.app.GenericRule;
+import com.untangle.uvm.generic.RuleGeneric;
+import org.json.JSONObject;
+import org.json.JSONString;
+
+/**
+ * Generic (V2) settings for the Web Filter app, consumed by the Vue UI.
+ *
+ * <p>All scalar/list fields mirror their V1 {@link WebFilterSettings} counterparts
+ * with the same names and types, so they can be copied without translation.
+ * The sole structural transformation is {@code filterRules}: the V1
+ * {@link WebFilterRule} list is converted to/from the shared
+ * {@link RuleGeneric} shape defined by the generic API contract.
+ *
+ * <p>V1-only fields ({@code version}, {@code blockedMimeTypes},
+ * {@code blockedExtensions}) are intentionally omitted here.
+ */
+@SuppressWarnings("serial")
+public class WebFilterSettingsGeneric implements Serializable, JSONString
+{
+    private Boolean enableHttpsSni = true;
+    private Boolean enableHttpsSniCertFallback = true;
+    private Boolean enableHttpsSniIpFallback = false;
+    private Boolean unblockPasswordEnabled = false;
+    private Boolean unblockPasswordAdmin = false;
+    private String  unblockPassword = "";
+    private String  unblockMode = WebFilterSettings.UNBLOCK_MODE_NONE;
+    private Integer unblockTimeout = 60*60; /* 1 hour */
+    private Boolean enforceSafeSearch = true;
+    private Boolean forceKidFriendly = false;
+    private Boolean restrictYoutube = false;
+    private Boolean blockQuic = true;
+    private Boolean logQuic = false;
+    private Boolean blockAllIpHosts = false;
+    private Boolean passReferers = true;
+    private Boolean restrictGoogleApps = false;
+    private String restrictGoogleAppsDomain = "";
+    private Boolean blockECH = false;
+
+    private Boolean customBlockPageEnabled = false;
+    private String customBlockPageUrl = "";
+    private Boolean closeHttpsBlockEnabled = false;
+
+    private LinkedList<RuleGeneric> filterRules = new LinkedList<>();
+    private LinkedList<GenericRule> passedClients = new LinkedList<>();
+    private LinkedList<GenericRule> passedUrls = new LinkedList<>();
+    private LinkedList<GenericRule> blockedUrls = new LinkedList<>();
+    private LinkedList<GenericRule> categories = new LinkedList<>();
+    private LinkedList<GenericRule> searchTerms = new LinkedList<>();
+
+    public Boolean getEnableHttpsSni() { return enableHttpsSni; }
+    public void setEnableHttpsSni(Boolean enableHttpsSni) { this.enableHttpsSni = enableHttpsSni; }
+
+    public Boolean getEnableHttpsSniCertFallback() { return enableHttpsSniCertFallback; }
+    public void setEnableHttpsSniCertFallback(Boolean enableHttpsSniCertFallback) { this.enableHttpsSniCertFallback = enableHttpsSniCertFallback; }
+
+    public Boolean getEnableHttpsSniIpFallback() { return enableHttpsSniIpFallback; }
+    public void setEnableHttpsSniIpFallback(Boolean enableHttpsSniIpFallback) { this.enableHttpsSniIpFallback = enableHttpsSniIpFallback; }
+
+    public Boolean getUnblockPasswordEnabled() { return unblockPasswordEnabled; }
+    public void setUnblockPasswordEnabled(Boolean unblockPasswordEnabled) { this.unblockPasswordEnabled = unblockPasswordEnabled; }
+
+    public Boolean getUnblockPasswordAdmin() { return unblockPasswordAdmin; }
+    public void setUnblockPasswordAdmin(Boolean unblockPasswordAdmin) { this.unblockPasswordAdmin = unblockPasswordAdmin; }
+
+    public String getUnblockPassword() { return unblockPassword; }
+    public void setUnblockPassword(String unblockPassword) { this.unblockPassword = unblockPassword; }
+
+    public String getUnblockMode() { return unblockMode; }
+    public void setUnblockMode(String unblockMode) { this.unblockMode = unblockMode; }
+
+    public Integer getUnblockTimeout() { return unblockTimeout; }
+    public void setUnblockTimeout(Integer unblockTimeout) { this.unblockTimeout = unblockTimeout; }
+
+    public Boolean getEnforceSafeSearch() { return enforceSafeSearch; }
+    public void setEnforceSafeSearch(Boolean enforceSafeSearch) { this.enforceSafeSearch = enforceSafeSearch; }
+
+    public Boolean getForceKidFriendly() { return forceKidFriendly; }
+    public void setForceKidFriendly(Boolean forceKidFriendly) { this.forceKidFriendly = forceKidFriendly; }
+
+    public Boolean getRestrictYoutube() { return restrictYoutube; }
+    public void setRestrictYoutube(Boolean restrictYoutube) { this.restrictYoutube = restrictYoutube; }
+
+    public Boolean getBlockQuic() { return blockQuic; }
+    public void setBlockQuic(Boolean blockQuic) { this.blockQuic = blockQuic; }
+
+    public Boolean getLogQuic() { return logQuic; }
+    public void setLogQuic(Boolean logQuic) { this.logQuic = logQuic; }
+
+    public Boolean getBlockAllIpHosts() { return blockAllIpHosts; }
+    public void setBlockAllIpHosts(Boolean blockAllIpHosts) { this.blockAllIpHosts = blockAllIpHosts; }
+
+    public Boolean getPassReferers() { return passReferers; }
+    public void setPassReferers(Boolean passReferers) { this.passReferers = passReferers; }
+
+    public Boolean getRestrictGoogleApps() { return restrictGoogleApps; }
+    public void setRestrictGoogleApps(Boolean restrictGoogleApps) { this.restrictGoogleApps = restrictGoogleApps; }
+
+    public String getRestrictGoogleAppsDomain() { return restrictGoogleAppsDomain; }
+    public void setRestrictGoogleAppsDomain(String restrictGoogleAppsDomain) { this.restrictGoogleAppsDomain = restrictGoogleAppsDomain; }
+
+    public Boolean getBlockECH() { return blockECH; }
+    public void setBlockECH(Boolean blockECH) { this.blockECH = blockECH; }
+
+    public Boolean getCustomBlockPageEnabled() { return customBlockPageEnabled; }
+    public void setCustomBlockPageEnabled(Boolean customBlockPageEnabled) { this.customBlockPageEnabled = customBlockPageEnabled; }
+
+    public String getCustomBlockPageUrl() { return customBlockPageUrl; }
+    public void setCustomBlockPageUrl(String customBlockPageUrl) { this.customBlockPageUrl = customBlockPageUrl; }
+
+    public Boolean getCloseHttpsBlockEnabled() { return closeHttpsBlockEnabled; }
+    public void setCloseHttpsBlockEnabled(Boolean closeHttpsBlockEnabled) { this.closeHttpsBlockEnabled = closeHttpsBlockEnabled; }
+
+    public LinkedList<RuleGeneric> getFilterRules() { return filterRules; }
+    public void setFilterRules(LinkedList<RuleGeneric> filterRules) { this.filterRules = filterRules; }
+
+    public LinkedList<GenericRule> getPassedClients() { return passedClients; }
+    public void setPassedClients(LinkedList<GenericRule> passedClients) { this.passedClients = passedClients; }
+
+    public LinkedList<GenericRule> getPassedUrls() { return passedUrls; }
+    public void setPassedUrls(LinkedList<GenericRule> passedUrls) { this.passedUrls = passedUrls; }
+
+    public LinkedList<GenericRule> getBlockedUrls() { return blockedUrls; }
+    public void setBlockedUrls(LinkedList<GenericRule> blockedUrls) { this.blockedUrls = blockedUrls; }
+
+    public LinkedList<GenericRule> getCategories() { return categories; }
+    public void setCategories(LinkedList<GenericRule> categories) { this.categories = categories; }
+
+    public LinkedList<GenericRule> getSearchTerms() { return searchTerms; }
+    public void setSearchTerms(LinkedList<GenericRule> searchTerms) { this.searchTerms = searchTerms; }
+
+    public String toJSONString()
+    {
+        JSONObject jO = new JSONObject(this);
+        return jO.toString();
+    }
+
+    /**
+     * Transforms this V2 generic settings object into V1 by mutating the
+     * passed-in (deep-cloned) {@link WebFilterSettings} object.
+     *
+     * <p>All scalar fields are copied directly. The {@code filterRules} list
+     * is structurally transformed from {@link RuleGeneric} back to
+     * {@link WebFilterRule}, preserving existing V1 rule objects by ruleId
+     * and removing any rules that were deleted in the UI.  GenericRule-typed
+     * lists (passedClients, passedUrls, blockedUrls, categories, searchTerms)
+     * are assigned directly — they share the same type in both V1 and V2.
+     *
+     * <p>V1-only fields ({@code version}, {@code blockedMimeTypes},
+     * {@code blockedExtensions}) are intentionally untouched so they survive
+     * the round-trip through the Vue UI unchanged.
+     *
+     * @param v1 deep-cloned V1 settings to mutate in place; a fresh instance
+     *           is created if {@code null}
+     * @return the same {@code v1} reference populated from this V2 object
+     */
+    public WebFilterSettings transformGenericToWebFilterSettings(WebFilterSettings v1)
+    {
+        if (v1 == null) v1 = new WebFilterSettings();
+
+        v1.setEnableHttpsSni(this.enableHttpsSni);
+        v1.setEnableHttpsSniCertFallback(this.enableHttpsSniCertFallback);
+        v1.setEnableHttpsSniIpFallback(this.enableHttpsSniIpFallback);
+        v1.setUnblockPasswordEnabled(this.unblockPasswordEnabled);
+        v1.setUnblockPasswordAdmin(this.unblockPasswordAdmin);
+        v1.setUnblockPassword(this.unblockPassword);
+        v1.setUnblockMode(this.unblockMode);
+        v1.setUnblockTimeout(this.unblockTimeout);
+        v1.setEnforceSafeSearch(this.enforceSafeSearch);
+        v1.setForceKidFriendly(this.forceKidFriendly);
+        v1.setRestrictYoutube(this.restrictYoutube);
+        v1.setBlockQuic(this.blockQuic);
+        v1.setLogQuic(this.logQuic);
+        v1.setBlockAllIpHosts(this.blockAllIpHosts);
+        v1.setPassReferers(this.passReferers);
+        v1.setRestrictGoogleApps(this.restrictGoogleApps);
+        v1.setRestrictGoogleAppsDomain(this.restrictGoogleAppsDomain);
+        v1.setBlockECH(this.blockECH);
+        v1.setCustomBlockPageEnabled(this.customBlockPageEnabled);
+        v1.setCustomBlockPageUrl(this.customBlockPageUrl);
+        v1.setCloseHttpsBlockEnabled(this.closeHttpsBlockEnabled);
+
+        // GenericRule lists - shared type, assign directly; always set (empty list when null)
+        v1.setPassedClients(this.passedClients != null ? new LinkedList<>(this.passedClients) : new LinkedList<>());
+        v1.setPassedUrls(this.passedUrls != null       ? new LinkedList<>(this.passedUrls)    : new LinkedList<>());
+        v1.setBlockedUrls(this.blockedUrls != null     ? new LinkedList<>(this.blockedUrls)   : new LinkedList<>());
+        v1.setCategories(this.categories != null       ? new LinkedList<>(this.categories)    : new LinkedList<>());
+        v1.setSearchTerms(this.searchTerms != null     ? new LinkedList<>(this.searchTerms)   : new LinkedList<>());
+
+        // filterRules - the ONE transformation (with orphan cleanup); returns empty list when null
+        v1.setFilterRules(WebFilterRule.transformGenericToWebFilterRules(this.filterRules, v1.getFilterRules()));
+
+        return v1;
+    }
+}

--- a/web-filter-base/src/com/untangle/app/web_filter/generic/WebFilterSettingsGeneric.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/generic/WebFilterSettingsGeneric.java
@@ -1,3 +1,6 @@
+/**
+ * $Id$
+ */
 package com.untangle.app.web_filter.generic;
 
 import java.io.Serializable;
@@ -13,15 +16,9 @@ import org.json.JSONString;
 
 /**
  * Generic (V2) settings for the Web Filter app, consumed by the Vue UI.
- *
- * <p>All scalar/list fields mirror their V1 {@link WebFilterSettings} counterparts
- * with the same names and types, so they can be copied without translation.
- * The sole structural transformation is {@code filterRules}: the V1
- * {@link WebFilterRule} list is converted to/from the shared
- * {@link RuleGeneric} shape defined by the generic API contract.
- *
- * <p>V1-only fields ({@code version}, {@code blockedMimeTypes},
- * {@code blockedExtensions}) are intentionally omitted here.
+ * Keeps V1 field names where structurally identical; transforms only the
+ * filterRules list into the shared RuleGeneric shape.
+ * V1-only fields (version, blockedMimeTypes, blockedExtensions) are omitted.
  */
 @SuppressWarnings("serial")
 public class WebFilterSettingsGeneric implements Serializable, JSONString
@@ -144,23 +141,12 @@ public class WebFilterSettingsGeneric implements Serializable, JSONString
     }
 
     /**
-     * Transforms this V2 generic settings object into V1 by mutating the
-     * passed-in (deep-cloned) {@link WebFilterSettings} object.
+     * Transforms this V2 settings object into V1 by mutating the passed-in
+     * (deep-cloned) V1 settings object. Preserves V1-only fields like
+     * version, blockedMimeTypes, blockedExtensions.
      *
-     * <p>All scalar fields are copied directly. The {@code filterRules} list
-     * is structurally transformed from {@link RuleGeneric} back to
-     * {@link WebFilterRule}, preserving existing V1 rule objects by ruleId
-     * and removing any rules that were deleted in the UI.  GenericRule-typed
-     * lists (passedClients, passedUrls, blockedUrls, categories, searchTerms)
-     * are assigned directly — they share the same type in both V1 and V2.
-     *
-     * <p>V1-only fields ({@code version}, {@code blockedMimeTypes},
-     * {@code blockedExtensions}) are intentionally untouched so they survive
-     * the round-trip through the Vue UI unchanged.
-     *
-     * @param v1 deep-cloned V1 settings to mutate in place; a fresh instance
-     *           is created if {@code null}
-     * @return the same {@code v1} reference populated from this V2 object
+     * @param v1 deep-cloned V1 settings (mutated in place)
+     * @return the same v1 reference, populated from this V2 object
      */
     public WebFilterSettings transformGenericToWebFilterSettings(WebFilterSettings v1)
     {

--- a/web-filter/src/com/untangle/app/web_filter/WebFilterApp.java
+++ b/web-filter/src/com/untangle/app/web_filter/WebFilterApp.java
@@ -86,6 +86,18 @@ public class WebFilterApp extends WebFilterBase
     }
 
     /**
+     * Called to lookup a specific site. This is v2 API of {@link #lookupSite(String)} used by the Vue UI.
+     * 
+     * @param url
+     *        The site to lookup
+     * 
+     * @return The list of categories
+     */
+    public List<Integer> lookupSiteV2(String url) {
+        return this.lookupSite(url);
+    }
+
+    /**
      * Called to submit request to recategorize site
      * 
      * @param url


### PR DESCRIPTION
## Summary

Adds `getSettingsV2` and `setSettingsV2` backend APIs for the Web Filter app to support the Vue UI migration. Introduces `WebFilterSettingsGeneric` as the V2 settings DTO and implements bidirectional transformation between the existing V1 model and the shared `RuleGeneric` shape consumed by the new Vue frontend.

## Motivation

Part of the ongoing NGFW-15783 effort to migrate Web Filter from the legacy ExtJS UI to Vue. The Vue frontend requires V2 API endpoints that expose settings in the standardized `RuleGeneric`/`RuleConditionGeneric` format used across other migrated apps (Captive Portal, WAN Balancer, Spam Blocker, etc.).

## Changes

**New V2 API endpoints (`web-filter-base`, `web-filter`)**
- Added `getSettingsV2()` and `setSettingsV2(WebFilterSettingsGeneric)` to the `WebFilter` interface and implemented in `WebFilterBase`
- `getSettingsV2()` converts live V1 settings to the generic shape; `setSettingsV2()` deep-clones V1 first (via `SerializationUtils.clone`) to preserve V1-only fields (`version`, `blockedMimeTypes`, `blockedExtensions`) before merging
- Added `lookupSiteV2(String url)` pass-through wrapper in `WebFilterApp`

**New V2 settings DTO (`WebFilterSettingsGeneric`)**
- New class under `web-filter-base/.../generic/` implementing `JSONString`
- Mirrors all V1 boolean/string settings fields; replaces `filterRules: List<WebFilterRule>` with `filterRules: List<RuleGeneric>`
- Contains `transformGenericToWebFilterSettings(WebFilterSettings v1)` for the V2→V1 direction; handles orphan rule cleanup via `RuleGeneric.deleteOrphanRules`

**Rule transformation (`WebFilterRule`)**
- `transformWebFilterRulesToGeneric()` — converts V1 `WebFilterRule` list → `RuleGeneric`, mapping `blocked` → `REJECT`/`ACCEPT` action type and preserving `flagged` as a dedicated action field
- `transformGenericToWebFilterRules()` — reverse transform; matches rules by `ruleId`, preserves existing rule state on update, handles new rules with UUID `ruleId` (assigned a real integer ID by `_setSettings()`)
- Condition `invert` field maps to/from the `IS_NOT_EQUALS_TO`/`IS_EQUALS_TO` operator strings

**Shared rule action model (`RuleActionGeneric`)**
- Added `flagged: Boolean` field to `RuleActionGeneric` to carry the Web Filter `flagged` semantic, independent of the `ACCEPT`/`REJECT` action type
- Updated Javadoc enum comment to include Web Filter rules

## Testing

1. Build and deploy the Web Filter app module.
2. `GET getSettingsV2` — verify the response uses `RuleGeneric` shape for `filterRules` and all V1 settings fields are present.
3. `POST setSettingsV2` with a modified payload — verify changes persist and V1-only fields (`blockedMimeTypes`, `blockedExtensions`, `version`) are unchanged.
4. Add a new filter rule via the Vue UI, save, reload — verify the rule appears with the correct `blocked`/`flagged` values.
5. Delete an existing rule via the Vue UI, save — verify the rule is removed and no orphan remains in the V1 store.
6. Call `lookupSiteV2` and confirm it returns the same category list as `lookupSite`.

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
