### PR TITLE
NGFW-15804 Saving license to the disk everytime downloaded from license server

### DIFF
--- a/license/src/com/untangle/app/license/LicenseManagerImpl.java
+++ b/license/src/com/untangle/app/license/LicenseManagerImpl.java
@@ -990,9 +990,7 @@ public class LicenseManagerImpl extends AppBase implements LicenseManager
                 }
 
                 _mapLicenses();
-                if (!this.settings.toJSONString().equals(oldSettingsString)) {
-                    _saveSettings(this.settings);
-                }
+                _saveSettings(this.settings);   // always save on successful sync, bounds disk file age to last successful contact
             }
             _cleanLicenseFiles();
             _runAppManagerSync();


### PR DESCRIPTION
## What this prevents

A destructive cascade observed during testing where a single transient license-server failure shuts down every licensed app, plus Reports /postgres / IPsec / WireGuard tunnels — until manual recovery (adminopening the Licenses tab in the UI).

The cascade reproduces on any box where:
1. License files on disk have aged past the 5-day cleanup window, AND
2. The next sync attempt hits any transient server-side failure (TCP  blip, HTTPS timeout, JSON parse error on a non-JSON body, etc.).

Both preconditions are easy to hit on stable boxes — the file ages out silently, and a single bad response or brief connectivity blip then craters every paid app.

## Root cause

`LicenseManagerImpl._syncLicensesWithServer` had a skip-if-unchanged guard on the success-branch save. When the server returns the same response every 4h sync (the normal case for stable subscriptions), no save fires → file mtime drifts. The 5-day file cleanup (anti-evasion intent) then deletes the only file → `licenses.js` symlink dangles. The next failure branch reload at L943 loads null, calls `_initializeSettings()`, clobbers valid in-memory licenses with an empty list, and `_runAppManagerSync()` stops every app.

The reload is correct behavior when the disk file is reliable. The bug was that nothing was keeping it reliable.

## The change

One line in the success branch of `_syncLicensesWithServer`: drop the skip-if-unchanged guard, always call _saveSettings()` after a successful sync. Bounds disk-file age to last successful contact (≤4h under normal operation).

Failure-branch skip-if-unchanged left intact — failure path must not refresh mtime, or the anti-evasion grace window  ould never expire under flapping disconnect/reconnect.

## What still works as before

| Scenario | Behavior |
|---|---|
| Successful download, non-empty list | Apps stay up (server-authoritative) |
| Successful download, empty `{"list":[]}` | Apps shut down (server-authoritative) |
| Transient TCP probe failure | **Apps stay up** ✓ |
| HTTPS throws / non-JSON body / JSONException | **Apps stay up** ✓ |
| No successful sync for 5+ days (deliberate disconnect) | Apps shut down (anti-evasion preserved) |
| First-boot, no internet | Unchanged (IPM message, install button on reconnect) |
| Revoke / expired-license / restricted-mode | Unchanged |

## Trade-offs

- Disk writes increase from ~0/week to ~6/day for stable subscriptions   (~240KB/day). Versioned-file pruning unchanged.
- `LICENSE_CHANGE` hook fires more often — verified zero subscribers in tree.
- `UVM_SETTINGS_CHANGE` hook fires more often — verified IpsecVpn  subscriber short-circuits on non-`system.js` filenames.