### PR TITLE
NGFW-15814: Fixed Dynamic Blocklists: setup/cleanup and on-demand job tests

### DIFF
--- a/dynamic-blocklists/hier/usr/share/untangle/bin/dbl-cleanup.sh
+++ b/dynamic-blocklists/hier/usr/share/untangle/bin/dbl-cleanup.sh
@@ -29,7 +29,6 @@ ipset destroy dblsets || true
 # Check if members exist
 if [ -z "$ipset_members" ]; then
     echo "No members found in the ipset set dblsets."
-    exit 1
 fi
 
 # Loop through each member and delete it from the ipset set


### PR DESCRIPTION
**ISSUE** : 
When the dblsets ipset has no members, the script does exit 1 — which aborts before reaching the iptables chain deletion.
In test_012, the app is enabled then immediately disabled without running any jobs, so there are no ipset members. The cleanup script exits early, leaving the dynamic-block-list iptables chain behind.

**Fix** : Removed the exit 1 so the script continues to delete the chain even when there are no ipset members.

**BEFORE :** 
<img width="1589" height="899" alt="Screenshot from 2026-06-09 14-48-59" src="https://github.com/user-attachments/assets/27ea4d44-783a-4d89-9e34-ac8176478c88" />

**AFTER:**
<img width="1589" height="899" alt="Screenshot from 2026-06-09 14-49-18" src="https://github.com/user-attachments/assets/e67b6dc0-fd77-4e81-a381-098a68ebdfc1" />
