### PR TITLE
NGFW-15841 Fixed ssl-inspector sni ssrf scenario

### DIFF
--- a/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
+++ b/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
@@ -1,10 +1,13 @@
 """ssl_inspector tests"""
+import base64
 import datetime
 import os
 import pytest
 import runtests
+import shlex
 import subprocess
 import sys
+import time
 import unittest
 
 from tests.common import NGFWTestCase
@@ -86,6 +89,83 @@ def search_term_rules_clear():
     webSettings = appWeb.getSettings()
     webSettings["searchTerms"]["list"] = []
     appWeb.setSettings(webSettings)
+
+
+# ---------------------------------------------------------------------------
+# SNI SSRF (NGFW-15841) — raw TLS ClientHello sender used by the SNI-SSRF tests.
+#
+# Python's ssl module IDNA-encodes server_hostname before sending, which
+# either errors out or silently strips the SNI extension for payloads that
+# contain ':', '/', CR/LF, leading '-', or exceed the 255-byte cap.  None of
+# those reach the firewall via ssl.wrap_socket, so they can't drive the patched
+# code path.  This minimal builder constructs a TLS 1.2 ClientHello byte-for-
+# byte and writes any SNI bytes the test wants, bypassing client-side cleaning.
+# The SNI argument is passed base64-encoded so any byte value survives shell
+# escaping.
+# ---------------------------------------------------------------------------
+_RAW_SNI_CLIENT_SCRIPT = r'''
+import base64, os, socket, struct, sys
+def build(sni):
+    sn = b"\x00" + struct.pack("!H", len(sni)) + sni
+    snl = struct.pack("!H", len(sn)) + sn
+    sni_ext = struct.pack("!HH", 0x0000, len(snl)) + snl
+    extensions = sni_ext
+    ext_block = struct.pack("!H", len(extensions)) + extensions
+    cipher_suites = struct.pack("!H", 2) + b"\x00\x3c"
+    body = (b"\x03\x03" + os.urandom(32) + b"\x00"
+            + cipher_suites + b"\x01\x00" + ext_block)
+    hs = b"\x01" + struct.pack("!I", len(body))[1:] + body
+    return b"\x16\x03\x01" + struct.pack("!H", len(hs)) + hs
+host, port, sni_b64 = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+sni = base64.b64decode(sni_b64)
+ch = build(sni)
+s = socket.create_connection((host, port), timeout=5)
+s.sendall(ch)
+s.settimeout(2)
+try: s.recv(4096)
+except socket.timeout: pass
+finally: s.close()
+'''
+
+
+def _send_raw_sni_from_client(host, port, sni_bytes):
+    """Send a raw TLS ClientHello with arbitrary SNI bytes from the LAN client.
+
+    sni_bytes is a Python bytes object — may contain any value (CR/LF/NUL/etc.).
+    The whole helper script is base64-encoded into a single shell command so
+    runtests.remote_control.run_command doesn't have to handle multi-line
+    quoting.  Returns the run_command exit code.
+    """
+    script_b64 = base64.b64encode(_RAW_SNI_CLIENT_SCRIPT.encode()).decode()
+    sni_b64 = base64.b64encode(sni_bytes).decode()
+    cmd = (f"echo {script_b64} | base64 -d | "
+           f"python3 - {shlex.quote(host)} {port} {shlex.quote(sni_b64)}")
+    return remote_control.run_command(cmd)
+
+
+def _inspector_log_path(app_obj):
+    """Return /var/log/uvm/app-<N>.log for the running ssl-inspector instance.
+
+    Takes the test class's self._app rather than reading the module-level `app`
+    global, which is only populated when SslInspectorTests.module_name() runs
+    during full-class setup.  When ATS invokes individual test methods, that
+    global may still be None.
+    """
+    return f"/var/log/uvm/app-{app_obj.getAppSettings()['id']}.log"
+
+
+def _log_line_count(path):
+    return int(subprocess.check_output(
+        f"wc -l {shlex.quote(path)} | cut -d' ' -f1",
+        shell=True).decode().strip())
+
+
+def _log_lines_since(path, start_line, pattern):
+    """awk-grep new log lines >= start_line whose body matches pattern."""
+    out = subprocess.check_output(
+        f"awk 'NR >= {start_line} && /{pattern}/' {shlex.quote(path)} || true",
+        shell=True).decode()
+    return [ln for ln in out.split('\n') if ln.strip()]
 
 
 @pytest.mark.ssl_inspector
@@ -329,6 +409,154 @@ class SslInspectorTests(NGFWTestCase):
         
         result = remote_control.run_command(global_functions.build_wget_command(output_file="-", uri=f"https://www.youtube.com/watch?v=esXGGdVL7ug") +  " 2>&1 | grep -q \'Loading icon\">'" )
         assert( result != 0 )
+
+    # -----------------------------------------------------------------------
+    # SNI SSRF (NGFW-15841) — SNI-driven SSRF in SSL Inspector CertCacheManager.
+    #
+    # Pre-fix: SNI bytes from the TLS ClientHello flowed straight into
+    #   new URL("https://" + sni).openConnection().connect()
+    # in CertCacheManagerImpl.fetchServerCertificate, letting an attacker steer
+    # the firewall's outbound TCP to an arbitrary IP:port (and inject CR/LF
+    # bytes into the cert-cache exception WARN line).
+    #
+    # Fix: validate the SNI at the inspector call site against SafeType.HOSTNAME
+    # (LDH regex + length cap, explicit null/empty reject) before passing it to
+    # the cache.  Malformed values fall back to session.getServerAddr() — the
+    # same primitive the SNI-absent branch already uses.  The cache method
+    # itself runs the same check at entry as defense-in-depth.  Log lines that
+    # interpolate the cache key are routed through a safeForLog() wrapper that
+    # strips CR/LF/TAB and truncates to 80 chars.
+    #
+    # These tests verify the security-relevant behavior end-to-end on a live
+    # appliance: a malformed SNI must not produce an outbound prefetch keyed by
+    # the attacker bytes; the SNI SSRF WARN must fire single-line, CR/LF-stripped.
+    # -----------------------------------------------------------------------
+    def test_720_sni_ssrf_legit_sni_no_warn(self):
+        """V1 — A legitimate LDH hostname in SNI must not trigger the SNI SSRF
+        WARN.  Negative regression check on the validator."""
+        log_file = _inspector_log_path(self._app)
+        start = _log_line_count(log_file) + 1
+
+        remote_control.run_command(
+            f"echo | openssl s_client -connect {testedServerName}:443 "
+            f"-servername {testedServerName} -quiet 2>/dev/null >/dev/null"
+        )
+        time.sleep(2)
+
+        warns = _log_lines_since(log_file, start, "SNI SSRF")
+        assert warns == [], (
+            f"Legitimate SNI {testedServerName!r} unexpectedly triggered "
+            f"SNI SSRF WARN(s): {warns}"
+        )
+
+    def test_721_sni_ssrf_malformed_sni_with_port_path_rejected(self):
+        """V2 — The audit payload (SNI with port + path + query) must be
+        rejected by the SafeType.HOSTNAME check; SNI SSRF WARN must fire and
+        name the IP-fallback target."""
+        log_file = _inspector_log_path(self._app)
+        uvm_log = "/var/log/uvm/uvm.log"
+        # Snapshot both log line counts BEFORE the trigger so the post-trigger
+        # grep is bounded to lines this test produced.  Without the uvm.log
+        # snapshot, a prior unpatched-build run (or any future test that uses
+        # the same payload) would leave a "CertCache Search 192.168.1.1:8443"
+        # line lying around forever and fail this test on every later run.
+        inspector_start = _log_line_count(log_file) + 1
+        uvm_start = _log_line_count(uvm_log) + 1
+
+        malicious_sni = b"192.168.1.1:8443/api/restart?x=1"
+        _send_raw_sni_from_client(testedServerName, 443, malicious_sni)
+        time.sleep(2)
+
+        warns = _log_lines_since(
+            log_file, inspector_start,
+            "SNI SSRF: rejected malformed SNI for cert prefetch")
+        assert warns, (
+            "Expected SNI SSRF WARN for malformed SNI "
+            f"{malicious_sni!r}; got none in new log lines.")
+        assert any(b"192.168.1.1:8443" in w.encode() for w in warns), (
+            f"SNI SSRF WARN should echo the rejected SNI bytes; got: {warns}")
+
+        # The cert cache must not have been searched with the attacker payload —
+        # if it had, we'd see a CertCache Search line keyed by the malicious SNI
+        # in uvm.log.  Bounded to new lines so prior runs don't poison this.
+        bad_searches = _log_lines_since(
+            uvm_log, uvm_start,
+            "CertCache Search 192.168.1.1:8443")
+        assert not bad_searches, (
+            f"Cert cache was searched with the attacker payload; the "
+            f"validator must reject before the cache key is used: "
+            f"{bad_searches}")
+
+    def test_722_sni_ssrf_crlf_sni_no_log_injection(self):
+        """V3 — SNI bytes containing CR/LF must be stripped to spaces by
+        safeForLog so the WARN line cannot inject a synthetic log entry."""
+        log_file = _inspector_log_path(self._app)
+        start = _log_line_count(log_file) + 1
+
+        injection_marker = "sni-ssrf-log-injected-v3"
+        sni_bytes = f"evil.example.com\r\n{injection_marker}".encode()
+        _send_raw_sni_from_client(testedServerName, 443, sni_bytes)
+        time.sleep(2)
+
+        warn_lines = _log_lines_since(
+            log_file, start,
+            "SslInspectorParserEventHandler.*SNI SSRF")
+        assert len(warn_lines) == 1, (
+            f"Expected exactly one SNI SSRF WARN line; got {len(warn_lines)}: "
+            f"{warn_lines}")
+        single = warn_lines[0]
+
+        # safeForLog replaces \r and \n with spaces — the raw bytes must not
+        # survive into the WARN line on the inspector's own log path.
+        assert "\r" not in single, (
+            f"safeForLog failed to strip CR from inspector WARN: {single!r}")
+        # Embedded \n would have split the message across two awk records, so
+        # the fact we got exactly one line is itself the no-CR/LF-survival
+        # assertion; double-check the marker is present in the surviving line
+        # rather than on a synthetic following line.
+        assert injection_marker in single, (
+            f"SNI SSRF WARN should still echo the (stripped) bad SNI bytes "
+            f"including the marker '{injection_marker}': {single!r}")
+
+    def test_723_sni_ssrf_leading_dash_sni_rejected(self):
+        """V4 — SNI starting with '-' must be rejected (argv-option-injection
+        defence — SafeType regex requires position 0 to be [A-Za-z0-9])."""
+        log_file = _inspector_log_path(self._app)
+        start = _log_line_count(log_file) + 1
+
+        malicious_sni = b"-rfevil.example.com"
+        _send_raw_sni_from_client(testedServerName, 443, malicious_sni)
+        time.sleep(2)
+
+        warns = _log_lines_since(
+            log_file, start,
+            "SNI SSRF: rejected malformed SNI for cert prefetch")
+        assert warns, (
+            f"Expected SNI SSRF WARN for leading-dash SNI {malicious_sni!r}; "
+            f"got none.")
+        assert any(b"-rfevil.example.com" in w.encode() for w in warns), (
+            f"SNI SSRF WARN should echo the rejected SNI: {warns}")
+
+    def test_724_sni_ssrf_oversize_sni_rejected(self):
+        """V10 — SNI exceeding the SafeType.HOSTNAME 253-char cap must be
+        rejected, and the WARN must show safeForLog's 80-char truncation
+        (trailing '...')."""
+        log_file = _inspector_log_path(self._app)
+        start = _log_line_count(log_file) + 1
+
+        long_sni = (b"a" * 254) + b".example.com"
+        _send_raw_sni_from_client(testedServerName, 443, long_sni)
+        time.sleep(2)
+
+        warns = _log_lines_since(
+            log_file, start,
+            "SNI SSRF: rejected malformed SNI for cert prefetch")
+        assert warns, (
+            f"Expected SNI SSRF WARN for oversize SNI ({len(long_sni)} bytes); "
+            "got none.")
+        assert any("..." in w for w in warns), (
+            f"Expected safeForLog truncation marker ('...') in WARN; "
+            f"got: {warns}")
 
     @classmethod
     def final_extra_tear_down(cls):

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 import com.untangle.uvm.OAuthDomain;
+import com.untangle.uvm.StringEscaperUtil;
 import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.util.SafeType;
 import com.untangle.uvm.vnet.AppSession;
@@ -71,23 +72,6 @@ public class SslInspectorParserEventHandler extends AbstractEventHandler
         super();
         this.clientSide = clientSide;
         this.app = app;
-    }
-
-    /**
-     * Render an SNI value safely for a single-line log entry by stripping
-     * CR/LF/TAB and capping length. Used only when logging the value of an
-     * SNI that failed validation -- attacker-controlled bytes must never
-     * land on a log line raw (log injection vector demonstrated under
-     * SNI SSRF, NGFW-15841).
-     *
-     * @param s the value to sanitize (may be null)
-     * @return a single-line, length-capped representation
-     */
-    private static String safeForLog(String s)
-    {
-        if (s == null) return "null";
-        String stripped = s.replace('\r', ' ').replace('\n', ' ').replace('\t', ' ');
-        return stripped.length() > 80 ? stripped.substring(0, 77) + "..." : stripped;
     }
 
     /**
@@ -722,10 +706,10 @@ public class SslInspectorParserEventHandler extends AbstractEventHandler
                 if (addr != null) {
                     certCacheKey = addr.getHostAddress();
                     logger.warn("SNI SSRF: rejected malformed SNI for cert prefetch, falling back to server IP "
-                        + certCacheKey + ": " + safeForLog(sniHostname));
+                        + certCacheKey + ": " + StringEscaperUtil.safeForLog(sniHostname));
                 } else {
                     logger.warn("SNI SSRF: rejected malformed SNI for cert prefetch, no server IP available for fallback: "
-                        + safeForLog(sniHostname));
+                        + StringEscaperUtil.safeForLog(sniHostname));
                 }
             }
             if (certCacheKey != null) {

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
@@ -18,6 +18,7 @@ import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLException;
 
+import java.net.InetAddress;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.apache.logging.log4j.LogManager;
 
 import com.untangle.uvm.OAuthDomain;
 import com.untangle.uvm.UvmContextFactory;
+import com.untangle.uvm.util.SafeType;
 import com.untangle.uvm.vnet.AppSession;
 import com.untangle.uvm.vnet.AppTCPSession;
 import com.untangle.uvm.vnet.AbstractEventHandler;
@@ -69,6 +71,23 @@ public class SslInspectorParserEventHandler extends AbstractEventHandler
         super();
         this.clientSide = clientSide;
         this.app = app;
+    }
+
+    /**
+     * Render an SNI value safely for a single-line log entry by stripping
+     * CR/LF/TAB and capping length. Used only when logging the value of an
+     * SNI that failed validation -- attacker-controlled bytes must never
+     * land on a log line raw (log injection vector demonstrated under
+     * SNI SSRF, NGFW-15841).
+     *
+     * @param s the value to sanitize (may be null)
+     * @return a single-line, length-capped representation
+     */
+    private static String safeForLog(String s)
+    {
+        if (s == null) return "null";
+        String stripped = s.replace('\r', ' ').replace('\n', ' ').replace('\t', ' ');
+        return stripped.length() > 80 ? stripped.substring(0, 77) + "..." : stripped;
     }
 
     /**
@@ -679,12 +698,49 @@ public class SslInspectorParserEventHandler extends AbstractEventHandler
         if (sniHostname != null) {
             session.globalAttach(AppTCPSession.KEY_SSL_INSPECTOR_SNI_HOSTNAME, sniHostname);
             logger.debug("SSL_INSPECTOR_SNI_HOSTNAME = " + sniHostname);
-            serverCert = UvmContextFactory.context().certCacheManager().fetchServerCertificate(sniHostname);
+
+            // SNI SSRF (NGFW-15841): SNI bytes come straight off the wire from
+            // the client (HttpUtility.extractedSNIHostname reads `nameLength`
+            // raw bytes into a String). Without validation they reach
+            // CertCacheManagerImpl which builds `new URL("https://" + sni)`
+            // and connects -- an SSRF primitive that lets an attacker steer
+            // the firewall's outbound TCP. Validate against SafeType.HOSTNAME
+            // (RFC 1035 LDH + NetBIOS underscore, max 253 chars, starts
+            // [A-Za-z0-9]). If the SNI is malformed, fall back to the actual
+            // server IP -- the same primitive the SNI-absent branch below
+            // already uses every day in production. CertCacheManagerImpl
+            // validates again at the sink as defense-in-depth.
+            //
+            // SafeType.HOSTNAME accepts null / empty (per SafeType.java:983);
+            // empty SNI is treated the same as malformed here (fall back to
+            // IP). Null can't appear inside this branch.
+            String certCacheKey = null;
+            if (!sniHostname.isEmpty() && SafeType.HOSTNAME.validate(sniHostname)) {
+                certCacheKey = sniHostname;
+            } else {
+                InetAddress addr = session.getServerAddr();
+                if (addr != null) {
+                    certCacheKey = addr.getHostAddress();
+                    logger.warn("SNI SSRF: rejected malformed SNI for cert prefetch, falling back to server IP "
+                        + certCacheKey + ": " + safeForLog(sniHostname));
+                } else {
+                    logger.warn("SNI SSRF: rejected malformed SNI for cert prefetch, no server IP available for fallback: "
+                        + safeForLog(sniHostname));
+                }
+            }
+            if (certCacheKey != null) {
+                serverCert = UvmContextFactory.context().certCacheManager().fetchServerCertificate(certCacheKey);
+            }
         }
 
-        // grab the cached certificate for the server but only for non-SMTP traffic 
+        // grab the cached certificate for the server but only for non-SMTP traffic
+        // SNI SSRF (NGFW-15841): null-guard on getServerAddr() for parity with the
+        // SNI-fallback path above; corner case is a partially-set-up session.
         if (session.getServerPort() != 25 && sniHostname == null) {
-            serverCert = UvmContextFactory.context().certCacheManager().fetchServerCertificate(session.getServerAddr().getHostAddress().toString());
+            InetAddress addr = session.getServerAddr();
+            if (addr != null) {
+                serverCert = UvmContextFactory.context().certCacheManager().fetchServerCertificate(addr.getHostAddress());
+            }
         }
 
         // attach the subject and issuer names for use by the rule matcher

--- a/uvm/bootstrap/com/untangle/uvm/StringEscaperUtil.java
+++ b/uvm/bootstrap/com/untangle/uvm/StringEscaperUtil.java
@@ -326,4 +326,32 @@ public class StringEscaperUtil {
     public static Map<CharSequence, CharSequence> invert(final Map<CharSequence, CharSequence> map) {
         return map.entrySet().stream().collect(Collectors.toMap(Entry::getValue, Entry::getKey));
     }
+
+    /**
+     * Render an arbitrary string safely for a single-line log entry by
+     * stripping CR/LF/TAB to spaces and capping length at 80 characters
+     * (truncated values end with {@code "..."}).
+     *
+     * Defense-in-depth against log injection: callers that interpolate
+     * potentially-attacker-controlled bytes (e.g. an SNI hostname read off
+     * the TLS wire) must wrap the value with this helper so a CR/LF in the
+     * value cannot forge a synthetic log entry on a line-based appender.
+     * The length cap protects shared appenders from oversized values.
+     *
+     * Different log-sanitization needs use different helpers in this codebase
+     * -- see {@code SafeUpload.safeForLog} for the upload-pipeline variant
+     * which preserves longer forensic values and uses {@code '_'} as its
+     * replacement sentinel. Pick the helper that matches the call site's
+     * contract; don't conflate the two.
+     *
+     * @param s the value to sanitize (may be null)
+     * @return a single-line, length-capped representation; the literal string
+     *         {@code "null"} if {@code s} is null
+     */
+    public static String safeForLog(String s)
+    {
+        if (s == null) return "null";
+        String stripped = s.replace('\r', ' ').replace('\n', ' ').replace('\t', ' ');
+        return stripped.length() > 80 ? stripped.substring(0, 77) + "..." : stripped;
+    }
 }

--- a/uvm/impl/com/untangle/uvm/CertCacheManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CertCacheManagerImpl.java
@@ -53,27 +53,6 @@ public class CertCacheManagerImpl implements CertCacheManager
     private final int prefetchTimeout = 1000;
 
     /**
-     * Render a serverAddress value safely for a single-line log entry by
-     * stripping CR/LF/TAB and capping length. Defense-in-depth against log
-     * injection: the entry guard in {@link #fetchServerCertificate(String)}
-     * already rejects anything containing these characters via
-     * {@link SafeType#HOSTNAME}, so callers that go through the public
-     * fetch path cannot reach the wrapped log lines with attacker bytes
-     * today. This helper protects (a) the new SNI SSRF rejection WARN itself
-     * and (b) any future caller / code path that might bypass the entry
-     * guard.
-     *
-     * @param s the value to sanitize (may be null)
-     * @return a single-line, length-capped representation
-     */
-    private static String safeForLog(String s)
-    {
-        if (s == null) return "null";
-        String stripped = s.replace('\r', ' ').replace('\n', ' ').replace('\t', ' ');
-        return stripped.length() > 80 ? stripped.substring(0, 77) + "..." : stripped;
-    }
-
-    /**
      * Holder for certificates that are cached in our hash map
      */
     class CertificateHolder
@@ -150,7 +129,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         if (serverAddress == null || serverAddress.isEmpty()
             || !SafeType.HOSTNAME.validate(serverAddress)) {
             logger.warn("SNI SSRF: rejecting invalid cert-cache serverAddress: "
-                + safeForLog(serverAddress));
+                + StringEscaperUtil.safeForLog(serverAddress));
             return null;
         }
 
@@ -159,7 +138,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         boolean certWaiter = false;
         int certTimer = 0;
 
-        logger.debug("CertCache Search " + safeForLog(serverAddress));
+        logger.debug("CertCache Search " + StringEscaperUtil.safeForLog(serverAddress));
 
         // first lets see if the certificate holder already exists
         certHolder = certTable.get(serverAddress);
@@ -168,7 +147,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         if (certHolder != null) {
             serverCertificate = certHolder.getCertificate();
             if (serverCertificate != null) {
-                logger.debug("CertCache Found " + safeForLog(serverAddress) + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
+                logger.debug("CertCache Found " + StringEscaperUtil.safeForLog(serverAddress) + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
                 return (serverCertificate);
             }
         }
@@ -178,9 +157,9 @@ public class CertCacheManagerImpl implements CertCacheManager
         synchronized (certLocker) {
             if ((certLocker.contains(serverAddress)) == false) {
                 certLocker.add(serverAddress);
-                logger.debug("CertLocker fetching " + safeForLog(serverAddress));
+                logger.debug("CertLocker fetching " + StringEscaperUtil.safeForLog(serverAddress));
             } else {
-                logger.debug("CertLocker waiting " + safeForLog(serverAddress));
+                logger.debug("CertLocker waiting " + StringEscaperUtil.safeForLog(serverAddress));
                 certWaiter = true;
             }
         }
@@ -201,7 +180,7 @@ public class CertCacheManagerImpl implements CertCacheManager
                 certTimer += 10;
 
                 if (certTimer > prefetchTimeout) {
-                    logger.debug("CertLocker timeout " + safeForLog(serverAddress));
+                    logger.debug("CertLocker timeout " + StringEscaperUtil.safeForLog(serverAddress));
                     return (null);
                 }
                 continue;
@@ -212,8 +191,8 @@ public class CertCacheManagerImpl implements CertCacheManager
             certHolder = certTable.get(serverAddress);
             serverCertificate = certHolder.getCertificate();
 
-            if (serverCertificate == null) logger.debug("CertLocker empty " + safeForLog(serverAddress));
-            else logger.debug("CertLocker acquire " + safeForLog(serverAddress));
+            if (serverCertificate == null) logger.debug("CertLocker empty " + StringEscaperUtil.safeForLog(serverAddress));
+            else logger.debug("CertLocker acquire " + StringEscaperUtil.safeForLog(serverAddress));
 
             return (serverCertificate);
         }
@@ -254,19 +233,19 @@ public class CertCacheManagerImpl implements CertCacheManager
             serverCertificate = (X509Certificate) certList[0];
             certTable.remove(serverAddress);
             certTable.put(serverAddress, new CertificateHolder(serverCertificate));
-            logger.info("CertCache Fetch " + safeForLog(serverAddress) + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
+            logger.info("CertCache Fetch " + StringEscaperUtil.safeForLog(serverAddress) + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
         }
 
         // we log and ignore all socket timeout exceptions 
         catch (SocketTimeoutException tex) {
-            logger.debug("Socket timeout fetching server certificate from " + safeForLog(serverAddress));
+            logger.debug("Socket timeout fetching server certificate from " + StringEscaperUtil.safeForLog(serverAddress));
             certTable.remove(serverAddress);
             certTable.put(serverAddress, new CertificateHolder());
         }
 
         // we log and ignore all other socket exceptions
         catch (SocketException soc) {
-            logger.debug("Socket exception fetching server certificate from " + safeForLog(serverAddress));
+            logger.debug("Socket exception fetching server certificate from " + StringEscaperUtil.safeForLog(serverAddress));
             certTable.remove(serverAddress);
             certTable.put(serverAddress, new CertificateHolder());
         }
@@ -275,7 +254,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         catch (Exception exn) {
             String exmess = exn.getMessage();
             if (exmess == null) exmess = "unknown";
-            logger.warn("Exception(" + exmess + ") fetching server certificate from " + safeForLog(serverAddress));
+            logger.warn("Exception(" + exmess + ") fetching server certificate from " + StringEscaperUtil.safeForLog(serverAddress));
             certTable.remove(serverAddress);
             certTable.put(serverAddress, new CertificateHolder());
         }
@@ -284,7 +263,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         // to remember to remove the address from the certlocker.
         synchronized (certLocker) {
             certLocker.remove(serverAddress);
-            logger.debug("CertLocker cleanup " + safeForLog(serverAddress));
+            logger.debug("CertLocker cleanup " + StringEscaperUtil.safeForLog(serverAddress));
         }
 
         return (serverCertificate);
@@ -322,7 +301,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         // not found, null or expired certificate so replace
         certTable.remove(serverAddress);
         certTable.put(serverAddress, new CertificateHolder(serverCertificate));
-        logger.debug("CertCache Update " + safeForLog(serverAddress) + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
+        logger.debug("CertCache Update " + StringEscaperUtil.safeForLog(serverAddress) + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/CertCacheManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CertCacheManagerImpl.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import com.untangle.uvm.CertCacheManager;
+import com.untangle.uvm.util.SafeType;
 
 /**
  * The Certificate Cache Manager is used to fetch and cache SSL certificates
@@ -50,6 +51,27 @@ public class CertCacheManagerImpl implements CertCacheManager
     private final Logger logger = LogManager.getLogger(getClass());
     private final long cacheTimeout = 60000;
     private final int prefetchTimeout = 1000;
+
+    /**
+     * Render a serverAddress value safely for a single-line log entry by
+     * stripping CR/LF/TAB and capping length. Defense-in-depth against log
+     * injection: the entry guard in {@link #fetchServerCertificate(String)}
+     * already rejects anything containing these characters via
+     * {@link SafeType#HOSTNAME}, so callers that go through the public
+     * fetch path cannot reach the wrapped log lines with attacker bytes
+     * today. This helper protects (a) the new SNI SSRF rejection WARN itself
+     * and (b) any future caller / code path that might bypass the entry
+     * guard.
+     *
+     * @param s the value to sanitize (may be null)
+     * @return a single-line, length-capped representation
+     */
+    private static String safeForLog(String s)
+    {
+        if (s == null) return "null";
+        String stripped = s.replace('\r', ' ').replace('\n', ' ').replace('\t', ' ');
+        return stripped.length() > 80 ? stripped.substring(0, 77) + "..." : stripped;
+    }
 
     /**
      * Holder for certificates that are cached in our hash map
@@ -114,12 +136,30 @@ public class CertCacheManagerImpl implements CertCacheManager
      */
     public X509Certificate fetchServerCertificate(String serverAddress)
     {
+        // SNI SSRF (NGFW-15841): sink-side defense-in-depth. The legitimate
+        // callers (SSL Inspector, Web Filter, Threat Prevention, Captive
+        // Portal) validate at their own call site, but this guard catches
+        // any future caller that forgets, and any regression that weakens
+        // the upstream validators. Rejecting at the sink also closes the
+        // log-injection vector in the WARN/exception loggers below -- with
+        // a bad value rejected here, those loggers can never receive
+        // attacker bytes via this call path.
+        //
+        // SafeType.HOSTNAME accepts null and empty (per SafeType.java:983);
+        // both are nonsensical as cert-cache keys, so reject them explicitly.
+        if (serverAddress == null || serverAddress.isEmpty()
+            || !SafeType.HOSTNAME.validate(serverAddress)) {
+            logger.warn("SNI SSRF: rejecting invalid cert-cache serverAddress: "
+                + safeForLog(serverAddress));
+            return null;
+        }
+
         X509Certificate serverCertificate = null;
         CertificateHolder certHolder = null;
         boolean certWaiter = false;
         int certTimer = 0;
 
-        logger.debug("CertCache Search " + serverAddress);
+        logger.debug("CertCache Search " + safeForLog(serverAddress));
 
         // first lets see if the certificate holder already exists
         certHolder = certTable.get(serverAddress);
@@ -128,7 +168,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         if (certHolder != null) {
             serverCertificate = certHolder.getCertificate();
             if (serverCertificate != null) {
-                logger.debug("CertCache Found " + serverAddress + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
+                logger.debug("CertCache Found " + safeForLog(serverAddress) + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
                 return (serverCertificate);
             }
         }
@@ -138,9 +178,9 @@ public class CertCacheManagerImpl implements CertCacheManager
         synchronized (certLocker) {
             if ((certLocker.contains(serverAddress)) == false) {
                 certLocker.add(serverAddress);
-                logger.debug("CertLocker fetching " + serverAddress);
+                logger.debug("CertLocker fetching " + safeForLog(serverAddress));
             } else {
-                logger.debug("CertLocker waiting " + serverAddress);
+                logger.debug("CertLocker waiting " + safeForLog(serverAddress));
                 certWaiter = true;
             }
         }
@@ -161,7 +201,7 @@ public class CertCacheManagerImpl implements CertCacheManager
                 certTimer += 10;
 
                 if (certTimer > prefetchTimeout) {
-                    logger.debug("CertLocker timeout " + serverAddress);
+                    logger.debug("CertLocker timeout " + safeForLog(serverAddress));
                     return (null);
                 }
                 continue;
@@ -172,8 +212,8 @@ public class CertCacheManagerImpl implements CertCacheManager
             certHolder = certTable.get(serverAddress);
             serverCertificate = certHolder.getCertificate();
 
-            if (serverCertificate == null) logger.debug("CertLocker empty " + serverAddress);
-            else logger.debug("CertLocker acquire " + serverAddress);
+            if (serverCertificate == null) logger.debug("CertLocker empty " + safeForLog(serverAddress));
+            else logger.debug("CertLocker acquire " + safeForLog(serverAddress));
 
             return (serverCertificate);
         }
@@ -214,19 +254,19 @@ public class CertCacheManagerImpl implements CertCacheManager
             serverCertificate = (X509Certificate) certList[0];
             certTable.remove(serverAddress);
             certTable.put(serverAddress, new CertificateHolder(serverCertificate));
-            logger.info("CertCache Fetch " + serverAddress + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
+            logger.info("CertCache Fetch " + safeForLog(serverAddress) + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
         }
 
         // we log and ignore all socket timeout exceptions 
         catch (SocketTimeoutException tex) {
-            logger.debug("Socket timeout fetching server certificate from " + serverAddress);
+            logger.debug("Socket timeout fetching server certificate from " + safeForLog(serverAddress));
             certTable.remove(serverAddress);
             certTable.put(serverAddress, new CertificateHolder());
         }
 
         // we log and ignore all other socket exceptions
         catch (SocketException soc) {
-            logger.debug("Socket exception fetching server certificate from " + serverAddress);
+            logger.debug("Socket exception fetching server certificate from " + safeForLog(serverAddress));
             certTable.remove(serverAddress);
             certTable.put(serverAddress, new CertificateHolder());
         }
@@ -235,7 +275,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         catch (Exception exn) {
             String exmess = exn.getMessage();
             if (exmess == null) exmess = "unknown";
-            logger.warn("Exception(" + exmess + ") fetching server certificate from " + serverAddress);
+            logger.warn("Exception(" + exmess + ") fetching server certificate from " + safeForLog(serverAddress));
             certTable.remove(serverAddress);
             certTable.put(serverAddress, new CertificateHolder());
         }
@@ -244,7 +284,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         // to remember to remove the address from the certlocker.
         synchronized (certLocker) {
             certLocker.remove(serverAddress);
-            logger.debug("CertLocker cleanup " + serverAddress);
+            logger.debug("CertLocker cleanup " + safeForLog(serverAddress));
         }
 
         return (serverCertificate);
@@ -282,7 +322,7 @@ public class CertCacheManagerImpl implements CertCacheManager
         // not found, null or expired certificate so replace
         certTable.remove(serverAddress);
         certTable.put(serverAddress, new CertificateHolder(serverCertificate));
-        logger.debug("CertCache Update " + serverAddress + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
+        logger.debug("CertCache Update " + safeForLog(serverAddress) + " SubjectDN(" + serverCertificate.getSubjectX500Principal().toString() + ") IssuerDN(" + serverCertificate.getIssuerX500Principal().toString() + ")");
     }
 
     /**


### PR DESCRIPTION
**What was wrong**
When a device on the network starts an HTTPS connection (say a browser opening github.com), it sends a small piece of text called the SNI — basically "I'm trying to reach github.com" — at the very start of the TLS handshake.

SSL Inspector reads this SNI so it can look up the server's certificate ahead of time and decide whether to inspect the traffic.
The problem: SSL Inspector trusted the SNI text completely and pasted it straight into a URL like https://<SNI>, then tried to connect. Whatever the user typed as SNI, the firewall would try to connect to.
So if someone on the network sent an SNI like:
```
192.168.1.1:8443/api/restart?x=1
```
the firewall would obediently open a TCP connection to `192.168.1.1:8443` — an internal IP the attacker themselves may not be able to reach, but the firewall can. That's an SSRF (Server-Side Request Forgery): the attacker uses the firewall as a relay to reach things they're not supposed to.
A secondary problem: if the SNI contained line-break characters, those bytes ended up in log files as separate-looking lines — letting an attacker forge fake log entries.

**How the fix works**
Two checks added before the firewall trusts the SNI:

1. At the SSL Inspector (the front door): before passing the SNI to the certificate lookup, check that it's a real-looking hostname (letters, digits, dots, dashes — same shape that's used everywhere else in the codebase via SafeType.HOSTNAME). If it isn't, ignore the SNI and use the actual destination IP instead — which is exactly what already happens when a client sends no SNI at all. A warning is logged.
2. At the certificate cache (the back door): the same check runs again, just inside the cache method itself. This way any future caller is protected even if they forget to validate. Belt-and-braces.

Both checks reject anything containing :, /, ?, line breaks, leading dashes, or values over 253 characters — all the shapes that legitimate SNI never has.

Log lines that print SNI values also got wrapped in a small helper that strips line-break characters and trims long values, so an attacker can't hide messages by stuffing newlines into the SNI.

**What doesn't change**
- Normal browsing continues to work exactly as before — every real hostname still passes the check.
- Sites that share an IP across many tenants (CDNs like Cloudflare, CloudFront) still work — they were the biggest worry, and they're covered.
- No new settings, no new dependencies, no behavior change on the happy path.
**Verification**
- Manually verified on test appliance: pre-fix, the firewall opened TCP to an attacker-controlled IP/port; post-fix, the firewall logs a warning and falls back to the real destination instead.
- 12 scenarios tested: legitimate hostnames, IDN/Punycode, IPv4 SNI, trailing dots, no-SNI, oversize SNI, embedded line breaks, leading dashes, real CDN browsing, cache hit/miss, and Web Filter compatibility — all behave correctly.
- 5 new ATS tests added under test_ssl_inspector.py covering the security-relevant cases.
```
== testing ssl-inspector ==
Test success : test_720_sni_ssrf_legit_sni_no_warn [64.4s] 
Test success : test_721_sni_ssrf_malformed_sni_with_port_path_rejected [3.2s] 
Test success : test_722_sni_ssrf_crlf_sni_no_log_injection [4.4s] 
Test success : test_723_sni_ssrf_leading_dash_sni_rejected [4.5s] 
Test success : test_724_sni_ssrf_oversize_sni_rejected [4.5s] 
== testing ssl-inspector [119.4s] ==

Tests complete. [119.4 seconds]
5 passed, 0 skipped, 0 failed

Total          :    5
Passed         :    5
Skipped        :    0
Passed/Skipped :    5 [100.00%]
Failed         :    0 [  0.00%]