### PR TITLE
ngfw-15812: Fixed captive portal SSL connection test

### DIFF
--- a/captive-portal/hier/usr/lib/python3/dist-packages/tests/test_captive_portal.py
+++ b/captive-portal/hier/usr/lib/python3/dist-packages/tests/test_captive_portal.py
@@ -1,5 +1,6 @@
 """captive_portal tests"""
 import inspect
+import os
 import time
 import socket
 import subprocess
@@ -287,6 +288,33 @@ class CaptivePortalTests(NGFWTestCase):
         else:
             appWeb = uvmContext.appManager().instantiate(cls.appNameWeb(), default_policy_id)
 
+        # Self-heal root CA symlinks if a prior test run left them dangling.
+        # Without valid symlinks SSL Inspector cannot MITM connections and
+        # test_028_captive_ssl_inspector fails with curl exit code 35.
+        cert_dir = "/usr/share/untangle/settings/untangle-certificates/"
+        if os.path.isdir(cert_dir):
+            root_crt = os.path.join(cert_dir, "untangle.crt")
+            root_key = os.path.join(cert_dir, "untangle.key")
+            if os.path.islink(root_crt) and not os.path.exists(root_crt):
+                print("captive-portal setup: dangling root CA symlink detected, repairing...")
+                # Find an existing CA subdirectory that has untangle.crt
+                repaired = False
+                for d in sorted(os.listdir(cert_dir)):
+                    ca_dir = os.path.join(cert_dir, d)
+                    ca_crt = os.path.join(ca_dir, "untangle.crt")
+                    ca_key = os.path.join(ca_dir, "untangle.key")
+                    if os.path.isdir(ca_dir) and os.path.isfile(ca_crt) and os.path.isfile(ca_key):
+                        print(f"captive-portal setup: restoring root CA symlinks to {d}/")
+                        os.remove(root_crt)
+                        os.symlink(ca_crt, root_crt)
+                        if os.path.islink(root_key):
+                            os.remove(root_key)
+                        os.symlink(ca_key, root_key)
+                        repaired = True
+                        break
+                if not repaired:
+                    print("captive-portal setup: no valid CA subdirectory found, skipping repair")
+
         if (uvmContext.appManager().isInstantiated(cls.appNameSSLInspector())):
             if cls.skip_instantiated():
                 pytest.skip('app %s already instantiated' % cls.appNameSSLInspector())
@@ -497,15 +525,18 @@ class CaptivePortalTests(NGFWTestCase):
         assert (search != 0)
 
     def test_028_captive_ssl_inspector(self):
-        global app, appData, appSSL, aapSSL
+        global app, appData, appSSL, appSSLData
         # Add SSL Inspector and check that HTTPS pages not inspected still show captive pages
-        appData['captureRules']['list'].append(create_capture_non_wan_nic_rule(2))
+        appData['captureRules']['list'] = []
+        appData['captureRules']['list'].append(create_capture_non_wan_nic_rule(1))
         appData['authenticationType']="NONE"
         appData['pageType'] = "BASIC_MESSAGE"
         appData['userTimeout'] = 3600  # default
         self._app.setSettings(appData)
 
+        appSSL.stop()
         appSSL.start()
+        time.sleep(5)
         result = remote_control.run_command(global_functions.build_curl_command(output_file="/tmp/capture_test_028.out"))
         appSSL.stop()
         assert (result == 0)

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
@@ -1607,29 +1607,13 @@ class AdministrationTests(NGFWTestCase):
         # INVALID — certSubject missing required '/CN=' anchor
         with pytest.raises(Exception):
             cert_mgr.generateCertificateAuthority("Test CA", "CN=NoSlash")
-        # VALID — both args match their SafeTypes; method writes to disk so
-        # we don't actually invoke it (would create a CA), and the rejection
-        # paths above are sufficient to prove the annotation fires. The
-        # validator runs before any side effects, so any non-rejection
-        # response counts as 'validation passed'.
-        #
-        # We still want one valid-shape probe: call with values that pass
-        # validation but use a unique throwaway CN; then restore by removing
-        # the generated CA directory below.
-        common_name = "atstest-safecheck-ca"
-        cert_subject = "/CN=" + common_name + "/O=ATS/L=Test"
-        cert_dir = "/usr/share/untangle/settings/untangle-certificates/"
-        before_dirs = set(os.listdir(cert_dir)) if os.path.isdir(cert_dir) else set()
-        try:
-            cert_mgr.generateCertificateAuthority(common_name, cert_subject)
-        finally:
-            # Best-effort cleanup of any new CA dir whose name starts with
-            # the throwaway prefix.
-            if os.path.isdir(cert_dir):
-                for d in os.listdir(cert_dir):
-                    if d not in before_dirs and d.startswith(common_name):
-                        import shutil
-                        shutil.rmtree(os.path.join(cert_dir, d), ignore_errors=True)
+        # Positive call skipped: generateCertificateAuthority() overwrites
+        # the active root-CA symlinks (untangle.crt/key) via symlinkRootCerts()
+        # and creates a new CA directory.  Cleaning this up reliably is fragile
+        # — previous attempts left dangling symlinks that broke SSL Inspector
+        # in downstream suites (captive-portal test_028).  The two negative
+        # cases above are sufficient to prove the @SafeCheckParam annotation
+        # fires; the validator runs before any side effects.
 
     def test_083_safecheckparam_generate_server_certificate(self):
         """CertificateManagerImpl.generateServerCertificate(certSubject: CERT_SUBJECT,


### PR DESCRIPTION
**ROOT CAUSE :** 
test_082 in the admin tests was calling generateCertificateAuthority() with a throwaway CA name as a "positive" probe. That method calls symlinkRootCerts() internally, which overwrites the active root-CA symlinks (untangle.crt / untangle.key) to point at the new CA directory. The cleanup code then deleted that new CA directory — but it did not restore the symlinks. This left dangling symlinks in /usr/share/untangle/settings/untangle-certificates/.

When the captive-portal suite ran later, SSL Inspector couldn't MITM connections because its root CA cert/key symlinks pointed to nothing  --> curl got exit code 35 (SSL connect error).

The Two-Part Fix
1. Admin test - removed the dangerous positive call ([test_administration.py](vscode-webview://1nmcf78ff5nhlv087u5es5c73oeked7m7mfsruj11sn8ornajifi/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py))
The test_082 positive case that called generateCertificateAuthority() and then tried to clean up was removed entirely. The two negative cases (pytest.raises(Exception)) are sufficient to prove @SafeCheckParam is wired — the validator runs before any side effects.

2. Captive portal -  added self-healing symlink repair ([test_captive_portal.py](vscode-webview://1nmcf78ff5nhlv087u5es5c73oeked7m7mfsruj11sn8ornajifi/captive-portal/hier/usr/lib/python3/dist-packages/tests/test_captive_portal.py))
A defensive repair was added to setUpClass(): if untangle.crt is a dangling symlink, it scans for an existing CA subdirectory with valid cert/key files and re-creates the symlinks. This makes the captive-portal suite resilient to any future test that might leave the root CA in a broken state.

3. Test_028 itself - minor robustness improvements
Fixed a typo: aapSSL -->  appSSLData
Resets captureRules to a clean list instead of appending to stale state
Calls appSSL.stop() before start() to ensure a clean restart
Added time.sleep(5) after start to let SSL Inspector fully initialize


Passing in all ATS servers:

<img width="776" height="1089" alt="Screenshot from 2026-06-15 18-25-44" src="https://github.com/user-attachments/assets/868aac87-889b-497f-9765-055c7ce2280e" />
<img width="776" height="1089" alt="Screenshot from 2026-06-15 18-25-40" src="https://github.com/user-attachments/assets/b3d0c374-3132-44fb-a384-c8b8d763c09e" />
<img width="776" height="1089" alt="Screenshot from 2026-06-15 18-25-35" src="https://github.com/user-attachments/assets/5554c1c8-8dce-495a-85fd-98fd02c2c4ef" />
