### PR TITLE
NGFW-15788 Fixed SafeType gap identified during settings validation

### DIFF
--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -1190,7 +1190,7 @@ class IPsecTests(NGFWTestCase):
           - leftSourceIp       (IP_OR_CIDR)
           - leftProtoPort      (ALPHANUM)
           - leftNextHop        (IP_OR_CIDR)
-          - right              ({HOSTNAME, IP_OR_CIDR})  dual-type
+          - right              (PEER_LIST)  comma-separated HOSTNAME-or-IP_OR_CIDR; LF/CR rejected
           - rightId            (SIMPLE_TEXT)
           - rightSourceIp      (IP_OR_CIDR)
           - rightProtoPort     (ALPHANUM)

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
@@ -58,7 +58,9 @@ public class IpsecVpnTunnel implements JSONString, Serializable
     private String leftNextHop;
     // %any is the strongSwan keyword for "accept any peer"; set by the
     // "Any Remote Host" checkbox in the IPsec tunnel editor.
-    @SafeCheck(value = {SafeType.HOSTNAME, SafeType.IP_OR_CIDR}, allow = {"%any"})
+    // PEER_LIST validates each comma-separated entry as HOSTNAME or IP_OR_CIDR
+    // and rejects newlines (ipsec.conf conn block is single-line per directive).
+    @SafeCheck(value = SafeType.PEER_LIST, allow = {"%any"})
     private String right;
     @SafeCheck(value = SafeType.SIMPLE_TEXT, allow = {"%any"})
     private String rightId;

--- a/reports/js/MainController.js
+++ b/reports/js/MainController.js
@@ -219,9 +219,8 @@ Ext.define('Ung.apps.reports.MainController', {
                 Util.successToast('Upload Data Succeeded'.t());
             },
             failure: function (form, action) {
-                // var errorMsg = 'Upload Data Failed'.t() + ' ' + action.result;
-                // Ext.MessageBox.alert('Failed'.t(), errorMsg);
-                Util.handleException('Upload Data Failed'.t() + ' ' + action.result);
+                var msg = (action.result && action.result.msg) ? action.result.msg : 'Upload Data Failed'.t();
+                Util.handleException(msg);
             }
         });
     },

--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -1086,12 +1086,10 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
      */
     private int restoreData( FileItem item )
     {
+        if (!item.getName().endsWith(".gz")) {
+            throw new RuntimeException("Invalid file extension. Allowed: .gz");
+        }
         try {
-            //validate zip
-            if (!item.getName().endsWith(".gz")) {
-                throw new RuntimeException("Invalid file extension. Allowed: .gz");
-            }
-
             String filename = "/tmp/reports_restore_data.sql.gz";
             File file = new File(filename);
             if (file.exists())
@@ -1535,18 +1533,11 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
         @Override
         public String handleFile(FileItem fileItem, String argument) throws Exception
         {
-            try {
-                int ret = restoreData(fileItem);
-
-                if ( ret == 0 ) {
-                    return I18nUtil.marktr("Successfully restored data");
-                } else {
-                    return I18nUtil.marktr("Error restoring data:") + " " + ret;
-                }
-                    
-            } catch ( Exception e ) {
-                return I18nUtil.marktr("Error restoring data:") + " " + e.toString();
+            int ret = restoreData(fileItem);
+            if ( ret == 0 ) {
+                return I18nUtil.marktr("Successfully restored data");
             }
+            throw new RuntimeException(I18nUtil.marktr("Error restoring data:") + " exit code " + ret);
          }
     }
     

--- a/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/SystemSettingsGeneric.java
@@ -63,7 +63,8 @@ public class SystemSettingsGeneric implements Serializable, JSONString {
     // Sinks into ddclient.conf where `cmd='...'` directive triggers shell exec.
     @SafeCheck(SafeType.ALPHANUM)
     private String  dynamicDnsServiceName = null;
-    @SafeCheck(SafeType.ALPHANUM)
+    // Must match main POJO: USERNAME_OR_EMAIL (DDNS providers accept email-format login IDs).
+    @SafeCheck(SafeType.USERNAME_OR_EMAIL)
     private String  dynamicDnsServiceUsername = null;
     @SafeCheck(SafeType.OPAQUE_SECRET)
     private String  dynamicDnsServicePassword = null;

--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -86,7 +86,10 @@ public class InterfaceSettings implements Serializable, JSONString
     
     @SafeCheck(SafeType.INTERFACE)
     private String      v4PPPoERootDev; /* The PPPoE root device (the device ppp is based on)  */
-    @SafeCheck(SafeType.ALPHANUM)
+    // Production sweep: ~32% of PPPoE appliances store user@isp.com format.
+    // ALPHANUM rejects '@'; USERNAME_OR_EMAIL admits it safely (pap-secrets
+    // is a colon-delimited data file with no shell-exec directives).
+    @SafeCheck(SafeType.USERNAME_OR_EMAIL)
     private String      v4PPPoEUsername; /* PPPoE Username */
     // No @SafeCheck: pap-secrets (the only sink) is auth-data only - pppd
     // parses but never execs values. Not RCE-class.

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -50,7 +50,9 @@ public class NetworkSettings implements Serializable, JSONString
     // of these would inject a malicious cmd= line. RCE-class.
     @SafeCheck(SafeType.ALPHANUM)
     private String  dynamicDnsServiceName = null;
-    @SafeCheck(SafeType.ALPHANUM)
+    // DDNS providers (No-IP, Cloudflare, DynDNS) use email-format login IDs;
+    // USERNAME_OR_EMAIL admits '@' safely (ddclient.conf login= is a value token).
+    @SafeCheck(SafeType.USERNAME_OR_EMAIL)
     private String  dynamicDnsServiceUsername = null;
     @SafeCheck(SafeType.OPAQUE_SECRET)
     private String  dynamicDnsServicePassword = null;

--- a/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/InterfaceSettingsGeneric.java
@@ -72,7 +72,8 @@ public class InterfaceSettingsGeneric implements Serializable, JSONString {
 
     // Mirror of InterfaceSettings.v4PPPoEUsername - closes V2 RPC bypass.
     // pppd peers file has connect= shell-exec directive.
-    @SafeCheck(SafeType.ALPHANUM)
+    // Must match main POJO: USERNAME_OR_EMAIL (admits @ for user@isp.com PPPoE).
+    @SafeCheck(SafeType.USERNAME_OR_EMAIL)
     private String v4PPPoEUsername;             /* PPPoE Username */
     private String v4PPPoEPassword;             /* PPPoE Password */
     private Boolean v4PPPoEUsePeerDNS;          /* If the DNS should be determined via PPP */

--- a/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
+++ b/uvm/api/com/untangle/uvm/util/SafeCheckValidator.java
@@ -355,19 +355,8 @@ public class SafeCheckValidator
             if (type.validate(value)) return;
         }
 
-        String message;
-        if (overrideMessage != null && !overrideMessage.isEmpty()) {
-            message = overrideMessage;
-        } else {
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < types.length; i++) {
-                if (i > 0) sb.append(" OR ");
-                sb.append(types[i].defaultMessage());
-            }
-            message = sb.toString();
-        }
         throw new SafeCheckValidationException(
-            "Invalid value in " + contextLabel + ": " + message);
+            buildErrorMessage("Invalid value in " + contextLabel, value, types, overrideMessage));
     }
 
     /**
@@ -452,22 +441,84 @@ public class SafeCheckValidator
             if (type.validate(value)) return;
         }
 
-        // No type accepted. Build the message - the offending value is
-        // never included (avoids credential leakage and pivot through
-        // error-channel echo).
-        String message;
+        // No type accepted. Build the message. The offending value is
+        // included verbatim for non-OPAQUE_SECRET fields so the admin can
+        // see exactly what was rejected. For OPAQUE_SECRET fields it is
+        // suppressed to avoid credential leakage through the error channel.
+        // The "why" clause from describeRejection() never echoes characters
+        // from the value regardless of field type.
+        throw new SafeCheckValidationException(
+            buildErrorMessage("Invalid value in field " + fieldName, value, types, overrideMessage));
+    }
+
+    /**
+     * Builds a user-facing error message of the form:
+     *
+     * <pre>
+     *   {prefix} - {why}; expected: {what}
+     * </pre>
+     *
+     * Where {why} comes from {@code types[0].describeRejection(value)}
+     * and {what} comes from {@code overrideMessage} (if non-empty) or
+     * the {@code OR}-joined {@code defaultMessage()} of every type.
+     *
+     * <p>For non-credential fields the rejected value is included verbatim
+     * after the prefix (e.g. {@code "Invalid value in field Foo.bar ('bad value')"})
+     * so admins can immediately see what they sent. For {@link SafeType#OPAQUE_SECRET}
+     * fields the value is suppressed to prevent password leakage through
+     * the JSON-RPC error channel. The {why} clause from
+     * {@link SafeType#describeRejection(String)} never echoes the value
+     * regardless. The {what} clause is static per-type text.</p>
+     *
+     * @param prefix          leading clause naming the field/param
+     *                        (e.g. {@code "Invalid value in field Foo.bar"})
+     * @param value           the rejected value - used only to compute the
+     *                        {why} reason; never embedded in the output
+     * @param types           the SafeTypes the value was checked against
+     * @param overrideMessage the annotation's {@code errorMessage()} override,
+     *                        or {@code null}/empty to use per-type defaults
+     * @return formatted error message string; never null
+     */
+    private static String buildErrorMessage(String prefix, String value, SafeType[] types, String overrideMessage)
+    {
+        // {why} from the first listed type - shortest message; matches
+        // how multi-type validators usually frame the error.
+        String why = types[0].describeRejection(value);
+
+        // {what} from override (if any), else OR-joined per-type defaults.
+        String what;
         if (overrideMessage != null && !overrideMessage.isEmpty()) {
-            message = overrideMessage;
+            what = overrideMessage;
         } else {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < types.length; i++) {
                 if (i > 0) sb.append(" OR ");
                 sb.append(types[i].defaultMessage());
             }
-            message = sb.toString();
+            what = sb.toString();
         }
-        throw new SafeCheckValidationException(
-            "Invalid value in field " + fieldName + ": " + message);
+
+        // Include the rejected value verbatim for non-credential fields so
+        // admins can see exactly what they sent. Suppressed for OPAQUE_SECRET
+        // fields (passwords, passphrases) to avoid leaking secrets through
+        // the JSON-RPC error channel.
+        boolean sensitive = false;
+        for (SafeType type : types) {
+            if (type == SafeType.OPAQUE_SECRET) {
+                sensitive = true;
+                break;
+            }
+        }
+
+        StringBuilder out = new StringBuilder(prefix);
+        if (!sensitive && value != null && !value.isEmpty()) {
+            out.append(" ('").append(value).append("')");
+        }
+        if (!why.isEmpty()) {
+            out.append(" - ").append(why);
+        }
+        out.append("; expected: ").append(what);
+        return out.toString();
     }
 
     /**

--- a/uvm/api/com/untangle/uvm/util/SafeType.java
+++ b/uvm/api/com/untangle/uvm/util/SafeType.java
@@ -107,22 +107,32 @@ public enum SafeType
         "must be alphanumeric (letters, digits, '_', '.', '-'; first char alphanumeric or '_'; max 64)"),
 
     /**
-     * Permissive text for descriptions, contact strings, system locations,
-     * and natural-language names like {@code O'Brien}, {@code John's Folder},
-     * or {@code Smith &amp; Co}. Allows Unicode letters, digits, whitespace,
-     * the safe punctuation set [. _ - @ : , / + ( )], the apostrophe ['],
-     * and the ampersand [&amp;]. Excludes the remaining shell metacharacters
-     * ({@code $ ` ; | < > \n \r "}).
+     * Structured free-text for descriptions, contact strings, system
+     * locations, and similar label fields. Allows Unicode letters, digits,
+     * Unicode whitespace ({@link Character#SPACE_SEPARATOR}), and the
+     * explicitly-safe punctuation set {@code . _ - @ : , / + ( ) &}.
      *
-     * <p>The apostrophe and ampersand are permitted because every current
-     * sink consumes {@code SIMPLE_TEXT} values either argv-form (e.g.
-     * openssl), URL-encoded (URIBuilder), or as JSON HTTP-body content -
-     * none string-concatenate the value into a shell command line.
-     * URL-encoders turn {@code &amp;} into {@code %26}; JSON bodies treat
-     * it as a literal; argv vectors do not re-tokenize. Future sinks that
-     * do shell interpolation must quote with {@code shlex.quote(...)}
-     * (Python) or {@code execCommand(List.of(...))} (Java); this is the
-     * same contract already required for {@link #OPAQUE_SECRET}.</p>
+     * <p><b>Design intent -- all special characters are blocked.</b>
+     * Rather than trying to enumerate which special characters are safe
+     * for every current and future sink, {@code SIMPLE_TEXT} takes the
+     * opposite approach: it allows only characters that have no
+     * shell-metacharacter meaning in any context. The excluded set
+     * therefore includes <em>all</em> of the following, even though some
+     * are harmless in certain sinks today:
+     * {@code ' " ` $ ; | < > ! { } [ ] # ? * \ \n \r \t}.
+     * Note: {@code &} is in the <em>allowed</em> set (it is not a
+     * shell-exec operator in the sinks SIMPLE_TEXT fields currently
+     * reach). In particular, the apostrophe ({@code '}) is intentionally
+     * excluded -- it terminates single-quoted shell strings and can break
+     * out of any config-file format that uses single-quote delimiters.
+     * Customers whose stored descriptions contain these characters will
+     * receive an error on the next settings save; this is a documented
+     * migration side-effect, not a bug.</p>
+     *
+     * <p><b>Migration note:</b> real-world descriptions with apostrophes
+     * (e.g. {@code "admin's device"}) or pipe characters
+     * (e.g. {@code "Server | DMZ"}) are correctly rejected. Customers
+     * must remove those characters before saving.</p>
      */
     SIMPLE_TEXT(
         Pattern.compile("^[\\p{L}\\p{N}\\p{Zs}._@:,/+()&-]{1,256}$"),
@@ -151,14 +161,56 @@ public enum SafeType
      * validation; blank entries are skipped. Accepts LF, CRLF, comma,
      * or any combination as separators.</p>
      *
-     * <p><b>Limits:</b> total string length lessthan equals 8192 chars; max 256
+     * <p><b>Limits:</b> total string length &le; 8192 chars; max 256
      * entries - both well above the size of any realistic VPN config
      * but bounded to avoid pathological input.</p>
+     *
+     * <p><b>Sink contract:</b> this type accepts LF and CR as entry
+     * separators. Any sink that interpolates an {@code IP_OR_CIDR_LIST}
+     * value into a <em>single-line</em> config slot (e.g. an ipsec.conf
+     * {@code leftsubnet=} directive) MUST join the parsed entries with
+     * commas before writing -- never write the raw multi-line value
+     * verbatim, because a literal newline would inject a new ipsec.conf
+     * directive into the same conn block. Sinks that write to
+     * newline-tolerant formats (e.g. a UI textarea) may use the value
+     * verbatim.</p>
      */
     IP_OR_CIDR_LIST(
         null,  // validated programmatically, see validate()
         8192,
         "must be a comma- or newline-separated list of valid IPv4/IPv6 addresses or CIDRs (max 256 entries)"),
+
+    /**
+     * Comma-separated list of {@link #HOSTNAME} entries. Used for multi-domain
+     * fields like {@code WireGuardVpnSettings.dnsSearchDomain}. LF and CR are
+     * intentionally rejected (unlike {@link #IP_OR_CIDR_LIST}) because every
+     * current sink writes this field to a single-line config slot -- a newline
+     * in the value would inject a new wg-quick directive line.
+     *
+     * <p><b>Limits:</b> total string length &le; 8192 chars; max 256 entries.
+     * Each entry validates as {@link #HOSTNAME}.</p>
+     */
+    HOSTNAME_LIST(
+        null,  // validated programmatically, see validate()
+        8192,
+        "must be a comma-separated list of valid hostnames (max 256 entries; no newlines; each: alphanumeric, '.', '_', '-'; first char alphanumeric; max 253)"),
+
+    /**
+     * Comma-separated list of {@link #HOSTNAME}-or-{@link #IP_OR_CIDR} entries.
+     * Used for peer-address fields that accept either a FQDN or an IP literal
+     * (e.g. {@code IpsecVpnTunnel.right}). LF and CR are rejected because the
+     * field feeds into a single-line ipsec.conf directive -- a newline would
+     * inject a {@code leftupdown=} directive in the same conn block.
+     * Magic values like {@code %any} can be passed through the
+     * {@link SafeCheck#allow()} allowlist.
+     *
+     * <p><b>Limits:</b> total string length &le; 8192 chars; max 256 entries.
+     * Each entry validates as {@link #HOSTNAME} or {@link #IP_OR_CIDR}.</p>
+     */
+    PEER_LIST(
+        null,  // validated programmatically, see validate()
+        8192,
+        "must be a comma-separated list of hostnames or IPv4/IPv6 addresses/CIDRs (max 256 entries; no newlines)"),
 
     /** http(s) URL with required host and no embedded credentials. */
     URL(
@@ -219,6 +271,41 @@ public enum SafeType
         "must be an email address like user@example.com , local part must start with a letter or digit, domain must have at least one dot and a 2+ letter TLD (max 254 chars)"),
 
     /**
+     * Username or email-address shape for credentials like PPPoE usernames
+     * and dynamic-DNS login IDs. Pattern {@code ^[A-Za-z0-9][A-Za-z0-9._%+@-]*$}
+     * -- the conservative subset that covers both plain usernames
+     * ({@code alice}, {@code admin}) and email-format usernames common in ISP
+     * PPPoE deployments ({@code user@isp.com}, {@code alice@bt.com}). Length
+     * cap 254 matches the SMTP path limit.
+     *
+     * <p><b>Why not {@link #ALPHANUM}?</b> {@code ALPHANUM} rejects {@code @}
+     * and {@code +}, which appear in real-world PPPoE usernames (BT, CenturyLink,
+     * German DTAG). Production-data sweep found {@code @}-format usernames in
+     * approximately 32% of sampled appliances with PPPoE configured -- using
+     * {@code ALPHANUM} would produce widespread migration failures.</p>
+     *
+     * <p><b>Why not {@link #EMAIL}?</b> {@code EMAIL} requires a full
+     * {@code user@domain.tld} form with a 2+ letter TLD. Plain usernames like
+     * {@code alice} or {@code admin} would be rejected.</p>
+     *
+     * <p><b>RCE safety:</b> all accepted characters ({@code . _ % + @ -}) are
+     * inert in every current sink. {@code pppoe_manager.py} writes the value
+     * to both {@code /etc/ppp/peers/*} (as {@code user "value"} -- double-quoted)
+     * and {@code pap-secrets}/{@code chap-secrets}. The peers file has
+     * {@code connect=}/{@code pty=} exec directives, so {@code \n} and {@code "}
+     * are the dangerous characters there; both are excluded from this type's
+     * character set, closing the newline-injection and double-quote-escape
+     * vectors. {@code ddclient.conf} {@code login=} is an unquoted INI value
+     * token -- {@code \n} would inject a {@code cmd=} exec directive, also
+     * excluded. Shell metacharacters ({@code $ ` ; | < > " ' \\})
+     * remain rejected.</p>
+     */
+    USERNAME_OR_EMAIL(
+        Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._%+@-]*$"),
+        254,
+        "must be a username or email address (letters, digits, '.', '_', '%', '+', '@', '-'; first char alphanumeric; max 254)"),
+
+    /**
      * Multi-line email subject/body template that may contain
      * {@code ${var}} placeholders. Length up to 8192 chars to fit
      * realistic alert templates with multiple variable substitutions.
@@ -229,6 +316,15 @@ public enum SafeType
      * {@code \t}. This blocks NUL, ESC, BEL, etc. - vectors that could
      * be smuggled into a subject header or body for downstream
      * mail-injection - while preserving normal multiline content.</p>
+     *
+     * <p><b>Sink contract:</b> values of this type are consumed by the
+     * mail API (JavaMail) only -- they are <b>never</b> interpolated into
+     * a shell command line. Shell metacharacters admitted by this type
+     * ({@code $ ` ; | < > " ' \}) are inert in a mail-API context but
+     * would execute if the value ever reached a shell. Any future sink
+     * that consumes an {@code EMAIL_TEMPLATE} value must use
+     * {@code execCommand(argv)} form or {@code shlex.quote()} -- the same
+     * contract required for {@link #OPAQUE_SECRET}.</p>
      */
     EMAIL_TEMPLATE(
         null, // validated programmatically, see validate()
@@ -459,8 +555,8 @@ public enum SafeType
      *
      * @param pattern        compiled regex used by {@link #validate(String)} for
      *                       regex-based types; {@code null} for types validated
-     *                       programmatically (IP_OR_CIDR, IP_OR_CIDR_LIST, URL,
-     *                       OPAQUE_SECRET).
+     *                       programmatically (IP_OR_CIDR, IP_OR_CIDR_LIST,
+     *                       HOSTNAME_LIST, PEER_LIST, URL, OPAQUE_SECRET).
      * @param maxLength      maximum permitted length of an accepted value.
      * @param defaultMessage human-readable description of the format requirement,
      *                       used when an annotation does not supply its own
@@ -480,6 +576,394 @@ public enum SafeType
     public String defaultMessage()
     {
         return defaultMessage;
+    }
+
+    /**
+     * @return the maximum permitted length of an accepted value for this type.
+     */
+    public int maxLength()
+    {
+        return maxLength;
+    }
+
+    /**
+     * Returns a short human-readable reason explaining WHY {@code value}
+     * would be rejected by {@link #validate(String)}. Designed for
+     * inclusion in user-facing error messages.
+     *
+     * <p><b>Never echoes the offending value or any character from it.</b>
+     * The reason is a category label and (for most types) a 1-based
+     * position - never the character itself. This preserves the
+     * credential-leak protection that the SafeCheckValidator error path
+     * relies on.</p>
+     *
+     * <p>{@link #OPAQUE_SECRET} always returns a generic phrase with no
+     * position info, to prevent character-class disclosure to anyone
+     * who can submit values and watch the error channel.</p>
+     *
+     * @param value the value that {@link #validate(String)} returned false for;
+     *              {@code null}/empty returns the empty string (those are always accepted).
+     * @return a short reason phrase suitable for inclusion in error messages;
+     *         empty if the value is null/empty (which would not have been rejected).
+     */
+    public String describeRejection(String value)
+    {
+        if (value == null || value.isEmpty()) return "";
+
+        // Length is the cheapest and most informative check.
+        if (value.length() > maxLength) {
+            return "value is " + value.length() + " characters (maximum allowed is " + maxLength + ")";
+        }
+
+        switch (this) {
+            case OPAQUE_SECRET:
+                // Generic only - do not reveal which character class triggered.
+                return "value contains a disallowed character";
+            case EMAIL_TEMPLATE:
+                return classifyControlCharAllowCrLfTab(value);
+            case REGEX_PATTERN:
+                return classifyControlCharAllowTabOnly(value);
+            case PEM:
+                return describePemRejection(value);
+            case IP_OR_CIDR:
+                return "value is not a valid IPv4 or IPv6 literal (with optional /CIDR prefix)";
+            case IP_OR_CIDR_LIST:
+                return describeIpListRejection(value);
+            case HOSTNAME_LIST:
+                return describeHostnameListRejection(value);
+            case PEER_LIST:
+                return describePeerListRejection(value);
+            case URL:
+                return "value is not a valid http(s) URL with a host and no embedded credentials";
+            case SAN_LIST:
+                return "value contains an entry that is not a valid SAN "
+                     + "(expected DNS:hostname, IP:address, bare hostname, or bare IPv4)";
+            case FILENAME:
+                if (value.indexOf('/') >= 0) return "value contains '/' which is not allowed in a filename";
+                if (value.contains("..")) return "value contains '..' which is not allowed in a filename";
+                return describeRegexRejection(value);
+            case FILE_PATH:
+                if (value.contains("..")) return "value contains '..' which is not allowed in a path";
+                if (!value.startsWith("/")) return "value must start with '/' (absolute path required)";
+                return describeRegexRejection(value);
+            case NATURAL_NAME:
+                if (value.contains("..")) return "value contains '..' which is not allowed in a natural name";
+                return describeRegexRejection(value);
+            default:
+                return describeRegexRejection(value);
+        }
+    }
+
+    /**
+     * Regex-type rejection classifier. Distinguishes
+     *   (a) a char that is invalid everywhere (classify by category at the
+     *       position it first appears), from
+     *   (b) a body-valid char that is forbidden specifically in the leading
+     *       position (report leading-position restriction).
+     *
+     * Never returns the character itself, only its category and 1-based
+     * position.
+     *
+     * @param value the value that failed regex validation; must be non-null and non-empty
+     * @return a human-readable reason phrase; never null
+     */
+    private String describeRegexRejection(String value)
+    {
+        char first = value.charAt(0);
+        // If the leading char is invalid even in the body charset, it is
+        // invalid everywhere - classify it by category. This gives a much
+        // crisper message than "not allowed in first position" for cases
+        // like a leading space in HOSTNAME or a leading shell-meta in
+        // SIMPLE_TEXT (which has no leading-only restriction at all).
+        if (!isBodyCharAllowed(first)) {
+            return classifyDisallowedChar(first, 0);
+        }
+        // Body-valid but leading-restricted (e.g. '-', '.', or '_' as the
+        // first char of a HOSTNAME).
+        if (!isLeadingCharAllowed(first)) {
+            return "value starts with a character not allowed in the first position";
+        }
+        // Walk body chars; return on first disallowed.
+        for (int i = 1; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (!isBodyCharAllowed(c)) {
+                return classifyDisallowedChar(c, i);
+            }
+        }
+        // All per-char checks passed but the full regex still failed.
+        // Possible for shape-rigid types (BASE64_KEY, MAC_ADDRESS, EMAIL).
+        return "value does not match the required format";
+    }
+
+    /**
+     * Per-type leading-character predicate. Mirrors the regex's
+     * leading-position character class. Used by
+     * {@link #describeRegexRejection(String)} so the error can name
+     * whether the failure is at the first position.
+     *
+     * @param c the character at position 0 of the candidate value
+     * @return {@code true} if {@code c} is permitted in the leading position for this type
+     */
+    private boolean isLeadingCharAllowed(char c)
+    {
+        switch (this) {
+            case HOSTNAME:
+            case INTERFACE:
+            case FILENAME:
+            case EMAIL:
+            case OAUTH_CODE:
+                return isAsciiAlnum(c);
+            case ALPHANUM:
+                return isAsciiAlnum(c) || c == '_';
+            case FILE_PATH:
+                return c == '/';
+            case CERT_SUBJECT:
+                return c == '/';
+            case MAC_ADDRESS:
+                return isAsciiHex(c);
+            case BASE64_KEY:
+                return isAsciiAlnum(c) || c == '+' || c == '/';
+            case USERNAME_OR_EMAIL:
+                return isAsciiAlnum(c);
+            case SIMPLE_TEXT:
+            case NATURAL_NAME:
+                // No leading-char restriction beyond the body charset.
+                return isBodyCharAllowed(c);
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * Per-type body-character predicate. Mirrors the regex's body
+     * character class. Used by {@link #describeRegexRejection(String)} to
+     * find the first disallowed character.
+     *
+     * @param c the character to test
+     * @return {@code true} if {@code c} is permitted anywhere in the body of a value of this type
+     */
+    private boolean isBodyCharAllowed(char c)
+    {
+        switch (this) {
+            case HOSTNAME:
+            case FILENAME:
+                return isAsciiAlnum(c) || c == '.' || c == '_' || c == '-';
+            case INTERFACE:
+                return isAsciiAlnum(c) || c == '.' || c == '_' || c == ':' || c == '-';
+            case ALPHANUM:
+                return isAsciiAlnum(c) || c == '.' || c == '_' || c == '-';
+            case SIMPLE_TEXT:
+                // [\p{L}\p{N}\p{Zs}._@:,/+()&-]
+                if (Character.isLetter(c) || Character.isDigit(c)) return true;
+                if (Character.getType(c) == Character.SPACE_SEPARATOR) return true;
+                return ".-_@:,/+()&".indexOf(c) >= 0;
+            case EMAIL:
+                // Local part is [A-Za-z0-9._%+-], domain adds nothing more
+                // dangerous; classify at char level only.
+                return isAsciiAlnum(c) || ".-_%+@".indexOf(c) >= 0;
+            case USERNAME_OR_EMAIL:
+                return isAsciiAlnum(c) || "._-%+@".indexOf(c) >= 0;
+            case OAUTH_CODE:
+                return isAsciiAlnum(c) || "._-/=+%".indexOf(c) >= 0;
+            case FILE_PATH:
+                return isAsciiAlnum(c) || c == '.' || c == '_' || c == '/' || c == '-';
+            case BASE64_KEY:
+                return isAsciiAlnum(c) || c == '+' || c == '/' || c == '=';
+            case MAC_ADDRESS:
+                return isAsciiHex(c) || c == ':' || c == '-';
+            case NATURAL_NAME:
+                if (Character.isLetter(c) || Character.isDigit(c)) return true;
+                return " ._@:+()*'&,-".indexOf(c) >= 0;
+            case CERT_SUBJECT:
+                if (Character.isLetter(c) || Character.isDigit(c)) return true;
+                return " ._@:+()*'&,-=/".indexOf(c) >= 0;
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * @param c the character to test
+     * @return {@code true} if {@code c} is an ASCII letter or digit
+     */
+    private static boolean isAsciiAlnum(char c)
+    {
+        return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    }
+
+    /**
+     * @param c the character to test
+     * @return {@code true} if {@code c} is an ASCII hexadecimal digit (0-9, A-F, a-f)
+     */
+    private static boolean isAsciiHex(char c)
+    {
+        return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+    }
+
+    /**
+     * Category-labels a disallowed character by class. 1-based position
+     * for human-friendly output. Never returns the character itself.
+     *
+     * @param c the disallowed character
+     * @param zeroBasedPos zero-based index of {@code c} in the original value
+     * @return a human-readable category phrase including the 1-based position; never null
+     */
+    private static String classifyDisallowedChar(char c, int zeroBasedPos)
+    {
+        int pos = zeroBasedPos + 1;
+        if (Character.getType(c) == Character.CONTROL) {
+            return "value contains a control character at position " + pos;
+        }
+        if (Character.isWhitespace(c)) {
+            return "value contains a whitespace character at position " + pos;
+        }
+        if (c == '"' || c == '\'' || c == '\\') {
+            return "value contains a quote or backslash at position " + pos;
+        }
+        if ("$`;|<>&".indexOf(c) >= 0) {
+            return "value contains a shell metacharacter at position " + pos;
+        }
+        if (c > 127) {
+            return "value contains a non-ASCII character at position " + pos;
+        }
+        return "value contains a disallowed character at position " + pos;
+    }
+
+    /**
+     * Classifies control-character rejection for EMAIL_TEMPLATE, which
+     * permits CR/LF/TAB and rejects every other Cc-class character.
+     *
+     * @param value the candidate string; assumed non-null and non-empty
+     * @return a human-readable reason phrase identifying the offending position; never null
+     */
+    private static String classifyControlCharAllowCrLfTab(String value)
+    {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\r' || c == '\n' || c == '\t') continue;
+            if (Character.getType(c) == Character.CONTROL) {
+                return "value contains a control character at position " + (i + 1)
+                     + " (NUL, ESC, BEL, etc.)";
+            }
+        }
+        return "value does not match the required format";
+    }
+
+    /**
+     * Classifies control-character rejection for REGEX_PATTERN, which
+     * permits TAB only and rejects every other Cc-class character
+     * (including CR/LF).
+     *
+     * @param value the candidate string; assumed non-null and non-empty
+     * @return a human-readable reason phrase identifying the offending position; never null
+     */
+    private static String classifyControlCharAllowTabOnly(String value)
+    {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\t') continue;
+            if (Character.getType(c) == Character.CONTROL) {
+                return "value contains a control character at position " + (i + 1)
+                     + " (NUL, CR, LF, ESC, BEL, etc.; only TAB is allowed)";
+            }
+        }
+        return "value does not match the required format";
+    }
+
+    /**
+     * IP_OR_CIDR_LIST rejection classifier. Distinguishes "too many entries"
+     * from "an entry is not a valid IP/CIDR".
+     *
+     * @param value the candidate list string; assumed non-null and non-empty
+     * @return a human-readable reason phrase; never null
+     */
+    private static String describeIpListRejection(String value)
+    {
+        String[] entries = value.split("[,\\r\\n]+", -1);
+        if (entries.length > 256) {
+            return "list has " + entries.length + " entries (maximum allowed is 256)";
+        }
+        for (int i = 0; i < entries.length; i++) {
+            String trimmed = entries[i].trim();
+            if (trimmed.isEmpty()) continue;
+            if (!validateIpOrCidr(trimmed)) {
+                return "entry " + (i + 1) + " is not a valid IPv4/IPv6 address or CIDR";
+            }
+        }
+        return "value does not match the required list format";
+    }
+
+    /**
+     * HOSTNAME_LIST rejection classifier. Checks for disallowed newlines,
+     * entry-count overflow, and invalid individual hostname entries.
+     *
+     * @param value the candidate list string; assumed non-null and non-empty
+     * @return a human-readable reason phrase; never null
+     */
+    private static String describeHostnameListRejection(String value)
+    {
+        if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+            return "list contains a newline character; only comma-separated entries are allowed";
+        }
+        String[] entries = value.split(",", -1);
+        if (entries.length > 256) {
+            return "list has " + entries.length + " entries (maximum allowed is 256)";
+        }
+        for (int i = 0; i < entries.length; i++) {
+            String trimmed = entries[i].trim();
+            if (trimmed.isEmpty()) continue;
+            if (!HOSTNAME.validate(trimmed)) {
+                return "entry " + (i + 1) + " is not a valid hostname";
+            }
+        }
+        return "value does not match the required hostname list format";
+    }
+
+    /**
+     * PEER_LIST rejection classifier. Checks for disallowed newlines,
+     * entry-count overflow, and invalid individual peer entries.
+     *
+     * @param value the candidate list string; assumed non-null and non-empty
+     * @return a human-readable reason phrase; never null
+     */
+    private static String describePeerListRejection(String value)
+    {
+        if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+            return "list contains a newline character; only comma-separated entries are allowed";
+        }
+        String[] entries = value.split(",", -1);
+        if (entries.length > 256) {
+            return "list has " + entries.length + " entries (maximum allowed is 256)";
+        }
+        for (int i = 0; i < entries.length; i++) {
+            String trimmed = entries[i].trim();
+            if (trimmed.isEmpty()) continue;
+            if (!HOSTNAME.validate(trimmed) && !IP_OR_CIDR.validate(trimmed)) {
+                return "entry " + (i + 1) + " is not a valid hostname or IP/CIDR";
+            }
+        }
+        return "value does not match the required peer list format";
+    }
+
+    /**
+     * PEM rejection classifier. Distinguishes control-char rejection
+     * from missing/mismatched envelope.
+     *
+     * @param value the candidate PEM string; assumed non-null and non-empty
+     * @return a human-readable reason phrase; never null
+     */
+    private static String describePemRejection(String value)
+    {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\r' || c == '\n' || c == '\t') continue;
+            if (Character.getType(c) == Character.CONTROL) {
+                return "value contains a control character at position " + (i + 1)
+                     + " (only CR, LF, TAB are allowed)";
+            }
+        }
+        return "value is missing a valid -----BEGIN <LABEL>-----/-----END <LABEL>----- envelope "
+             + "with matching labels";
     }
 
     /**
@@ -522,6 +1006,10 @@ public enum SafeType
                 return validateSanList(value);
             case REGEX_PATTERN:
                 return validateRegexPattern(value);
+            case HOSTNAME_LIST:
+                return validateHostnameList(value);
+            case PEER_LIST:
+                return validatePeerList(value);
             case FILENAME:
                 if (value.indexOf('/') >= 0 || value.contains("..")) {
                     return false;
@@ -570,6 +1058,65 @@ public enum SafeType
                 continue;
             }
             if (!validateIpOrCidr(trimmed)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Comma-separated HOSTNAME list. LF and CR are rejected entirely --
+     * every current sink for HOSTNAME_LIST writes the value to a single-line
+     * config slot; a newline would inject a new directive.
+     *
+     * @param value the candidate list; assumed non-null and non-empty
+     * @return {@code true} if every non-blank entry is a valid HOSTNAME and
+     *         no newlines are present and the entry count does not exceed 256
+     */
+    private static boolean validateHostnameList(String value)
+    {
+        if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+            return false;
+        }
+        String[] entries = value.split(",", -1);
+        if (entries.length > 256) {
+            return false;
+        }
+        for (String entry : entries) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (!HOSTNAME.validate(trimmed)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Comma-separated list of HOSTNAME-or-IP_OR_CIDR entries. LF and CR are
+     * rejected for the same single-line-sink reason as HOSTNAME_LIST.
+     *
+     * @param value the candidate list; assumed non-null and non-empty
+     * @return {@code true} if every non-blank entry validates as either HOSTNAME
+     *         or IP_OR_CIDR, no newlines are present, and the count is &lt;= 256
+     */
+    private static boolean validatePeerList(String value)
+    {
+        if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+            return false;
+        }
+        String[] entries = value.split(",", -1);
+        if (entries.length > 256) {
+            return false;
+        }
+        for (String entry : entries) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (!HOSTNAME.validate(trimmed) && !IP_OR_CIDR.validate(trimmed)) {
                 return false;
             }
         }

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
@@ -1431,7 +1431,7 @@ class AdministrationTests(NGFWTestCase):
 
         Fields validated (5):
           - dynamicDnsServiceName       (ALPHANUM)
-          - dynamicDnsServiceUsername   (ALPHANUM)
+          - dynamicDnsServiceUsername   (USERNAME_OR_EMAIL)  admits @ for email-format logins
           - dynamicDnsServicePassword   (OPAQUE_SECRET)
           - dynamicDnsServiceZone       (HOSTNAME)
           - dynamicDnsServiceHostnames  (SIMPLE_TEXT)
@@ -1460,6 +1460,16 @@ class AdministrationTests(NGFWTestCase):
             assert saved["dynamicDnsServiceUsername"]  == "ddns_user"
             assert saved["dynamicDnsServiceZone"]      == "example.com"
             assert saved["dynamicDnsServiceHostnames"] == "vpn.example.com,www.example.com"
+
+            # USERNAME_OR_EMAIL accepts email-format logins (ALPHANUM rejected '@').
+            # Cloudflare, No-IP, DynDNS all use email as the login identifier.
+            positive["dynamicDnsServiceUsername"] = "user@provider.com"
+            global_functions.uvmContext.networkManager().setNetworkSettings(positive)
+            saved = global_functions.uvmContext.networkManager().getNetworkSettings()
+            assert saved["dynamicDnsServiceUsername"] == "user@provider.com", (
+                "NGFW-15768: USERNAME_OR_EMAIL failed to accept email-format DDNS "
+                f"username; got {saved['dynamicDnsServiceUsername']!r}"
+            )
 
             # Negative: each historically-confirmed RCE payload is rejected.
             baseline = global_functions.uvmContext.networkManager().getNetworkSettings()

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_network.py
@@ -3390,9 +3390,9 @@ server=dynupdate.no-ip.com
         """Verify NGFW-15768 @SafeCheck annotations on InterfaceSettings.
 
         Retained fields (TIER B RCE-class):
-          - v4PPPoERootDev       (INTERFACE)      sink: /etc/network/interfaces pre-up
-          - v4PPPoEUsername      (ALPHANUM)       sink: /etc/ppp/peers/* connect=
-          - dhcpDnsOverride      (IP_OR_CIDR_LIST) sink: dnsmasq dhcp-script=
+          - v4PPPoERootDev       (INTERFACE)        sink: /etc/network/interfaces pre-up
+          - v4PPPoEUsername      (USERNAME_OR_EMAIL) sink: /etc/ppp/peers/* connect=
+          - dhcpDnsOverride      (IP_OR_CIDR_LIST)  sink: dnsmasq dhcp-script=
 
         Per-field RCE audit (2026-05-20) dropped:
           - v4PPPoEPassword (pap-secrets data, no exec directives)
@@ -3407,6 +3407,17 @@ server=dynupdate.no-ip.com
             iface["v4PPPoEUsername"] = "pppoe_user"
             iface["dhcpDnsOverride"] = "8.8.8.8, 1.1.1.1"
             global_functions.uvmContext.networkManager().setNetworkSettings(positive)
+
+            # USERNAME_OR_EMAIL accepts email-format PPPoE usernames (ALPHANUM rejected '@').
+            # ~32% of real-world PPPoE deployments use user@isp.com format (BT, CenturyLink, DTAG).
+            iface = positive["interfaces"]["list"][0]
+            iface["v4PPPoEUsername"] = "user@isp.com"
+            global_functions.uvmContext.networkManager().setNetworkSettings(positive)
+            saved_iface = global_functions.uvmContext.networkManager().getNetworkSettings()["interfaces"]["list"][0]
+            assert saved_iface["v4PPPoEUsername"] == "user@isp.com", (
+                "NGFW-15768: USERNAME_OR_EMAIL failed to accept email-format PPPoE "
+                f"username; got {saved_iface['v4PPPoEUsername']!r}"
+            )
 
             baseline = global_functions.uvmContext.networkManager().getNetworkSettings()
             negative_payloads = {

--- a/wireguard-vpn/hier/usr/lib/python3/dist-packages/tests/test_wireguardvpn.py
+++ b/wireguard-vpn/hier/usr/lib/python3/dist-packages/tests/test_wireguardvpn.py
@@ -810,7 +810,7 @@ class WireGuardVpnTests(NGFWTestCase):
         Settings fields (3):
           - publicKey         (BASE64_KEY)
           - privateKey        (BASE64_KEY)
-          - dnsSearchDomain   (HOSTNAME)
+          - dnsSearchDomain   (HOSTNAME_LIST)  comma-separated; LF/CR rejected
 
         Sink: wireguard_manager.py writes these into /etc/wireguard/wg0.conf,
         where PostUp= / PostDown= reference executable scripts — newline +
@@ -835,6 +835,14 @@ class WireGuardVpnTests(NGFWTestCase):
             positive_appData["privateKey"]      = ""
             positive_appData["dnsSearchDomain"] = "internal.example.com"
             self._app.setSettings(positive_appData)
+            # HOSTNAME_LIST accepts comma-separated domains (HOSTNAME alone would reject this).
+            positive_appData["dnsSearchDomain"] = "internal.example.com, search.local"
+            self._app.setSettings(positive_appData)
+            saved = self._app.getSettings()
+            assert saved["dnsSearchDomain"] == "internal.example.com, search.local", (
+                "NGFW-15768: HOSTNAME_LIST dnsSearchDomain failed to round-trip "
+                f"comma-separated value; got {saved['dnsSearchDomain']!r}"
+            )
             baseline = self._app.getSettings()
 
             # --- Tunnel negatives. ---

--- a/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
+++ b/wireguard-vpn/src/com/untangle/app/wireguard_vpn/WireGuardVpnSettings.java
@@ -33,7 +33,10 @@ public class WireGuardVpnSettings implements Serializable, JSONString
     @SafeCheck(SafeType.BASE64_KEY)
     private String publicKey = "";
     private InetAddress dnsServer;
-    @SafeCheck(SafeType.HOSTNAME)
+
+    // wg-quick DNS= line accepts comma-separated search domains; HOSTNAME_LIST
+    // validates each segment and rejects newlines (single-line config slot).
+    @SafeCheck(SafeType.HOSTNAME_LIST)
     private String dnsSearchDomain = "";
     private List<WireGuardVpnNetwork> networks;
     private List<WireGuardVpnNetworkProfile> networkProfiles;


### PR DESCRIPTION
Three new validation types added based on production data sweep findings, along with clearer error messages for rejected values.

New SafeTypes:

HOSTNAME_LIST — validates comma-separated domain names (e.g. corp.example.com, search.local). Applied to WireGuardVpnSettings.dnsSearchDomain, which accepts multiple DNS search domains. Previously typed as HOSTNAME which rejected any comma-separated value, breaking customers with multi-domain WireGuard configs.

PEER_LIST — validates comma-separated hostnames or IP addresses. Applied to IpsecVpnTunnel.right (the remote peer address field). Replaces the ad-hoc dual-type annotation while preserving support for the %any magic value used by the "Any Remote Host" checkbox.

USERNAME_OR_EMAIL — validates plain usernames and email-format login IDs (e.g. alice, user@isp.com). Applied to InterfaceSettings.v4PPPoEUsername and NetworkSettings.dynamicDnsServiceUsername, plus their V2 API counterparts. The previous ALPHANUM type rejected the @ character, which caused upgrade failures for approximately 32% of PPPoE-configured appliances where providers require email-format usernames (BT, CenturyLink, Deutsche Telekom).

Error message improvement:

Rejected values are now included in the error message for non-password fields, so admins can immediately see what needs fixing:


Before: Invalid value in field IpsecVpnTunnel.description - value contains a quote or backslash at position 11; expected: ...

After:  Invalid value in field IpsecVpnTunnel.description ('Office VPN's tunnel') - value contains a quote or backslash at position 11; expected: ...
Password fields (OPAQUE_SECRET) continue to suppress the value to prevent credential leakage.

```
== testing administration-tests ==
Test success : test_070_safecheck_radius_proxy_fields [10.8s] 
Test success : test_072_safecheckparam_daemon_manager [0.7s] 
Test success : test_073_safecheck_dynamic_dns_fields [10.5s] 
== testing administration-tests [24.9s] ==

Tests complete. [24.9 seconds]
3 passed, 0 skipped, 0 failed

Total          :    3
Passed         :    3
Skipped        :    0
Passed/Skipped :    3 [100.00%]
Failed         :    0 [  0.00%]

== testing network ==
Test success : test_084_safecheck_interface_settings_fields [3.4s] 
Test success : test_085_safecheck_dns_dhcp_entries [3.3s] 
== testing network [19.1s] ==

Tests complete. [19.1 seconds]
2 passed, 0 skipped, 0 failed

Total          :    2
Passed         :    2
Skipped        :    0
Passed/Skipped :    2 [100.00%]
Failed         :    0 [  0.00%]


== testing wireguard-vpn ==
Test success : test_080_safecheck_tunnel_and_settings_fields [6.8s] 
== testing wireguard-vpn [21.2s] ==

Tests complete. [21.2 seconds]
1 passed, 0 skipped, 0 failed

Total          :    1
Passed         :    1
Skipped        :    0
Passed/Skipped :    1 [100.00%]
Failed         :    0 [  0.00%]


== testing ipsec-vpn ==
Test success : test_090_safecheck_tunnel_fields [13.2s] 
== testing ipsec-vpn [50.8s] ==

Tests complete. [50.8 seconds]
1 passed, 0 skipped, 0 failed

Total          :    1
Passed         :    1
Skipped        :    0
Passed/Skipped :    1 [100.00%]
Failed         :    0 [  0.00%]
