### PR TITLE
NGFW-15787: Fixed Dynamic block lists to update properly for CIDR-only source lists

### DIFF
--- a/dynamic-blocklists/hier/usr/share/untangle/bin/dbl-cleanup.sh
+++ b/dynamic-blocklists/hier/usr/share/untangle/bin/dbl-cleanup.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
-
-# Exit immediately if a command exits with a non-zero status
-set -e
-
 # Remove the DROP rule from the dynamic-block-list chain
 echo "Removing DROP rule from dynamic-block-list chain..."
-iptables -t filter -D dynamic-block-list -m set --match-set dblsets dst -j DROP ||
+iptables -t filter -D dynamic-block-list -m set --match-set dblsets dst -j DROP 2>/dev/null || true
 
 # Remove the NFLOG rule from the dynamic-block-list chain
 echo "Removing NFLOG rule from dynamic-block-list chain..."
-iptables -t filter -D dynamic-block-list -m set --match-set dblsets dst -j NFLOG --nflog-prefix "dynamic_block_list_blocked" ||
+iptables -t filter -D dynamic-block-list -m set --match-set dblsets dst -j NFLOG --nflog-prefix "dynamic_block_list_blocked" 2>/dev/null || true
 
 # Remove rule from FORWARD chain
 echo "Removing rule from FORWARD chain..."
@@ -28,7 +24,7 @@ echo "Destroying specified IP sets..."
 ipset_members=$(sudo ipset list dblsets | awk '/Members:/ {flag=1; next} flag && NF {print $1} /done/ {flag=0}')
 
 # Destroy parent set
-ipset destroy dblsets ||
+ipset destroy dblsets || true
 
 # Check if members exist
 if [ -z "$ipset_members" ]; then

--- a/dynamic-blocklists/hier/usr/share/untangle/bin/dbl-setup.sh
+++ b/dynamic-blocklists/hier/usr/share/untangle/bin/dbl-setup.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status
-set -e
-
 echo "Creating parent set for all the blocking set"
-ipset create dblsets list:set
+ipset create dblsets list:set -exist
 
 echo "Creating dynamic-block-list chain..."
-iptables -t filter -N dynamic-block-list
+iptables -t filter -N dynamic-block-list 2>/dev/null || true
 
 echo "Linking dynamic-block-list chain to FORWARD chain..."
-iptables -t filter -A FORWARD -m conntrack --ctstate NEW -j dynamic-block-list
+iptables -t filter -C FORWARD -m conntrack --ctstate NEW -j dynamic-block-list 2>/dev/null ||
+    iptables -t filter -A FORWARD -m conntrack --ctstate NEW -j dynamic-block-list
 
 echo "Adding rule to log and drop parent ipset"
-iptables -t filter -A dynamic-block-list -m set --match-set dblsets dst -j NFLOG --nflog-prefix "dynamic_block_list_blocked"
-iptables -t filter -A dynamic-block-list -m set --match-set dblsets dst -j DROP
+iptables -t filter -C dynamic-block-list -m set --match-set dblsets dst -j NFLOG --nflog-prefix "dynamic_block_list_blocked" 2>/dev/null ||
+    iptables -t filter -A dynamic-block-list -m set --match-set dblsets dst -j NFLOG --nflog-prefix "dynamic_block_list_blocked"
+iptables -t filter -C dynamic-block-list -m set --match-set dblsets dst -j DROP 2>/dev/null ||
+    iptables -t filter -A dynamic-block-list -m set --match-set dblsets dst -j DROP
 
 echo "Filter chain setup complete!"

--- a/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsApp.java
+++ b/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsApp.java
@@ -44,7 +44,6 @@ public class DynamicBlockListsApp extends AppBase
     private final Logger logger = LogManager.getLogger(getClass());
     private final String SettingsDirectory = "/dynamic-blocklists/";
 
-    private static final String CRON_FILE = "/etc/cron.d/dbl-crons";
     private static final String BLOCK_LISTS_DIR = "/etc/config/blocklists";
     private final PipelineConnector[] connectors = new PipelineConnector[] {};
 
@@ -219,93 +218,48 @@ public class DynamicBlockListsApp extends AppBase
     public Object runJobsByConfigIdsV2(LinkedList<String> configIds) throws Exception {
         List<String> successfulIds = new ArrayList<>();
 
-        // Validate all configIds as UUIDs before doing any file I/O
-        for (String configId : configIds) {
-            try {
-                UUID.fromString(configId);
-            } catch (IllegalArgumentException e) {
-                logger.error("Invalid configId format (must be UUID): {}", configId);
-                Map<String, Object> messageMap = new HashMap<>();
-                messageMap.put("message", "invalid_config_id_format");
-                messageMap.put("vars", null);
-                return Map.of(
-                    "type", "Error",
-                    "success", false,
-                    "messages", List.of(messageMap)
-                );
-            }
-        }
+        String scriptPath = "/usr/share/untangle/bin/fetch_ip_list.py";
 
-        List<String> cronLines;
-        try {
-            cronLines = Files.readAllLines(Paths.get(CRON_FILE));
-        } catch (java.nio.file.NoSuchFileException e) {
-            logger.warn("Cron file not found: {}", CRON_FILE);
-            Map<String, Object> messageMap = new HashMap<>();
-            messageMap.put("message", "download_blocklist_to_appliance_failure");
-            messageMap.put("vars", null);
-            return Map.of(
-                "type", "Error",
-                "success", false,
-                "messages", List.of(messageMap)
+        for (String configId : configIds) {
+            // Validate by existence in current settings instead of UUID format check,
+            // since stored IDs are 28-char generated strings (not UUID format).
+            DynamicBlockList config = this.settings.getConfigurations().stream()
+                .filter(c -> configId.equals(c.getId()) && c.isEnabled())
+                .findFirst().orElse(null);
+
+            if (config == null) {
+                logger.error("No enabled config found for configId: {}", configId);
+                continue;
+            }
+
+            String filePath = BLOCK_LISTS_DIR + "/dynamic_ip_addresses_list_" + configId + ".txt";
+            List<String> args = Arrays.asList(
+                configId,
+                config.getSource(),
+                filePath,
+                String.valueOf(config.getSkipCertCheck()),
+                config.getParsingMethod(),
+                this.getSettingsFilename(),
+                "True"
             );
-        }
 
-        for (String configId : configIds) {
-            boolean found = false;
-            boolean success = false;
-
-            for (String line : cronLines) {
-                line = line.trim();
-                if (line.isEmpty() || line.startsWith("#")) {
-                    continue;
+            try {
+                ExecManagerResult result = UvmContextFactory.context().execManager().execCommand(scriptPath, args);
+                String resultOutput = result.getOutput();
+                if (resultOutput != null && (resultOutput.contains("[ERROR]") || resultOutput.contains("[WARNING]"))) {
+                    logger.error("Command failed for configId {}: {}", configId, resultOutput);
+                } else {
+                    successfulIds.add(configId);
                 }
-                if (line.contains(configId)) {
-                    found = true;
-                    String[] parts = line.split("\\s+", 7);
-                    if (parts.length < 7) {
-                        logger.error("Invalid cron line format: {}", line);
-                        continue;
-                    }
-                    String command = parts[6];
-
-                    if (StringUtils.isNotBlank(command)) {
-                        command = command.replace("2>&1 | logger -t dynamic_list_manager", "").trim();
-                    }
-                    try {
-                        String[] cmdParts = command.split("\\s+");
-                        String script = cmdParts[0];
-                        List<String> args = Arrays.asList(Arrays.copyOfRange(cmdParts, 1, cmdParts.length));
-                        ExecManagerResult result = UvmContextFactory.context().execManager().execCommand(script, args);
-                        String resultOutput = result.getOutput();
-                        // Mark as failed if output contains [ERROR]/[WARNING]
-                        if ( (resultOutput != null && (resultOutput.contains("[ERROR]") || resultOutput.contains("[WARNING]")))) {
-                            logger.error("Command failed for configId {}: Error :{}", configId, resultOutput);
-                            success = false;
-                        } else {
-                            successfulIds.add(configId);
-                            success = true;
-                        }
-
-                    } catch (Exception e) {
-                        logger.warn("Exception running command for configId {}: {}", configId, e.getMessage());
-                        success = false;
-                    }
-
-                    break;
-                }
-            }
-            if (!found) {
-                logger.info("No cron job found for config ID {}", configId);
-                success = false;
+            } catch (Exception e) {
+                logger.warn("Exception running command for configId {}: {}", configId, e.getMessage());
             }
         }
-        //if none of sourcelist is run sucessfully without error send the error response
-        if (successfulIds.size() == 0) {
+
+        if (successfulIds.isEmpty()) {
             Map<String, Object> messageMap = new HashMap<>();
             messageMap.put("message", "download_blocklist_to_appliance_failure");
             messageMap.put("vars", null);
-
             return Map.of(
                 "type", "Error",
                 "success", false,
@@ -358,6 +312,21 @@ public class DynamicBlockListsApp extends AppBase
         if (readSettings == null) {
             logger.warn("No settings found - Initializing new settings.");
             this.initializeSettings();
+        }
+    }
+
+    /**
+     * Called after the application transitions to RUNNING state.
+     * Ensures parent ipset and iptables chain exist (idempotent) and
+     * triggers sync-settings to recreate child ipsets -critical after
+     * a system reboot when in-kernel ipsets are lost.
+     * @param isPermanentTransition
+     */
+    @Override
+    protected void postStart(boolean isPermanentTransition) {
+        dynamicBlockListsManager.ensureSetup();
+        if (this.settings != null && this.settings.getEnabled()) {
+            dynamicBlockListsManager.configure();
         }
     }
 

--- a/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsManager.java
+++ b/dynamic-blocklists/src/com/untangle/app/dynamic_blocklists/DynamicBlockListsManager.java
@@ -37,8 +37,15 @@ public class DynamicBlockListsManager {
      */
     protected void start() {
         this.app.start();
-        logger.info("Staring the Dynamic Blocklist Setup Process");
-        ExecManagerResult result = UvmContextFactory.context().execManager().exec(DBL_SETUP_SCRIPT); 
+    }
+
+    /**
+     * Ensure parent ipset and iptables chain exist (idempotent).
+     * Safe to call multiple times -dbl-setup.sh uses -exist flags.
+     */
+    protected void ensureSetup() {
+        logger.info("Starting the Dynamic Blocklist Setup Process");
+        ExecManagerResult result = UvmContextFactory.context().execManager().exec(DBL_SETUP_SCRIPT);
         logger.info("DBL setup script result: {}", result.getOutput());
     }
 

--- a/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
+++ b/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
@@ -55,7 +55,8 @@ ALLOWED_EXECUTABLES = {
     "/usr/share/untangle/bin/ut-radius-proxy",
     "/usr/share/untangle/bin/ipsec-tunnel-status",
     "/usr/share/untangle/bin/wan-failover-pingable-hosts.sh",
-    "/usr/share/untangle/bin/ut-wireguard-helpers.sh"
+    "/usr/share/untangle/bin/ut-wireguard-helpers.sh",
+    "/usr/share/untangle/bin/fetch_ip_list.py",
 
 }
 


### PR DESCRIPTION
**Summary**

- Eliminated cron-file parsing as the execution mechanism for on-demand blocklist updates (runJobsByConfigIdsV2). Instead of reading /etc/cron.d/dbl-crons, extracting the command, and shelling it out, the method now directly invokes fetch_ip_list.py with arguments built from the in-memory config object. This fixes failures where CIDR-only source lists weren't updating because the cron-file parsing approach was fragile.
- Made iptables/ipset setup idempotent - dbl-setup.sh now uses -exist flags and check-before-add (iptables -C … || iptables -A …) so re-running it on an already-configured system is a no-op instead of an error. dbl-cleanup.sh drops set -e and appends || true / 2>/dev/null so cleanup doesn't abort on missing rules.
- Added postStart() hook to DynamicBlockListsApp that calls ensureSetup() + configure() after the app transitions to RUNNING - critical after a reboot when in-kernel ipsets are lost.
- Allowlisted fetch_ip_list.py in ut-exec-safe-launcher so the new direct-invocation path passes the safe-exec whitelist.
