### PR TITLE
NGFW-15831 Fixed captive portal pre-auth reflected XSS and hide debug tracebacks

### DIFF
--- a/captive-portal/hier/usr/share/untangle/conf/apache2/conf.d/capture.conf
+++ b/captive-portal/hier/usr/share/untangle/conf/apache2/conf.d/capture.conf
@@ -6,7 +6,7 @@ Alias /capture @PREFIX@/usr/share/untangle/web/capture
     Require all granted
     AddHandler mod_python .py
     PythonHandler mod_python.publisher
-    PythonDebug On
+    PythonDebug Off
 </Location>
 
 <Location /capture/logout>
@@ -16,5 +16,5 @@ Alias /capture @PREFIX@/usr/share/untangle/web/capture
     Require all granted
     AddHandler mod_python .py
     PythonHandler mod_python.publisher
-    PythonDebug On
+    PythonDebug Off
 </Location>

--- a/captive-portal/hier/usr/share/untangle/web/capture/handler.py
+++ b/captive-portal/hier/usr/share/untangle/web/capture/handler.py
@@ -1,6 +1,7 @@
 from mod_python import apache
 from mod_python import util
 from mod_python import Cookie
+import html
 import sys
 
 if "@PREFIX@" != '':
@@ -491,15 +492,17 @@ def _generate_page(req,captureSettings,args,extra='',page=None,template_name=Non
         page = _replace_marker(page,'$.AuthRelayUri.$', uvmContext.uriManager().getUri("https://auth-relay.edge.arista.com/callback.php"))
 
     # plug the values into the hidden form fields of the authentication page
-    # page by doing  search and replace for each of the placeholder text tags
-    page = _replace_marker(page,'$.method.$', args['METHOD'])
-    page = _replace_marker(page,'$.nonce.$', args['NONCE'])
-    page = _replace_marker(page,'$.appid.$', args['APPID'])
-    page = _replace_marker(page,'$.host.$', args['HOST'])
-    page = _replace_marker(page,'$.uri.$', args['URI'])
+    # page by doing  search and replace for each of the placeholder text tags.
+    # These values originate from end-user form/query input and are HTML-escaped
+    # to prevent reflected XSS into attribute contexts (UNT-02).
+    page = _replace_marker(page,'$.method.$', _html_escape(args['METHOD']))
+    page = _replace_marker(page,'$.nonce.$', _html_escape(args['NONCE']))
+    page = _replace_marker(page,'$.appid.$', _html_escape(args['APPID']))
+    page = _replace_marker(page,'$.host.$', _html_escape(args['HOST']))
+    page = _replace_marker(page,'$.uri.$', _html_escape(args['URI']))
 
     # replace the text in the problem section with the agumented value
-    page = _replace_marker(page,'$.ProblemText.$',extra)
+    page = _replace_marker(page,'$.ProblemText.$', _html_escape(extra))
 
     # debug = create_debug(args,captureSettings)
     debug = ""
@@ -633,6 +636,19 @@ def _replace_marker(page,marker,output):
     page = page.replace(marker,output)
 
     return(page)
+
+#-----------------------------------------------------------------------------
+# HTML-escapes a value for safe substitution into HTML attribute / text contexts.
+# Tolerates bytes input - the i18n _() helper uses lgettext() which returns
+# bytes on Python < 3.11, matching the existing _replace_marker contract.
+
+def _html_escape(value):
+
+    if value is None:
+        return ''
+    if type(value) == bytes:
+        value = value.decode("utf-8")
+    return html.escape(value, quote=True)
 
 #-----------------------------------------------------------------------------
 # handler for custom.py integration which dynamically loads the custom.py


### PR DESCRIPTION
**Summary**

Closes two security findings on the captive portal:
- Pre-auth reflected XSS on the captive portal login page. End-user form fields (host, uri, method, nonce, appid) and the error message were rendered back into the page without HTML escaping. An attacker could plant JavaScript that runs in the firewall's own origin on any LAN client or admin who reaches the captive page.

- Debug traceback exposure. The captive-portal Apache configuration had PythonDebug On, so any uncaught error rendered a full Python traceback (file paths, line numbers, code excerpts) into the HTTP response.

**What changed**
- captive-portal/.../handler.py — End-user form values and the error message string are HTML-escaped before they are substituted into the captive page. Admin-set strings (company name, page title, welcome / message / footer text, agree text, etc.) are intentionally left untouched — those are trusted authorial content and may legitimately contain characters like &.
- captive-portal/.../apache2/conf.d/capture.conf — PythonDebug On → PythonDebug Off on both /capture and /capture/logout blocks. Tracebacks continue to be written to /var/log/apache2/error.log for support.

**Why this is safe to ship**
- Browsers HTML-decode attribute values before resubmitting forms, so legitimate hostnames/URIs/methods round-trip end-to-end without change.
- Admin-controlled branding is untouched; a company name like Acme & Co still displays as Acme & Co.
- All standard browsers and captive-portal mini-browsers (iOS/Android/Windows CNA) handle the HTML entities used (&amp; &lt; &gt; &quot; &#x27;) — these have been universal since HTML 2.0.
- Pre/post-fix behavior is identical for every realistic input that isn't an attack payload.