### PR TITLE
ngfw-15835 mythhos UNT-08-10-39 Fix

### DIFF
--- a/uvm/servlets/admin/app/view/extra/Sessions.js
+++ b/uvm/servlets/admin/app/view/extra/Sessions.js
@@ -338,12 +338,14 @@ Ext.define('Ung.view.extra.Sessions', {
             header: 'Hostname'.t(),
             dataIndex: 'hostname',
             width: Renderer.hostnameWidth,
-            filter: Renderer.stringFilter
+            filter: Renderer.stringFilter,
+            renderer: Ext.util.Format.htmlEncode
         }, {
             header: 'Username'.t(),
             dataIndex: 'username',
             width: Renderer.usernameWidth,
-            filter: Renderer.stringFilter
+            filter: Renderer.stringFilter,
+            renderer: Ext.util.Format.htmlEncode
         }, {
             header: 'NATd'.t(),
             dataIndex: 'natted',
@@ -516,19 +518,22 @@ Ext.define('Ung.view.extra.Sessions', {
                 header: 'Protocol'.t(),
                 dataIndex: "application-control-lite-protocol",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Category'.t(),
                 dataIndex: "application-control-lite-category",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Description'.t(),
                 dataIndex: "application-control-lite-description",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Matched?'.t(),
@@ -542,24 +547,28 @@ Ext.define('Ung.view.extra.Sessions', {
                 header: 'Protochain'.t(),
                 dataIndex: "application-control-protochain",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 header: 'Application'.t(),
                 dataIndex: "application-control-application",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Category'.t(),
                 dataIndex: "application-control-category",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Detail'.t(),
                 dataIndex: "application-control-detail",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Confidence'.t(),
@@ -571,13 +580,15 @@ Ext.define('Ung.view.extra.Sessions', {
                 header: 'Productivity'.t(),
                 dataIndex: "application-control-productivity",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Risk'.t(),
                 dataIndex: "application-control-risk",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             }]
         }, {
             header: 'Web Filter',
@@ -587,13 +598,15 @@ Ext.define('Ung.view.extra.Sessions', {
                 header: 'Category Name'.t(),
                 dataIndex: "web-filter-best-category-name",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Category Description'.t(),
                 dataIndex: "web-filter-best-category-description",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Category Flagged'.t(),
@@ -621,25 +634,29 @@ Ext.define('Ung.view.extra.Sessions', {
                 header: 'Hostname'.t(),
                 dataIndex: "http-hostname",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'URL'.t(),
                 dataIndex: "http-url",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'User Agent'.t(),
                 dataIndex: "http-user-agent",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'URI'.t(),
                 dataIndex: "http-uri",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Request Method'.t(),
@@ -651,43 +668,50 @@ Ext.define('Ung.view.extra.Sessions', {
                 header: 'Request File Name'.t(),
                 dataIndex: "http-request-file-name",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Request File Extension'.t(),
                 dataIndex: "http-request-file-extension",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Request File Path'.t(),
                 dataIndex: "http-request-file-path",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Response File Name'.t(),
                 dataIndex: "http-response-file-name",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Response File Extension'.t(),
                 dataIndex: "http-response-file-extension",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Content Type'.t(),
                 dataIndex: "http-content-type",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Referrer'.t(),
                 dataIndex: "http-referer",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Content Length'.t(),
@@ -703,13 +727,15 @@ Ext.define('Ung.view.extra.Sessions', {
                 header: 'Subject DN'.t(),
                 dataIndex: "ssl-subject-dn",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Issuer DN'.t(),
                 dataIndex: "ssl-issuer-dn",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Inspected'.t(),
@@ -721,7 +747,8 @@ Ext.define('Ung.view.extra.Sessions', {
                 header: 'SNI Hostname'.t(),
                 dataIndex: "ssl-sni-host",
                 width: Renderer.hostnameWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             }]
         }, {
             header: 'FTP',
@@ -731,7 +758,8 @@ Ext.define('Ung.view.extra.Sessions', {
                 header: 'Filename'.t(),
                 dataIndex: "ftp-file-name",
                 width: Renderer.messageWidth,
-                filter: Renderer.stringFilter
+                filter: Renderer.stringFilter,
+                renderer: Ext.util.Format.htmlEncode
             },{
                 hidden: true,
                 header: 'Data Session'.t(),

--- a/uvm/servlets/admin/app/view/extra/Users.js
+++ b/uvm/servlets/admin/app/view/extra/Users.js
@@ -97,7 +97,8 @@ Ext.define('Ung.view.extra.Users', {
             header: 'Username'.t(),
             dataIndex: 'username',
             width: Renderer.usernameWidth,
-            filter: Renderer.stringFilter
+            filter: Renderer.stringFilter,
+            renderer: Ext.util.Format.htmlEncode
         }, {
             header: 'Creation Time'.t(),
             dataIndex: 'creationTime',

--- a/uvm/servlets/admin/config/email/MainController.js
+++ b/uvm/servlets/admin/config/email/MainController.js
@@ -248,7 +248,7 @@ Ext.define('Ung.config.email.MainController', {
         var me = this;
         me.dialog = me.getView().add({
             xtype: 'window',
-            title: 'Email Quarantine Details for:'.t() + ' ' + record.get('address'),
+            title: 'Email Quarantine Details for:'.t() + ' ' + Ext.String.htmlEncode(record.get('address')),
             width: Ext.getBody().getViewSize().width - 20,
             maxHeight: Ext.getBody().getViewSize().height - 20,
             modal: true,
@@ -290,13 +290,15 @@ Ext.define('Ung.config.email.MainController', {
                     header: 'Sender'.t(),
                     width: Renderer.emailWidth,
                     dataIndex: 'sender',
-                    filter: { type: 'string' }
+                    filter: { type: 'string' },
+                    renderer: Ext.util.Format.htmlEncode
                 }, {
                     header: 'Subject'.t(),
                     width: Renderer.messageWidth,
                     flex: 1,
                     dataIndex: 'subject',
-                    filter: { type: 'string' }
+                    filter: { type: 'string' },
+                    renderer: Ext.util.Format.htmlEncode
                 }, {
                     header: 'Size (KB)'.t(),
                     width: Renderer.sizeWidth,
@@ -307,7 +309,8 @@ Ext.define('Ung.config.email.MainController', {
                     header: 'Category'.t(),
                     width: Renderer.idWidth,
                     dataIndex: 'quarantineCategory',
-                    filter: { type: 'string' }
+                    filter: { type: 'string' },
+                    renderer: Ext.util.Format.htmlEncode
                 }, {
                     header: 'Detail'.t(),
                     width: Renderer.sizeWidth,
@@ -321,7 +324,7 @@ Ext.define('Ung.config.email.MainController', {
                         } else {
                             return parseFloat(detail).toFixed(3);
                         }
-                        return detail;
+                        return Ext.String.htmlEncode(detail);
                     },
                     filter: { type: 'numeric' }
                 }],


### PR DESCRIPTION
## Summary

Fix three stored XSS vulnerabilities (UNT-08, UNT-10, UNT-39) in NGFW admin UI grids. User-controlled strings (hostnames, HTTP headers, email subjects/senders, usernames) were rendered via ExtJS `innerHTML` without encoding, allowing script execution when an attacker injects HTML/JS payloads into network traffic or email metadata.

## Motivation

ExtJS 6.2 grid cells render content via `innerHTML`. Any user-controlled string field displayed in a grid without HTML encoding is a stored XSS vector. Three admin UI grids were affected:

- **UNT-08 — Sessions monitor:** 28 traffic-derived string columns (hostname, http-user-agent, http-hostname, ssl-sni-host, etc.)
- **UNT-39 — Users monitor:** username column
- **UNT-10 — Email quarantine dialog:** sender, subject, quarantineCategory, quarantineDetail columns, and the window title

## Changes

### Sessions monitor (`Sessions.js`)
- Add `renderer: Ext.util.Format.htmlEncode` to 28 column definitions covering all traffic-derived string fields: hostname, username, application-control-*, web-filter-*, http-*, ssl-*, ftp-file-name
- Uses `renderer:` (display-time encoding) instead of `convert:` (store-time encoding) to avoid double-encoding in the RecordDetails property grid panel — ExtJS's `Ext.grid.property.HeaderContainer.renderCell` applies `htmlEncode` by default when no custom renderer is in the sourceConfig

### Users monitor (`Users.js`)
- Add `renderer: Ext.util.Format.htmlEncode` to the username column definition
- Must use `renderer:` (not `convert:`) because Users.js has save/RPC operations (`saveUsers`, `refillQuota`, `removeQuota`) that read `record.get('username')` — `convert:` would send encoded values to the server, breaking user lookups and corrupting stored data

### Email quarantine dialog (`MainController.js`)
- Add `renderer: Ext.util.Format.htmlEncode` to sender, subject, and quarantineCategory columns
- Encode the fallback path in the quarantineDetail custom renderer via `Ext.String.htmlEncode(detail)`
- Encode the window title via `Ext.String.htmlEncode(record.get('address'))`

## Testing

### UNT-08 — Sessions monitor
1. From a client behind the NGFW, send HTTP traffic with an XSS payload in the User-Agent header:
   `curl -A "<svg/onload=document.title='SESSIONS-XSS'>" http://speedtest.tele2.net/1MB.zip --limit-rate 10k -o /dev/null &`
2. Open admin UI → Sessions monitor, enable the HTTP User Agent column
3. Verify `document.title` is unchanged (no XSS execution)
4. Verify the payload renders as visible text in the grid column
5. Click the session row — verify the Session Details panel shows the payload as plain text with no `&lt;` entity artifacts
6. Sort by User Agent column — verify correct lexicographic order
7. Filter for `<svg` — verify the filter matches

### UNT-10 — Email quarantine
1. From the client, send a GTUBE spam email with an XSS subject through the NGFW to a mail server:
   `swaks --to root@test.com --from attacker@evil.com --server <MAIL_SERVER> --header "Subject: <svg/onload=document.title='QUARANTINE-XSS'>" --body "XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X"`
2. Send a second email with XSS in the From display name:
   `swaks --to root@test.com --from xss-test@evil.com --server <MAIL_SERVER> --header "From: <svg/onload=alert(1)> <xss-test@evil.com>" --header "Subject: Test sender XSS" --body "<GTUBE string>"`
3. Open Config → Email → Quarantine → click the inbox
4. Verify Subject and Sender columns show payloads as text, window title is safely encoded, `document.title` unchanged

### UNT-39 — Users monitor
1. Inject a user with XSS username via `userTable.setUsers()` JSON-RPC (or Captive Portal registration if installed)
2. Open Sessions → Users monitor
3. Verify username column shows payload as text, `document.title` unchanged
4. Sort by username — verify correct order
5. Select a normal user → Refill Quota / Drop Quota — verify operations succeed (confirms `record.get('username')` returns raw value, not encoded)

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
