### PR TITLE
NGFW-15836: fix stored XSS in grids and notifications widget

### DIFF
--- a/captive-portal/js/view/Status.js
+++ b/captive-portal/js/view/Status.js
@@ -68,7 +68,7 @@ Ext.define('Ung.apps.captive-portal.view.Status', {
                     dataIndex: 'userName',
                     width: Renderer.usernameWidth,
                     flex: 1,
-                    renderer: Ext.util.Format.htmlEncode,
+                    renderer: function(value) { return value ? Ext.String.htmlEncode(value) : ''; },
                     filter: Renderer.stringFilter
                 }, {
                     header: 'Login Time'.t(),

--- a/captive-portal/js/view/Status.js
+++ b/captive-portal/js/view/Status.js
@@ -68,6 +68,7 @@ Ext.define('Ung.apps.captive-portal.view.Status', {
                     dataIndex: 'userName',
                     width: Renderer.usernameWidth,
                     flex: 1,
+                    renderer: Ext.util.Format.htmlEncode,
                     filter: Renderer.stringFilter
                 }, {
                     header: 'Login Time'.t(),

--- a/ipsec-vpn/js/view/Status.js
+++ b/ipsec-vpn/js/view/Status.js
@@ -174,6 +174,7 @@ Ext.define('Ung.apps.ipsecvpn.view.Status', {
                     sortable: true,
                     width: Renderer.usernameWidth,
                     flex: 1,
+                    renderer: Ext.util.Format.htmlEncode,
                     filter: Renderer.stringFilter
                 }, {
                     header: 'Interface'.t(),

--- a/smtp-casing/servlets/quarantine/root/script/inbox.js
+++ b/smtp-casing/servlets/quarantine/root/script/inbox.js
@@ -438,6 +438,7 @@ Ext.define('Ung.view.Messages', {
         width: Renderer.emailWidth,
         flex: 1,
         sortable: true,
+        renderer: Ext.util.Format.htmlEncode,
         filter: { type: 'string' }
     }, {
         header: 'Attachments'.t(),
@@ -464,6 +465,7 @@ Ext.define('Ung.view.Messages', {
         flex: 1,
         width: Renderer.messageWidth,
         sortable: true,
+        renderer: Ext.util.Format.htmlEncode,
         filter: { type : 'string' }
     }, {
         header: 'Date'.t(),

--- a/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
@@ -380,12 +380,12 @@ public class NotificationManagerImpl implements NotificationManager
         ExecManagerResult result;
         result = this.execManager.exec(System.getProperty(UVM_BIN_DIR) + "/ut-notification-helpers.sh testDiskError1");
         if (result.getResult() == 0) {
-            notificationList.add(i18nUtil.tr("Disk errors reported.") + "<br/>\n" + result.getOutput().replaceAll("\n", "<br/>\n"));
+            notificationList.add(i18nUtil.tr("Disk errors reported.") + " | " + result.getOutput().replaceAll("\n", " | "));
         }
 
         result = this.execManager.exec(System.getProperty(UVM_BIN_DIR) + "/ut-notification-helpers.sh testDiskError2");
         if (result.getResult() == 0) {
-            notificationList.add(i18nUtil.tr("Disk errors reported.") + "<br/>\n" + result.getOutput().replaceAll("\n", "<br/>\n"));
+            notificationList.add(i18nUtil.tr("Disk errors reported.") + " | " + result.getOutput().replaceAll("\n", " | "));
         }
     }
 
@@ -837,7 +837,7 @@ public class NotificationManagerImpl implements NotificationManager
         boolean fullFlag = reports.getDiskFullFlag();
         if (fullFlag) {
             String notificationText = StringUtils.EMPTY;
-            notificationText += i18nUtil.tr("Reports event processing disabled due to low disk space. <a href='/admin/index.do#service/reports/data'>Manage reports data here</a>");
+            notificationText += i18nUtil.tr("Reports event processing disabled due to low disk space. Manage reports data at /admin/index.do#service/reports/data");
             notificationList.add(notificationText);
         }
     }
@@ -979,7 +979,7 @@ public class NotificationManagerImpl implements NotificationManager
     private void testUserPasswords(List<String> notificationList)
     {
         if (UvmContextFactory.context().adminManager().getWeakPasswordHashes()) {
-            String notificationText = i18nUtil.tr("Some admin user accounts are using weak password hashes.  <a href='/admin/index.do#config/administration/admin'> Update them here </a>");
+            String notificationText = i18nUtil.tr("Some admin user accounts are using weak password hashes. Update them at /admin/index.do#config/administration/admin");
             notificationList.add(notificationText);
         }
     }

--- a/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NotificationManagerImpl.java
@@ -380,12 +380,12 @@ public class NotificationManagerImpl implements NotificationManager
         ExecManagerResult result;
         result = this.execManager.exec(System.getProperty(UVM_BIN_DIR) + "/ut-notification-helpers.sh testDiskError1");
         if (result.getResult() == 0) {
-            notificationList.add(i18nUtil.tr("Disk errors reported.") + " | " + result.getOutput().replaceAll("\n", " | "));
+            notificationList.add(i18nUtil.tr("Disk errors reported.") + "<br/>\n" + result.getOutput().replaceAll("\n", "<br/>\n"));
         }
 
         result = this.execManager.exec(System.getProperty(UVM_BIN_DIR) + "/ut-notification-helpers.sh testDiskError2");
         if (result.getResult() == 0) {
-            notificationList.add(i18nUtil.tr("Disk errors reported.") + " | " + result.getOutput().replaceAll("\n", " | "));
+            notificationList.add(i18nUtil.tr("Disk errors reported.") + "<br/>\n" + result.getOutput().replaceAll("\n", "<br/>\n"));
         }
     }
 
@@ -837,7 +837,7 @@ public class NotificationManagerImpl implements NotificationManager
         boolean fullFlag = reports.getDiskFullFlag();
         if (fullFlag) {
             String notificationText = StringUtils.EMPTY;
-            notificationText += i18nUtil.tr("Reports event processing disabled due to low disk space. Manage reports data at /admin/index.do#service/reports/data");
+            notificationText += i18nUtil.tr("Reports event processing disabled due to low disk space. <a href='/admin/index.do#service/reports/data'>Manage reports data here</a>");
             notificationList.add(notificationText);
         }
     }
@@ -979,7 +979,7 @@ public class NotificationManagerImpl implements NotificationManager
     private void testUserPasswords(List<String> notificationList)
     {
         if (UvmContextFactory.context().adminManager().getWeakPasswordHashes()) {
-            String notificationText = i18nUtil.tr("Some admin user accounts are using weak password hashes. Update them at /admin/index.do#config/administration/admin");
+            String notificationText = i18nUtil.tr("Some admin user accounts are using weak password hashes.  <a href='/admin/index.do#config/administration/admin'> Update them here </a>");
             notificationList.add(notificationText);
         }
     }

--- a/uvm/servlets/admin/app/view/main/MainController.js
+++ b/uvm/servlets/admin/app/view/main/MainController.js
@@ -59,7 +59,10 @@ Ext.define('Ung.view.main.MainController', {
                 btn.show();
                 notificationArr += '<h3>' + 'Notifications:'.t() + '</h3><ul>';
                 for (i = 0; i < result.list.length; i += 1) {
-                    notificationArr += '<li>' + Ext.String.htmlEncode(result.list[i]) + '</li>';
+                    var safe = Ext.String.htmlEncode(result.list[i]);
+                    safe = safe.replace(/&lt;br\/&gt;/g, '<br/>');
+                    safe = safe.replace(/&lt;a href=&#39;(\/admin\/[^&]*)&#39;&gt;(.*?)&lt;\/a&gt;/g, '<a href="$1">$2</a>');
+                    notificationArr += '<li>' + safe + '</li>';
                 }
                 notificationArr += '</ul>';
                 btn.setText(result.list.length);

--- a/uvm/servlets/admin/app/view/main/MainController.js
+++ b/uvm/servlets/admin/app/view/main/MainController.js
@@ -59,7 +59,7 @@ Ext.define('Ung.view.main.MainController', {
                 btn.show();
                 notificationArr += '<h3>' + 'Notifications:'.t() + '</h3><ul>';
                 for (i = 0; i < result.list.length; i += 1) {
-                    notificationArr += '<li>' + result.list[i] + '</li>';
+                    notificationArr += '<li>' + Ext.String.htmlEncode(result.list[i]) + '</li>';
                 }
                 notificationArr += '</ul>';
                 btn.setText(result.list.length);

--- a/uvm/servlets/admin/app/widget/Notifications.js
+++ b/uvm/servlets/admin/app/widget/Notifications.js
@@ -51,7 +51,7 @@ Ext.define('Ung.widget.Notifications', {
                 var notificationArr = '<ul style="margin: 0; padding: 0 10px 30px 30px;">', i;
                 if (result != null && result.list.length > 0) {
                     for (i = 0; i < result.list.length; i += 1) {
-                        notificationArr += '<li>' + result.list[i] + '</li>';
+                        notificationArr += '<li>' + Ext.String.htmlEncode(result.list[i]) + '</li>';
                     }
                     notificationArr += '</ul>';
                     notifCmp.setHtml(notificationArr);

--- a/uvm/servlets/admin/app/widget/Notifications.js
+++ b/uvm/servlets/admin/app/widget/Notifications.js
@@ -51,7 +51,10 @@ Ext.define('Ung.widget.Notifications', {
                 var notificationArr = '<ul style="margin: 0; padding: 0 10px 30px 30px;">', i;
                 if (result != null && result.list.length > 0) {
                     for (i = 0; i < result.list.length; i += 1) {
-                        notificationArr += '<li>' + Ext.String.htmlEncode(result.list[i]) + '</li>';
+                        var safe = Ext.String.htmlEncode(result.list[i]);
+                        safe = safe.replace(/&lt;br\/&gt;/g, '<br/>');
+                        safe = safe.replace(/&lt;a href=&#39;(\/admin\/[^&]*)&#39;&gt;(.*?)&lt;\/a&gt;/g, '<a href="$1">$2</a>');
+                        notificationArr += '<li>' + safe + '</li>';
                     }
                     notificationArr += '</ul>';
                     notifCmp.setHtml(notificationArr);


### PR DESCRIPTION
Add renderer: Ext.util.Format.htmlEncode to quarantine inbox sender/subject columns (UNT-37), captive-portal userName (UNT-38), and ipsec-vpn clientUsername (UNT-38). Wrap notification list items with Ext.String.htmlEncode in both the dashboard widget and toolbar menu (UNT-40). Remove intentional HTML from three server-side notification messages so htmlEncode does not break their display.