### PR TITLE
ngfw-15786 handled v4ConfigType null check while loading the interfaces

### DIFF
--- a/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
+++ b/uvm/api/com/untangle/uvm/network/InterfaceSettings.java
@@ -618,6 +618,7 @@ public class InterfaceSettings implements Serializable, JSONString
      * @return InterfaceSettingsGeneric.V4ConfigType
      */
     private InterfaceSettingsGeneric.V4ConfigType transformV4ConfigTypeEnum(V4ConfigType v4ConfigType) {
+        if (this.v4ConfigType == null) return InterfaceSettingsGeneric.V4ConfigType.DHCP;
         return  (this.v4ConfigType == V4ConfigType.AUTO) ? InterfaceSettingsGeneric.V4ConfigType.DHCP
                 : InterfaceSettingsGeneric.V4ConfigType.valueOf(this.v4ConfigType.name());
     }
@@ -628,6 +629,7 @@ public class InterfaceSettings implements Serializable, JSONString
      * @return InterfaceSettingsGeneric.V6ConfigType
      */
     private InterfaceSettingsGeneric.V6ConfigType transformV6ConfigTypeEnum(V6ConfigType v6ConfigType) {
+        if (this.v6ConfigType == null) return InterfaceSettingsGeneric.V6ConfigType.DISABLED;
         return  (this.v6ConfigType == V6ConfigType.AUTO) ? InterfaceSettingsGeneric.V6ConfigType.SLAAC
                 : InterfaceSettingsGeneric.V6ConfigType.valueOf(this.v6ConfigType.name());
     }


### PR DESCRIPTION
Description:

In the transformation process, when v4Config field is empty in json, it shows warning pop as shown below.
Fixed it by setting the default value.

Steps to replicate:
setting > support > Reset configuration 
The below pop will be visible on Network > Interface tab
Before :
<img width="670" height="282" alt="image" src="https://github.com/user-attachments/assets/b2683c8a-3ed9-4958-9525-f5e1a7dd2292" />

After fix :
No warning pop will be shown.
<img width="1847" height="1132" alt="image" src="https://github.com/user-attachments/assets/512780fb-db55-4a45-b1bc-1587cb1cdefe" />
