### PR TITLE
NGFW-15837: fix secret key disclosure and open redirect in auth flow

### DIFF
--- a/directory-connector/hier/usr/lib/python3/dist-packages/tests/test_directory_connector.py
+++ b/directory-connector/hier/usr/lib/python3/dist-packages/tests/test_directory_connector.py
@@ -395,16 +395,22 @@ class DirectoryConnectorTests(NGFWTestCase):
 
     def test_033_checkUserNotificationLoginScriptDownload(self):
         """
-        Check download of user notification script
+        Check download of user notification script (requires apiSecretKey)
         """
         # remove leading and trailing spaces.
         http_admin = global_functions.get_http_url()
         assert(http_admin)
-        
-        script_uri = "userapi/registration?download=download"
+
+        appSettings = self._app.getSettings()
+        secret_key = appSettings.get("apiSecretKey", "")
+        if not secret_key:
+            secret_key = "test_secret_key_033"
+            appSettings["apiSecretKey"] = secret_key
+            self._app.setSettings(appSettings)
+
+        script_uri = "userapi/registration?download=download&secretKey=" + secret_key
         script_url = http_admin + script_uri
         response = requests.get(script_url)
-        # print(user_script)
 
         assert ("serverLocation" in response.text)
         assert ("secret" in response.text)

--- a/directory-connector/js/MainController.js
+++ b/directory-connector/js/MainController.js
@@ -87,7 +87,9 @@ Ext.define('Ung.apps.directory-connector.MainController', {
     },
 
     downloadUserApiScript: function(){
-        window.open("../userapi/");
+        var vm = this.getViewModel();
+        var secretKey = vm.get('settings.apiSecretKey') || '';
+        window.open("../userapi/registration?download=download&secretKey=" + encodeURIComponent(secretKey));
     },
 
     closeWindow: function (button) {

--- a/directory-connector/servlets/userapi/root/index.jsp
+++ b/directory-connector/servlets/userapi/root/index.jsp
@@ -18,6 +18,13 @@ UvmContext uvm = UvmContextFactory.context();
 String company = uvm.brandingManager().getCompanyName();
 String companyUrl = uvm.brandingManager().getCompanyUrl();
 request.setAttribute( "i18n_map", uvm.languageManager().getTranslations("directory-connector"));
+
+com.untangle.app.directory_connector.DirectoryConnectorApp dcApp =
+    (com.untangle.app.directory_connector.DirectoryConnectorApp)uvm.appManager().app("directory-connector");
+String apiSecretKey = "";
+if (dcApp != null && dcApp.getSettings() != null && dcApp.getSettings().getApiSecretKey() != null) {
+    apiSecretKey = java.net.URLEncoder.encode(dcApp.getSettings().getApiSecretKey(), "UTF-8");
+}
 %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -48,7 +55,7 @@ request.setAttribute( "i18n_map", uvm.languageManager().getTranslations("directo
 
         <span class="un_login_sub_title"><uvm:i18n>Download</uvm:i18n></span>
         <br /><br />
-         <a href="/userapi/registration?download=download"><b><uvm:i18n>User Notification Login Script</uvm:i18n></b></a>
+         <a href="/userapi/registration?download=download&amp;secretKey=<%=apiSecretKey%>"><b><uvm:i18n>User Notification Login Script</uvm:i18n></b></a>
          <div  class="un_login_sub_text">
     <p>
          <uvm:i18n>The User Notification Login Script is a small script that runs on client machines that notifies the <%=company%> server when a user logs in. This allows the <%=company%> server to add the username to the appropriate host in the Host Table so the appropriate rules can apply for that user and the events will be recorded as associated with that user.</uvm:i18n>

--- a/directory-connector/servlets/userapi/src/com/untangle/app/directory_connector/Registration.java
+++ b/directory-connector/servlets/userapi/src/com/untangle/app/directory_connector/Registration.java
@@ -72,12 +72,17 @@ public class Registration extends HttpServlet
             }
             if (requiredSecretKey == null || "".equals(requiredSecretKey)) {
                 logger.warn("Download rejected: API secret key is not configured.");
-                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                response.sendError(HttpServletResponse.SC_FORBIDDEN,
+                    "A Secret Key must be configured before downloading the login script. " +
+                    "The script uses this key to authenticate user registration requests. " +
+                    "Set one in Apps > Directory Connector > User Notification API > Secret Key.");
                 return;
             }
             if (!requiredSecretKey.equals(dlSecretKey)) {
                 logger.warn("Download rejected: secret key does not match.");
-                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                response.sendError(HttpServletResponse.SC_FORBIDDEN,
+                    "The provided secret key does not match. " +
+                    "Verify the key in Apps > Directory Connector > User Notification API > Secret Key.");
                 return;
             }
             generateInstaller( request, response );

--- a/directory-connector/servlets/userapi/src/com/untangle/app/directory_connector/Registration.java
+++ b/directory-connector/servlets/userapi/src/com/untangle/app/directory_connector/Registration.java
@@ -54,22 +54,38 @@ public class Registration extends HttpServlet
     {
         DirectoryConnectorApp directoryConnector = (DirectoryConnectorApp)UvmContextFactory.context().appManager().app("directory-connector");
 
-        String download = request.getParameter( "download" );
-        if ( download != null && download.equals( "download" ) ) {
-            generateInstaller( request, response );
-            return;
-        }
-
         if ( ! directoryConnector.getSettings().getApiEnabled() ) {
             logger.warn("API not enabled.");
             response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             return;
         }
 
+        String requiredSecretKey = directoryConnector.getSettings().getApiSecretKey();
+
+        // NGFW-15837 / UNT-01: download path requires a configured and matching secret key.
+        // Previously this branch ran before any auth check, leaking the secret to unauthenticated callers.
+        String download = request.getParameter( "download" );
+        if ( download != null && download.equals( "download" ) ) {
+            String dlSecretKey = request.getParameter( "secretKey" );
+            if ( dlSecretKey == null ) {
+                dlSecretKey = request.getParameter( "secretkey" );
+            }
+            if (requiredSecretKey == null || "".equals(requiredSecretKey)) {
+                logger.warn("Download rejected: API secret key is not configured.");
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return;
+            }
+            if (!requiredSecretKey.equals(dlSecretKey)) {
+                logger.warn("Download rejected: secret key does not match.");
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return;
+            }
+            generateInstaller( request, response );
+            return;
+        }
+
         response.setContentType( "text/html" );
         response.setHeader( "Content-Disposition", "text/html");
-
-        String requiredSecretKey = directoryConnector.getSettings().getApiSecretKey();
 
         String username = null;
         String hostname = null;

--- a/uvm/hier/usr/share/untangle/web/auth/index.py
+++ b/uvm/hier/usr/share/untangle/web/auth/index.py
@@ -71,8 +71,12 @@ def login(req, url=None, realm='Administrator', token=None):
                 return apache.OK
             else:
                 url = re.sub('[^A-Za-z0-9-_/.#?=]','',url) # sanitize input
+                if url == '' or not re.fullmatch(r'/[^/].*|/', url):
+                    url = '/'
                 if 'fragment' in form and form['fragment'] != '':
-                    url = url + form['fragment']
+                    fragment = re.sub('[^A-Za-z0-9-_/.#?=]','',form['fragment'])
+                    if fragment != '' and re.fullmatch(r'#[^/].*|#', fragment):
+                        url = url + fragment
                 util.redirect(req, url)
                 return
 
@@ -95,8 +99,12 @@ def login(req, url=None, realm='Administrator', token=None):
                 return apache.OK
             else:
                 url = re.sub('[^A-Za-z0-9-_/.#?=]','',url) # sanitize input
+                if url == '' or not re.fullmatch(r'/[^/].*|/', url):
+                    url = '/'
                 if 'fragment' in form and form['fragment'] != '':
-                    url = url + form['fragment']
+                    fragment = re.sub('[^A-Za-z0-9-_/.#?=]','',form['fragment'])
+                    if fragment != '' and re.fullmatch(r'#[^/].*|#', fragment):
+                        url = url + fragment
                 util.redirect(req, url)
                 return
 
@@ -125,6 +133,8 @@ def logout(req, url=None, realm='Administrator'):
         return apache.OK
     else:
         url = re.sub('[^A-Za-z0-9-_/.#?=]','',url) # sanitize input
+        if url == '' or not re.fullmatch(r'/[^/].*|/', url):
+            url = '/'
         util.redirect(req, url)
         return
 


### PR DESCRIPTION
UNT-01: Move the download branch in Registration.doGet() below the apiEnabled and secretKey checks. Previously the download=download path returned the VBS installer (with embedded API secret) before any auth gate, allowing unauthenticated callers to leak the secret key. The download now requires apiEnabled=true and a configured+matching secretKey. Update the WebUI download button, index.jsp link, and ATS test to pass the secretKey in the request.

UNT-27: Add protocol-relative URL rejection in auth/index.py. The existing regex whitelist permits '//' so //evil.example/... survived sanitization, enabling post-login open redirect. Add re.fullmatch check requiring exactly one leading '/' after the regex strip. Sanitize the fragment parameter with the same whitelist+check. Applied to all three redirect paths (token login, password login, logout).