### PR TITLE
ngfw-15834 Mythos UNT-06 Fix

### DIFF
--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -533,6 +533,27 @@ SQL_INJECT_REPORTENTRIES = overrides.get(
     }
 })
 
+def reports_realm_rpc_login(user, password):
+    """
+    Authenticate to the /reports realm and return a JSON-RPC session, nonce,
+    and the reportsManager objectID and javaClass.
+    Returns (session, rpc_url, nonce, object_id, java_class)
+    """
+    url = global_functions.get_http_url()
+    rpc_url = f"{url}/reports/JSON-RPC"
+    s = requests.Session()
+    s.post(
+        f"{url}/auth/login?url=/reports&realm=Reports",
+        data=f"fragment=&username={user}&password={password}",
+        verify=False
+    )
+    r = s.post(rpc_url, json={"id": 1, "nonce": "", "method": "system.getNonce", "params": []}, verify=False)
+    nonce = json.loads(r.text)["result"]
+    r = s.post(rpc_url, json={"id": 2, "nonce": nonce, "method": "ReportsContext.reportsManager", "params": []}, verify=False)
+    result = json.loads(r.text).get("result", {})
+    return s, rpc_url, nonce, result.get("objectID", ""), result.get("javaClass", "")
+
+
 def sql_injection(user, password, inject_filename_base, report_entry_type):
     """
     Run SQL injection
@@ -1430,8 +1451,6 @@ class ReportsTests(NGFWTestCase):
         assert (resultLoginPage == 0)
         # Restore original settings
         self._app.setSettings(original_settings)
-
-
     def test_111_data_retention_days(self):
         """
         Day retention removal
@@ -1546,6 +1565,73 @@ class ReportsTests(NGFWTestCase):
         # After cleaning, expecting to have less records
         print(f"Pre/post record counts: {start_count} < {end_count}")
         assert(end_count < start_count)
+
+    def test_120_reports_proxy_access_control(self):
+        """
+        Verify the ReportsManager proxy is correctly instantiated in the /reports realm and enforces access control.
+
+        Checks:
+        - reportsManager() returns the restricted proxy class, not the base singleton
+        - Write methods (saveReportEntry, removeReportEntry, setReportEntries, reinitializeDatabase) are blocked for reports-realm users
+        - Read method (getReportEntries) remains accessible through the proxy
+        """
+        original_settings = self._app.getSettings()
+        settings = copy.deepcopy(original_settings)
+        settings["reportsUsers"]["list"] = settings["reportsUsers"]["list"][:1]
+        test_email = global_functions.random_email()
+        settings["reportsUsers"]["list"].append(create_reports_user(profile_email=test_email, access=True))
+        self._app.setSettings(settings)
+
+        s, rpc_url, nonce, oid, java_class = reports_realm_rpc_login(test_email, "passwd")
+
+        # Verify the proxy class is returned, not the unrestricted base singleton
+        assert "ReportsContextImpl" in java_class, \
+            f"Expected restricted proxy class, got base singleton: {java_class}"
+
+        probe = {"javaClass": "com.untangle.app.reports.ReportEntry", "uniqueId": "unt06-test-probe",
+                 "title": "unt06-test", "category": "Hosts", "type": "TEXT", "table": "sessions",
+                 "textColumns": ["1"], "enabled": True, "readOnly": False, "displayOrder": 99999}
+
+        # Verify all write methods are blocked for reports-realm users
+        blocked_methods = [
+            (f".obj#{oid}.saveReportEntry", [probe]),
+            (f".obj#{oid}.removeReportEntry", [probe]),
+            (f".obj#{oid}.setReportEntries", [{"javaClass": "java.util.LinkedList", "list": []}]),
+            (f".obj#{oid}.reinitializeDatabase", []),
+        ]
+        errors = []
+        for method, params in blocked_methods:
+            r = s.post(rpc_url, json={"id": 3, "nonce": nonce, "method": method, "params": params}, verify=False)
+            resp = json.loads(r.text)
+            if "error" not in resp:
+                errors.append(f"{method} was NOT blocked (expected error)")
+        assert len(errors) == 0, f"Write methods not blocked for reports-realm user: {errors}"
+
+        # Verify read-only methods remain accessible through the proxy
+        r = s.post(rpc_url, json={"id": 4, "nonce": nonce, "method": f".obj#{oid}.getReportEntries", "params": []}, verify=False)
+        resp = json.loads(r.text)
+        assert "error" not in resp, f"getReportEntries() blocked unexpectedly: {resp.get('error')}"
+        assert "result" in resp, "getReportEntries() did not return a result"
+
+        self._app.setSettings(original_settings)
+
+    def test_129_admin_realm_write_methods_allowed(self):
+        """
+        UNT-06 non-regression: verify that admin can still call saveReportEntry
+        and removeReportEntry via the admin realm (unaffected by the proxy fix).
+        """
+        reports_manager = global_functions.uvmContext.appManager().app("reports").getReportsManager()
+        java_class = type(reports_manager).__name__
+
+        probe = {"javaClass": "com.untangle.app.reports.ReportEntry", "uniqueId": f"unt06-admin-probe-{int(time.time())}",
+                 "title": "unt06-admin-test", "category": "Hosts", "type": "TEXT", "table": "sessions",
+                 "textColumns": ["1"], "enabled": True, "readOnly": False, "displayOrder": 99999}
+
+        reports_manager.saveReportEntry(probe)
+        reports_manager.removeReportEntry(probe)
+
+        assert "ReportsContextImpl" not in java_class, \
+            f"Admin should receive unrestricted base singleton, not proxy: {java_class}"
 
     # tests for each report type:
     #    case EVENT_LIST:

--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -1451,6 +1451,8 @@ class ReportsTests(NGFWTestCase):
         assert (resultLoginPage == 0)
         # Restore original settings
         self._app.setSettings(original_settings)
+
+
     def test_111_data_retention_days(self):
         """
         Day retention removal

--- a/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/ReportsContextImpl.java
+++ b/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/ReportsContextImpl.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 import com.untangle.app.reports.ReportEntry;
+import com.untangle.app.reports.ReportsApp;
 import com.untangle.app.reports.ReportsManager;
 import com.untangle.uvm.LanguageManager;
 import com.untangle.uvm.LanguageSettings;
@@ -37,7 +38,7 @@ public class ReportsContextImpl implements UtJsonRpcServlet.ReportsContext
 
     private final SkinManager skinManager = new SkinManagerImpl();
     private final LanguageManager languageManager = new LanguageManagerImpl();
-    private final ReportsManager reportsManager = ReportsManagerImpl.getInstance();
+    private final ReportsManager reportsManager = this.new ReportsManagerImpl();
 
     /**
      * Initialize reportscontext with UVM context.
@@ -244,6 +245,7 @@ public class ReportsContextImpl implements UtJsonRpcServlet.ReportsContext
          * @param newEntries
          *  New report entries.
          */
+        @Override
         public void setReportEntries( List<ReportEntry> newEntries ) { throw new RuntimeException("Unable to set the report entries."); }
         /**
          * Save report entry.
@@ -251,6 +253,28 @@ public class ReportsContextImpl implements UtJsonRpcServlet.ReportsContext
          * @param entry
          *  Report entry to save.
          */
-        public void saveReportEntry( ReportEntry entry ) { throw new RuntimeException("Unable to set the event entries."); }
+        @Override
+        public void saveReportEntry( ReportEntry entry ) { throw new RuntimeException("Unable to save the report entry."); }
+        /**
+         * Remove report entry.
+         *
+         * @param entry
+         *  Report entry to remove.
+         */
+        @Override
+        public void removeReportEntry( ReportEntry entry ) { throw new RuntimeException("Unable to remove the report entry."); }
+        /**
+         * Set reports app.
+         *
+         * @param app
+         *  Reports app to set.
+         */
+        @Override
+        public void setReportsApp( ReportsApp app ) { throw new RuntimeException("Unable to set the reports app."); }
+        /**
+         * Reinitialize database.
+         */
+        @Override
+        public void reinitializeDatabase() { throw new RuntimeException("Unable to reinitialize the database."); }
     }
 }


### PR DESCRIPTION
## Summary

Fix reports-realm proxy bypass where `ReportsManagerImpl.getInstance()` returned the unrestricted base singleton instead of the restricted inner proxy class, leaving all write/destructive `ReportsManager` methods accessible to reports-only users. Add 3 missing write-method overrides and regression tests for both reports and admin realms.

## Motivation

NGFW-15834 / Mythos UNT-06: Due to Java name shadowing (JLS §6.3) and static method inheritance (JLS §8.4.8), `ReportsContextImpl` line 40 called the base class `getInstance()` instead of instantiating the inner proxy class. The proxy was effectively dead code — reports-only users received the unrestricted singleton, giving them access to `removeReportEntry()`, `setReportsApp()`, and `reinitializeDatabase()` (which wipes the entire PostgreSQL reports database).

## Changes

**Reports realm proxy (`ReportsContextImpl.java`)**
- Fixed proxy instantiation: `ReportsManagerImpl.getInstance()` → `this.new ReportsManagerImpl()` so the inner proxy class is actually used
- Added 3 missing `@Override` methods that were unblocked: `removeReportEntry()`, `setReportsApp()`, `reinitializeDatabase()`
- Added `@Override` annotations to all 5 proxy methods for compile-time safety
- Standardized exception messages to the `"Unable to ..."` scheme consistent with `SkinManagerImpl` and `LanguageManagerImpl` in the same file

**Regression tests (`test_reports.py`)**
- Added `reports_realm_rpc_login()` helper for authenticating to the `/reports` JSON-RPC realm
- Added `test_120_reports_proxy_access_control`: verifies proxy class is returned, all 4 write methods are blocked, and read-only `getReportEntries()` remains accessible
- Added `test_129_admin_realm_write_methods_allowed`: verifies admin realm still receives the unrestricted base singleton and can call `saveReportEntry`/`removeReportEntry`

<img width="1468" height="1088" alt="Mythos_UNT_06_ATS_Tests_Result" src="https://github.com/user-attachments/assets/83596399-dc9d-4968-bcc9-1e55cad5ada9" />


## Testing

1. Build and deploy the reports module
2. Create a reports-only user in Reports → Email Templates/Users
3. Log in as the reports user at `/reports` — verify all reports render and data queries work
4. As the reports user, attempt to save/delete a report entry — verify the operation is blocked
5. Log in as admin — verify reports can be saved, deleted, and database reinitialized
6. Run `test_120_reports_proxy_access_control` and `test_129_admin_realm_write_methods_allowed` — both should pass

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
