### PR TITLE
ngfw-15838 Mythos UNT 54-60 Fix

### DIFF
--- a/smtp-casing/servlets/quarantine/src/com/untangle/app/smtp/web/euv/InboxMaintenenceServlet.java
+++ b/smtp-casing/servlets/quarantine/src/com/untangle/app/smtp/web/euv/InboxMaintenenceServlet.java
@@ -78,25 +78,18 @@ public class InboxMaintenenceServlet extends HttpServlet
 
         String account = null;
         try {
-            if("test".equals(authToken)) { //Just for ui testing
-                account="test@untangle.com";
-                req.setAttribute( "forwardAddress", "remapped@untangle.com");
-                req.setAttribute( "safelistData", buildJsonList(new String[] {"safeOne@test.com", "safeTwo@test.com"}));
-                req.setAttribute( "remapsData", "[]");
-            } else {
-                account = quarantine.getAccountFromToken(authToken);
+            account = quarantine.getAccountFromToken(authToken);
 
-                String remappedTo = quarantine.getMappedTo(account);
-                if(remappedTo != null) {
-                    req.setAttribute( "forwardAddress", remappedTo);
-                }
-
-                String[] inboundRemappings = quarantine.getMappedFrom(account);
-                req.setAttribute( "remapsData", buildJsonList(inboundRemappings));
-
-                String[] safelistData = safelistManipulation.getSafelistContents(account);
-                req.setAttribute( "safelistData", buildJsonList(safelistData));
+            String remappedTo = quarantine.getMappedTo(account);
+            if(remappedTo != null) {
+                req.setAttribute( "forwardAddress", remappedTo);
             }
+
+            String[] inboundRemappings = quarantine.getMappedFrom(account);
+            req.setAttribute( "remapsData", buildJsonList(inboundRemappings));
+
+            String[] safelistData = safelistManipulation.getSafelistContents(account);
+            req.setAttribute( "safelistData", buildJsonList(safelistData));
         }
         catch(BadTokenException ex) {
             req.getRequestDispatcher(REQUEST_FWD).forward(req, resp);

--- a/uvm/impl/com/untangle/uvm/TomcatManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/TomcatManagerImpl.java
@@ -115,7 +115,7 @@ public class TomcatManagerImpl implements TomcatManager
 
         ctx = loadServlet("/gdrive", "gdrive");
 
-        ctx = loadServlet("/support", "support");
+        ctx = loadServlet("/support", "support", true);
     }
 
     /**

--- a/uvm/servlets/support/src/com/untangle/uvm/AdvancedSupportHandler.java
+++ b/uvm/servlets/support/src/com/untangle/uvm/AdvancedSupportHandler.java
@@ -81,6 +81,7 @@ public class AdvancedSupportHandler extends HttpServlet
         // first make sure the advanced support handler script exists
         if (!script.exists() || !script.canExecute()) {
             response.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED);
+            return;
         }
 
         // put all of the request parameter names and values into a JSON object


### PR DESCRIPTION
## Summary

Remove hard-coded `tkn=test` backdoor in the quarantine inbox servlet and fix missing auth + logic bug in the `/support` servlet. Both are pentest findings (UNT-54, UNT-60) — the first allows unauthenticated rendering of the quarantine inbox SPA, the second allows the support servlet to fall through to script execution after an error and lacks Tomcat-level auth enforcement.

## Motivation

- **UNT-54 (MEDIUM, CVSS 5.3):** A dev-only test fixture (`if("test".equals(authToken))`) shipped in production, allowing anyone to `GET /quarantine/manageuser?tkn=test` and render the inbox UI bound to `test@untangle.com` without authentication. Discloses company branding, skin name, retention settings, and page layout.
- **UNT-60 (LOW, CVSS 5.3):** The `/support` servlet has two issues: (1) `sendError(501)` is missing a `return`, so execution falls through to `execOutput()` even when the handler script doesn't exist; (2) the servlet is mounted without `AdministrationValve`, unlike `/admin` and `/setup`. Apache's `uvm_login` covers the path in deployment, but the Tomcat layer has no defense-in-depth.

## Changes

### Quarantine Inbox (UNT-54)
- Removed the `if("test".equals(authToken))` branch and all associated hard-coded test data (`test@untangle.com`, `remapped@untangle.com`, fake safelist entries) from `InboxMaintenenceServlet.service()`. All tokens now go through `quarantine.getAccountFromToken()` — passing `tkn=test` throws `BadTokenException` and redirects to the `/request` page.

### Support Servlet (UNT-60)
- Added `return;` after `response.sendError(SC_NOT_IMPLEMENTED)` in `AdvancedSupportHandler.requestHandler()` to prevent fall-through to `execOutput()` when the handler script is missing.
- Changed `loadServlet("/support", "support")` to `loadServlet("/support", "support", true)` in `TomcatManagerImpl`, adding `AdministrationValve` protection consistent with `/admin` and `/setup`.

## Local Testing

### UNT-54 — Quarantine backdoor removal
1. Open an unauthenticated browser and navigate to `https://<NGFW_IP>/quarantine/manageuser?tkn=test`
2. **Expected:** Redirected to the quarantine email request page — no inbox UI rendered
3. Verify normal quarantine flow still works: receive a quarantine digest email, click the link (contains a real encrypted token), confirm the inbox loads correctly


### UNT-60 — Support servlet hardening

**Missing return fix:**
4. Log in to the NGFW admin UI, open DevTools (F12) → Network tab
5. Navigate to `https://<NGFW_IP>/support`
6. **Expected:** Status `501`. Response body contains only the standard Arista "Not Implemented" error page with no extra content appended

**AdministrationValve — parity with `/admin`:**
7. Open a private/incognito browser window (no login session)
8. Navigate to `http://<NGFW_IP>/support`
9. **Expected:** Redirected to `/auth/login?url=/support&realm=Administrator`
10. Navigate to `http://<NGFW_IP>/admin` in the same window
11. **Expected:** Same redirect behavior — `/support` and `/admin` behave identically for unauthenticated users

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
