### PR TITLE
NGFW-15832: fix block page XSS via JS-string context injection

### DIFF
--- a/http-casing/src/com/untangle/app/http/BlockPageUtil.java
+++ b/http-casing/src/com/untangle/app/http/BlockPageUtil.java
@@ -68,6 +68,14 @@ public class BlockPageUtil
         RedirectDetails bd = params.getBlockDetails();
         request.setAttribute( "bd", bd );
 
+        String nonce = request.getParameter("nonce");
+        String appid = request.getParameter("appid");
+        String tid = request.getParameter("tid");
+        request.setAttribute("safeNonceJs", escapeJsString(nonce));
+        request.setAttribute("safeAppidJs", escapeJsString(appid));
+        request.setAttribute("safeTidJs", escapeJsString(tid));
+        request.setAttribute("safeBdUrlJs", escapeJsString(bd != null ? bd.getUrl() : ""));
+
         String contactHtml = I18nUtil.marktr("your network administrator");
         if (bm.getContactEmail() != null) {
             String emailSubject = "";
@@ -175,5 +183,25 @@ public class BlockPageUtil
     public static BlockPageUtil getInstance()
     {
         return INSTANCE;
+    }
+
+    private static String escapeJsString(String s)
+    {
+        if (s == null) return "";
+        StringBuilder sb = new StringBuilder(s.length() + 16);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '\'': sb.append("\\'"); break;
+                case '"':  sb.append("\\\""); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\0': sb.append("\\0"); break;
+                case '<':  sb.append("\\x3c"); break;
+                default:   sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/uvm/servlets/blockpage/root/blockpage_template.jspx
+++ b/uvm/servlets/blockpage/root/blockpage_template.jspx
@@ -36,10 +36,10 @@
 
     <uvm:inlineScript>
       <![CDATA[
-          var nonce = '${param.nonce}';
-          var appid = '${param.appid}';
-          var tid = '${param.tid}';
-          var url = '${bd.url}';
+          var nonce = '${safeNonceJs}';
+          var appid = '${safeAppidJs}';
+          var tid = '${safeTidJs}';
+          var url = '${safeBdUrlJs}';
       ]]>
     </uvm:inlineScript>
 


### PR DESCRIPTION
BlockPageUtil.handle() now JS-escapes nonce, appid, tid, and bd.url before passing them to blockpage_template.jspx. The template references the pre-escaped request attributes instead of raw ${param.*} and ${bd.url}, preventing single-quote breakout in the <script> block.


<p data-start="58" data-end="79" class="PDq2pG_selectionAnchorContainer"><strong data-start="58" data-end="79">Impact Assessment</strong><span aria-hidden="true" class="PDq2pG_selectionAnchor"></span></p>
<p data-start="84" data-end="183">Only the following 3 apps use this template. No other apps (including Captive Portal) are affected:</p>
<ul data-start="188" data-end="242">
<li data-section-id="1n8atbs" data-start="188" data-end="200">
Web Filter
</li>
<li data-section-id="1krgryo" data-start="203" data-end="222">
Threat Prevention
</li>
<li data-section-id="1fpvh99" data-start="225" data-end="240">
Virus Blocker
</li>
</ul>
### Validation Performed
<p data-start="274" data-end="335">Dev testing has been completed with XSS payload verification:</p>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">

**Web Filter**
- Test: `http://smokeshop.co.in/';alert(1);//`
- Result: ✅ PASS — Block page rendered correctly, no alert executed, source shows escaped `\'`

**Threat Prevention**
- Test: `http://185.220.101.1/';alert(1);//`
- Result: ✅ PASS — Block page rendered correctly, no alert executed

**Virus Blocker**
- Test: `http://192.168.1.16:80/eicar.com?foo=';alert(1);//`
- Result: ✅ PASS — Redirect to `/virus/blockpage` confirmed, no alert executed


</div></div>
<p data-start="824" data-end="838"><strong data-start="824" data-end="838">Conclusion</strong></p>
<p data-start="843" data-end="1002" data-is-last-node="">The fix has been validated across all affected applications. User-controlled input is properly escaped and no JavaScript execution was observed during testing.</p>