### PR TITLE
ngfw-15800 Virus Blocker should be enabled if Virus Blocker Lite was enabled before 17.5 upgrade

### DIFF
--- a/uvm/impl/com/untangle/uvm/AppManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/AppManagerImpl.java
@@ -1642,7 +1642,18 @@ public class AppManagerImpl implements AppManager
                 if (item.getAppName().equals("ips")) continue;
                 if (item.getAppName().equals("spam-blocker-lite")) continue;
                 if (item.getAppName().equals("idps")) continue;
-                if (item.getAppName().equals("virus-blocker-lite")) continue;
+                if (item.getAppName().equals("virus-blocker-lite")) {
+                    // If Lite was running, ensure Virus Blocker (same clamav backend) is also running.
+                    if (AppSettings.AppState.RUNNING.equals(item.getTargetState())) {
+                        final Integer policyId = item.getPolicyId();
+                        readSettings.getApps().stream()
+                            .filter(s -> "virus-blocker".equals(s.getAppName())
+                                      && java.util.Objects.equals(s.getPolicyId(), policyId))
+                            .findFirst()
+                            .ifPresent(vb -> vb.setTargetState(AppSettings.AppState.RUNNING));
+                    }
+                    continue;
+                }
                 cleanList.add(item);
             }
 


### PR DESCRIPTION
## Summary

Fix upgrade path from pre-17.5 so that Virus Blocker is automatically enabled when Virus Blocker Lite was previously running. Without this fix, customers upgrading from versions that shipped Virus Blocker Lite would lose virus scanning coverage because the lite variant is removed but Virus Blocker was not enabled as its replacement.

## Motivation

NGFW-15800 — Virus Blocker Lite was removed in 17.5 and replaced by Virus Blocker (both use the same ClamAV backend). During upgrade, the existing code skipped Virus Blocker Lite entries entirely without propagating the running state to Virus Blocker, leaving virus scanning disabled on the upgraded system.

## Changes

- **UVM / AppManagerImpl.java** — Upgrade migration logic (`loadSettings` clean-up loop)
  - When a `virus-blocker-lite` entry is encountered with `targetState == RUNNING`, find the corresponding `virus-blocker` entry in the same policy and set its `targetState` to `RUNNING`
  - Preserves the existing `continue` to still strip the lite entry from the persisted app list

## Testing

1. Set up a pre-17.5 system with Virus Blocker Lite enabled (targetState = RUNNING) and Virus Blocker installed but not running
2. Perform the 17.5 upgrade
3. Verify Virus Blocker is automatically set to RUNNING on the upgraded system
4. Confirm Virus Blocker Lite is removed from the app list
5. Repeat with Virus Blocker Lite in a non-RUNNING state and verify Virus Blocker's state is unchanged
6. Verify multi-policy setups — Lite running in policy A but not policy B should only enable Virus Blocker in policy A

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features

