### PR TITLE
ngfw-15825 On VBL removal VB should be installed

### DIFF
--- a/uvm/impl/com/untangle/uvm/AppManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/AppManagerImpl.java
@@ -13,6 +13,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1636,6 +1638,7 @@ public class AppManagerImpl implements AppManager
             // UPDATE settings if necessary
 
             // look for and remove old apps that no longer exist
+            boolean settingsModified = false;
             LinkedList<AppSettings> cleanList = new LinkedList<>();
             for (AppSettings item : readSettings.getApps()) {
                 if (item.getAppName().equals("webfilter-lite")) continue;
@@ -1643,22 +1646,37 @@ public class AppManagerImpl implements AppManager
                 if (item.getAppName().equals("spam-blocker-lite")) continue;
                 if (item.getAppName().equals("idps")) continue;
                 if (item.getAppName().equals("virus-blocker-lite")) {
+                    // One-time 17.4 -> 17.5 upgrade migration; can be removed in the next release
+                    // once 17.4 is no longer a supported upgrade path.
                     // If Lite was running, ensure Virus Blocker (same clamav backend) is also running.
                     if (AppSettings.AppState.RUNNING.equals(item.getTargetState())) {
                         final Integer policyId = item.getPolicyId();
-                        readSettings.getApps().stream()
+                        Optional<AppSettings> existingVb = readSettings.getApps().stream()
                             .filter(s -> "virus-blocker".equals(s.getAppName())
-                                      && java.util.Objects.equals(s.getPolicyId(), policyId))
-                            .findFirst()
-                            .ifPresent(vb -> vb.setTargetState(AppSettings.AppState.RUNNING));
+                                      && Objects.equals(s.getPolicyId(), policyId))
+                            .findFirst();
+                        if (existingVb.isPresent()) {
+                            existingVb.get().setTargetState(AppSettings.AppState.RUNNING);
+                        } else {
+                            // VB was never installed for this policy. Create an entry so the
+                            // customer retains virus protection after VBL is removed in 17.5.
+                            // restartUnloaded() picks this up; postInit() creates default
+                            // settings via initializeSettings() if no settings file exists.
+                            long newId = readSettings.getNextAppId();
+                            readSettings.setNextAppId(newId + 1);
+                            AppSettings newVb = new AppSettings(newId, policyId, "virus-blocker");
+                            newVb.setTargetState(AppSettings.AppState.RUNNING);
+                            cleanList.add(newVb);
+                        }
+                        settingsModified = true;
                     }
                     continue;
                 }
                 cleanList.add(item);
             }
 
-            // if we removed anything update the app list and save
-            if (cleanList.size() != readSettings.getApps().size()) {
+            // if we removed or added anything, update the app list and save
+            if (cleanList.size() != readSettings.getApps().size() || settingsModified) {
                 readSettings.setApps(cleanList);
                 this._setSettings(readSettings);
             }


### PR DESCRIPTION
## Summary

When upgrading from 17.4 to 17.5, customers who had Virus Blocker Lite (VBL) running but not installed Virus Blocker (VB) would lose virus scanning entirely. This extends the existing VBL->VB migration in `loadSettings()` to create a new VB entry when no existing one is found for the same policy.

## Motivation

NGFW-15825. In 17.5 VBL is removed and replaced by VB (both share the same ClamAV backend). The prior fix (NGFW-15800) handled the case where VB was already installed by transferring VBL's RUNNING state to VB. However, if a customer only ever had VBL installed (VB was never instantiated), no VB entry existed in `apps.js` to transfer the state to — the customer silently lost virus protection after upgrade.

## Changes

### UVM App Manager (`AppManagerImpl.java` — `loadSettings()`)
- Extended the `virus-blocker-lite` migration block with an `else` branch: when VBL was RUNNING but no VB entry exists for the same `policyId`, creates a new `AppSettings` entry for VB with `targetState=RUNNING` and adds it to the app list
- Allocates a unique app ID via `readSettings.getNextAppId()` and increments it for the new entry
- Added `settingsModified` flag to fix the save condition — removing VBL (-1) and adding VB (+1) leaves list sizes equal, so the original size-based check would skip persisting
- Cleaned up fully-qualified `java.util.Objects` and `java.util.Optional` references into proper imports

## Testing

The new VB entry is picked up by `restartUnloaded()` on the same boot. `AppBase.loadClass(isNew=false)` calls `resumeState(RUNNING)` which calls `postInit()` — this detects no existing `settings_{appId}.js` and falls back to `initializeSettings()`, creating default VB settings. `start(false)` then gates on `isLicenseValid()` and starts the app normally.

Tested on device across all 5 policy scenarios:

| # | Setup | VB after upgrade | Branch |
|---|-------|-----------------|--------|
| 1 | VBL RUNNING + VB INITIALIZED | RUNNING | `if` (existing) |
| 2 | VBL INITIALIZED + VB INITIALIZED | INITIALIZED | no-op |
| 3 | VBL RUNNING + VB RUNNING | RUNNING | no-op |
| 4 | VBL INITIALIZED + VB RUNNING | RUNNING | no-op |
| **5** | **VBL RUNNING + no VB entry** | **RUNNING** | **`else` (this fix)** |

Manual verification steps:
1. Back up `apps.js`, inject VBL RUNNING entry with no VB entry for policyId=1
2. Restart UVM
3. Verify VB appears in `appInstances()` with `targetState=RUNNING`
4. Verify VBL entry is removed from `apps.js`
5. Verify `settings_{newId}.js` exists on disk (default settings created by `postInit()` fallback)
6. Restore original `apps.js`

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
