### PR TITLE
ngfw-15808 rename pass sites and block sites lists variables in v2 model

### DIFF
--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterSettings.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterSettings.java
@@ -208,9 +208,9 @@ public class WebFilterSettings implements Serializable, JSONString
         g.setCloseHttpsBlockEnabled(this.closeHttpsBlockEnabled);
 
         // GenericRule lists - shared type, copy to avoid aliasing; always set (empty list when null)
-        g.setPassedClients(this.passedClients != null ? new LinkedList<>(this.passedClients) : new LinkedList<>());
-        g.setPassedUrls(this.passedUrls != null       ? new LinkedList<>(this.passedUrls)    : new LinkedList<>());
-        g.setBlockedUrls(this.blockedUrls != null     ? new LinkedList<>(this.blockedUrls)   : new LinkedList<>());
+        g.setPassClients(this.passedClients != null ? new LinkedList<>(this.passedClients) : new LinkedList<>());
+        g.setPassList(this.passedUrls != null       ? new LinkedList<>(this.passedUrls)    : new LinkedList<>());
+        g.setBlockList(this.blockedUrls != null     ? new LinkedList<>(this.blockedUrls)   : new LinkedList<>());
         g.setCategories(this.categories != null       ? new LinkedList<>(this.categories)    : new LinkedList<>());
         g.setSearchTerms(this.searchTerms != null     ? new LinkedList<>(this.searchTerms)   : new LinkedList<>());
 

--- a/web-filter-base/src/com/untangle/app/web_filter/generic/WebFilterSettingsGeneric.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/generic/WebFilterSettingsGeneric.java
@@ -47,9 +47,9 @@ public class WebFilterSettingsGeneric implements Serializable, JSONString
     private Boolean closeHttpsBlockEnabled = false;
 
     private LinkedList<RuleGeneric> filterRules = new LinkedList<>();
-    private LinkedList<GenericRule> passedClients = new LinkedList<>();
-    private LinkedList<GenericRule> passedUrls = new LinkedList<>();
-    private LinkedList<GenericRule> blockedUrls = new LinkedList<>();
+    private LinkedList<GenericRule> passClients = new LinkedList<>();
+    private LinkedList<GenericRule> passList = new LinkedList<>();
+    private LinkedList<GenericRule> blockList = new LinkedList<>();
     private LinkedList<GenericRule> categories = new LinkedList<>();
     private LinkedList<GenericRule> searchTerms = new LinkedList<>();
 
@@ -119,14 +119,14 @@ public class WebFilterSettingsGeneric implements Serializable, JSONString
     public LinkedList<RuleGeneric> getFilterRules() { return filterRules; }
     public void setFilterRules(LinkedList<RuleGeneric> filterRules) { this.filterRules = filterRules; }
 
-    public LinkedList<GenericRule> getPassedClients() { return passedClients; }
-    public void setPassedClients(LinkedList<GenericRule> passedClients) { this.passedClients = passedClients; }
+    public LinkedList<GenericRule> getPassClients() { return passClients; }
+    public void setPassClients(LinkedList<GenericRule> passClients) { this.passClients = passClients; }
 
-    public LinkedList<GenericRule> getPassedUrls() { return passedUrls; }
-    public void setPassedUrls(LinkedList<GenericRule> passedUrls) { this.passedUrls = passedUrls; }
+    public LinkedList<GenericRule> getPassList() { return passList; }
+    public void setPassList(LinkedList<GenericRule> passList) { this.passList = passList; }
 
-    public LinkedList<GenericRule> getBlockedUrls() { return blockedUrls; }
-    public void setBlockedUrls(LinkedList<GenericRule> blockedUrls) { this.blockedUrls = blockedUrls; }
+    public LinkedList<GenericRule> getBlockList() { return blockList; }
+    public void setBlockList(LinkedList<GenericRule> blockList) { this.blockList = blockList; }
 
     public LinkedList<GenericRule> getCategories() { return categories; }
     public void setCategories(LinkedList<GenericRule> categories) { this.categories = categories; }
@@ -175,9 +175,9 @@ public class WebFilterSettingsGeneric implements Serializable, JSONString
         v1.setCloseHttpsBlockEnabled(this.closeHttpsBlockEnabled);
 
         // GenericRule lists - shared type, assign directly; always set (empty list when null)
-        v1.setPassedClients(this.passedClients != null ? new LinkedList<>(this.passedClients) : new LinkedList<>());
-        v1.setPassedUrls(this.passedUrls != null       ? new LinkedList<>(this.passedUrls)    : new LinkedList<>());
-        v1.setBlockedUrls(this.blockedUrls != null     ? new LinkedList<>(this.blockedUrls)   : new LinkedList<>());
+        v1.setPassedClients(this.passClients != null ? new LinkedList<>(this.passClients) : new LinkedList<>());
+        v1.setPassedUrls(this.passList != null       ? new LinkedList<>(this.passList)    : new LinkedList<>());
+        v1.setBlockedUrls(this.blockList != null     ? new LinkedList<>(this.blockList)   : new LinkedList<>());
         v1.setCategories(this.categories != null       ? new LinkedList<>(this.categories)    : new LinkedList<>());
         v1.setSearchTerms(this.searchTerms != null     ? new LinkedList<>(this.searchTerms)   : new LinkedList<>());
 


### PR DESCRIPTION
## Summary

Renames three list fields in the Web Filter V2 settings model to align with the naming convention used in vuntangle (`passClients`, `passList`, `blockList`).

## Changes

**Web Filter — V2 settings model (`WebFilterSettingsGeneric.java`)**
- Renamed field `passedClients` → `passClients` with updated getter/setter (`getPassClients` / `setPassClients`)
- Renamed field `passedUrls` → `passList` with updated getter/setter (`getPassList` / `setPassList`)
- Renamed field `blockedUrls` → `blockList` with updated getter/setter (`getBlockList` / `setBlockList`)
- Updated `transformGenericToWebFilterSettings()` to reference the new field names

**V1 → V2 transformation (`WebFilterSettings.java`)**
- Updated `transformWebFilterSettingsToGeneric()` to call `setPassClients`, `setPassList`, and `setBlockList` on the generic settings object
