### PR TITLE
NGFW-15848: fix path traversal vulnerability in quarantine inbox storage

### DIFF
--- a/debian/untangle-vm.postinst
+++ b/debian/untangle-vm.postinst
@@ -89,4 +89,26 @@ systemctl unmask suricata # NGFW-12939, NGFW-13217
 usermod -a -G winbindd_priv freerad
 chown root:winbindd_priv /var/lib/samba/winbindd_privileged
 
+# UNT-30: Archive any quarantine inbox directories with path-traversal names.
+# Moves suspicious entries to inboxes-archive/ (never deletes). Idempotent.
+QUARANTINE_INBOXES="/usr/share/untangle/conf/quarantine/inboxes"
+QUARANTINE_ARCHIVE="/usr/share/untangle/conf/quarantine/inboxes-archive"
+if [ -d "$QUARANTINE_INBOXES" ] ; then
+    for inbox in "$QUARANTINE_INBOXES"/* ; do
+        [ -d "$inbox" ] || continue
+        dirname="$(basename "$inbox")"
+        case "$dirname" in
+            *..* | *\\*)
+                if [ ! -d "$QUARANTINE_ARCHIVE" ] ; then
+                    mkdir -p "$QUARANTINE_ARCHIVE"
+                fi
+                if [ ! -e "$QUARANTINE_ARCHIVE/$dirname" ] ; then
+                    mv "$inbox" "$QUARANTINE_ARCHIVE/$dirname"
+                    logger -t untangle-vm "UNT-30: Archived quarantine inbox with suspicious name"
+                fi
+                ;;
+        esac
+    done
+fi
+
 exit 0

--- a/smtp-casing/servlets/quarantine/src/com/untangle/app/smtp/web/euv/JsonInterfaceImpl.java
+++ b/smtp-casing/servlets/quarantine/src/com/untangle/app/smtp/web/euv/JsonInterfaceImpl.java
@@ -20,6 +20,7 @@ import com.untangle.app.smtp.quarantine.InboxRecord;
 import com.untangle.app.smtp.quarantine.NoSuchInboxException;
 import com.untangle.app.smtp.quarantine.QuarantineUserActionFailedException;
 import com.untangle.app.smtp.quarantine.QuarantineUserView;
+import com.untangle.app.smtp.quarantine.store.QuarantineAddressValidator;
 import com.untangle.app.smtp.safelist.NoSuchSafelistException;
 import com.untangle.app.smtp.safelist.SafelistActionFailedException;
 import com.untangle.app.smtp.safelist.SafelistManipulation;
@@ -55,6 +56,10 @@ public class JsonInterfaceImpl implements JsonInterface
     {
         if (account == null)
             throw new RuntimeException("Missing account");
+
+        if (!QuarantineAddressValidator.isValidAddress(account)) {
+            throw new RuntimeException("Invalid Email Address"); 
+        }
 
         // Validate at least basic format
         try {

--- a/smtp-casing/src/com/untangle/app/smtp/EmailAddressPairRule.java
+++ b/smtp-casing/src/com/untangle/app/smtp/EmailAddressPairRule.java
@@ -5,13 +5,18 @@ package com.untangle.app.smtp;
 
 import java.io.Serializable;
 
+import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
+
 /**
  * Class used to associate two email addresses
  */
 @SuppressWarnings("serial")
 public class EmailAddressPairRule implements Serializable
 {
+    @SafeCheck(SafeType.EMAIL_GLOB)
     private String addr1;
+    @SafeCheck(SafeType.EMAIL_GLOB)
     private String addr2;
 
     /**

--- a/smtp-casing/src/com/untangle/app/smtp/EmailAddressRule.java
+++ b/smtp-casing/src/com/untangle/app/smtp/EmailAddressRule.java
@@ -5,12 +5,16 @@ package com.untangle.app.smtp;
 
 import java.io.Serializable;
 
+import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
+
 /**
  * Class used to hold an email address
  */
 @SuppressWarnings("serial")
 public class EmailAddressRule implements Serializable
 {
+    @SafeCheck(SafeType.EMAIL_WILDCARD)
     private String addr;
 
     /**

--- a/smtp-casing/src/com/untangle/app/smtp/quarantine/Quarantine.java
+++ b/smtp-casing/src/com/untangle/app/smtp/quarantine/Quarantine.java
@@ -28,6 +28,7 @@ import com.untangle.app.smtp.SmtpImpl;
 import com.untangle.app.smtp.SmtpSettings;
 import com.untangle.app.smtp.mime.MIMEUtil;
 import com.untangle.app.smtp.quarantine.store.InboxSummary;
+import com.untangle.app.smtp.quarantine.store.QuarantineAddressValidator;
 import com.untangle.app.smtp.quarantine.store.QuarantineStore;
 import com.untangle.uvm.util.Pair;
 import com.untangle.uvm.UvmContextFactory;
@@ -231,12 +232,25 @@ public class Quarantine implements QuarantineAppView, QuarantineMaintenenceView,
             }
 
             String recipientAddress = eAddr.getAddress().toLowerCase();
+
+            if (!QuarantineAddressValidator.isValidAddress(recipientAddress)) {
+                logger.warn("Quarantine rejecting recipient with invalid address: "
+                    + QuarantineAddressValidator.getViolation(recipientAddress));
+                continue;
+            }
+
             String inboxAddress = this.addressAliases.getAddressMapping(recipientAddress);
 
             if (inboxAddress != null) {
                 logger.debug("Recipient \"" + recipientAddress + "\" remaps to \"" + inboxAddress + "\"");
             } else {
                 inboxAddress = recipientAddress;
+            }
+
+            if (!QuarantineAddressValidator.isValidAddress(inboxAddress)) {
+                logger.warn("Quarantine rejecting inbox alias with invalid address: "
+                    + QuarantineAddressValidator.getViolation(inboxAddress));
+                continue;
             }
 
             List<String> listForInbox = recipientGroupings.get(inboxAddress);
@@ -294,6 +308,11 @@ public class Quarantine implements QuarantineAppView, QuarantineMaintenenceView,
     public InboxIndex purge(String account, String... doomedMails) throws NoSuchInboxException,
             QuarantineUserActionFailedException
     {
+        if (!QuarantineAddressValidator.isValidAddress(account)) {
+            logger.warn("Rejecting purge for invalid account: "
+                + QuarantineAddressValidator.getViolation(account));
+            throw new QuarantineUserActionFailedException("Invalid account address");
+        }
         Pair<QuarantineStore.GenericStatus, InboxIndex> result = this.store.purge(account, doomedMails);
         checkAndThrowCommonErrors(result.a, account);
         return result.b;
@@ -311,6 +330,11 @@ public class Quarantine implements QuarantineAppView, QuarantineMaintenenceView,
     public InboxIndex rescue(String account, String... rescuedMails) throws NoSuchInboxException,
             QuarantineUserActionFailedException
     {
+        if (!QuarantineAddressValidator.isValidAddress(account)) {
+            logger.warn("Rejecting rescue for invalid account: "
+                + QuarantineAddressValidator.getViolation(account));
+            throw new QuarantineUserActionFailedException("Invalid account address");
+        }
         Pair<QuarantineStore.GenericStatus, InboxIndex> result = this.store.rescue(account, rescuedMails);
         checkAndThrowCommonErrors(result.a, account);
         return result.b;
@@ -361,6 +385,11 @@ public class Quarantine implements QuarantineAppView, QuarantineMaintenenceView,
      */
     private InboxIndex getInboxIndex(String account) throws NoSuchInboxException, QuarantineUserActionFailedException
     {
+        if (!QuarantineAddressValidator.isValidAddress(account)) {
+            logger.warn("Rejecting inbox access for invalid account: "
+                + QuarantineAddressValidator.getViolation(account));
+            throw new QuarantineUserActionFailedException("Invalid account address");
+        }
         Pair<QuarantineStore.GenericStatus, InboxIndex> result = this.store.getIndex(account);
         checkAndThrowCommonErrors(result.a, account);
         return result.b;
@@ -423,6 +452,11 @@ public class Quarantine implements QuarantineAppView, QuarantineMaintenenceView,
     @Override
     public void deleteInbox(String account) throws NoSuchInboxException, QuarantineUserActionFailedException
     {
+        if (!QuarantineAddressValidator.isValidAddress(account)) {
+            logger.warn("Rejecting deleteInbox for invalid account: "
+                + QuarantineAddressValidator.getViolation(account));
+            throw new QuarantineUserActionFailedException("Invalid account address");
+        }
         switch (this.store.deleteInbox(account)) {
             case NO_SUCH_INBOX:
                 // Just supress this one for now
@@ -464,7 +498,14 @@ public class Quarantine implements QuarantineAppView, QuarantineMaintenenceView,
             throw new BadTokenException(token);
         }
 
-        return p.b;
+        String account = p.b;
+        if (!QuarantineAddressValidator.isValidAddress(account)) {
+            logger.warn("Token decrypted to invalid account: "
+                + QuarantineAddressValidator.getViolation(account));
+            throw new BadTokenException(token);
+        }
+
+        return account;
     }
 
     /**
@@ -516,6 +557,12 @@ public class Quarantine implements QuarantineAppView, QuarantineMaintenenceView,
         if ((from.length() == 0) || (to.length() == 0)) {
             logger.warn("empty from or to string.");
             return;
+        }
+
+        if (!QuarantineAddressValidator.isValidAddress(to)) {
+            logger.warn("Rejecting remap target with invalid address: "
+                + QuarantineAddressValidator.getViolation(to));
+            throw new QuarantineUserActionFailedException("Invalid target address");
         }
 
         GlobEmailAddressMapper currentMapper = null;

--- a/smtp-casing/src/com/untangle/app/smtp/quarantine/store/MasterTable.java
+++ b/smtp-casing/src/com/untangle/app/smtp/quarantine/store/MasterTable.java
@@ -273,6 +273,12 @@ final class MasterTable
     private static void visit(File f, StoreSummary storeMeta)
     {
         String emailAddress = f.getName();
+        if (!QuarantineAddressValidator.isValidAddress(emailAddress)) {
+            LogManager.getLogger(MasterTable.class).warn(
+                "Skipping inbox directory with invalid name: "
+                + QuarantineAddressValidator.getViolation(emailAddress));
+            return;
+        }
         InboxIndex inboxIndex = QuarantineStorageManager.readQuarantine(emailAddress, f.getAbsolutePath());
         if (inboxIndex != null) {
             long totalSz = 0;

--- a/smtp-casing/src/com/untangle/app/smtp/quarantine/store/QuarantineAddressValidator.java
+++ b/smtp-casing/src/com/untangle/app/smtp/quarantine/store/QuarantineAddressValidator.java
@@ -1,0 +1,66 @@
+/**
+ * $Id$
+ */
+package com.untangle.app.smtp.quarantine.store;
+
+/**
+ * Validates email addresses used as quarantine inbox identifiers against
+ * filesystem-safety rules. Rejects path traversal sequences, directory
+ * separators, and control characters while accepting all legitimate
+ * RFC 5321 email address characters.
+ */
+public final class QuarantineAddressValidator
+{
+    private static final int MAX_ADDRESS_LENGTH = 254;
+
+    /** Prevent instantiation. */
+    private QuarantineAddressValidator() {}
+
+    /**
+     * Check whether an address is safe to use as a quarantine inbox name.
+     * @param address the email address to validate.
+     * @return true if the address is safe, false otherwise.
+     */
+    public static boolean isValidAddress(String address)
+    {
+        return getViolation(address) == null;
+    }
+
+    /**
+     * Return a human-readable reason why the address is unsafe, or null if valid.
+     * The returned message never includes the address value itself.
+     * @param address the email address to validate.
+     * @return violation description, or null if the address is valid.
+     */
+    public static String getViolation(String address)
+    {
+        if (address == null || address.isEmpty()) {
+            return "address is null or empty";
+        }
+
+        if (address.length() > MAX_ADDRESS_LENGTH) {
+            return "address exceeds 254 characters";
+        }
+
+        if (address.contains("..")) {
+            return "address contains path traversal sequence '..'";
+        }
+
+        if (address.indexOf('/') >= 0) {
+            return "address contains forward slash";
+        }
+
+        if (address.indexOf('\\') >= 0) {
+            return "address contains backslash";
+        }
+
+        for (int i = 0; i < address.length(); i++) {
+            char c = address.charAt(i);
+            if (c <= 0x1F || c == 0x7F) {
+                return "address contains control character at position " + (i + 1);
+            }
+        }
+
+        return null;
+    }
+}

--- a/smtp-casing/src/com/untangle/app/smtp/quarantine/store/QuarantineStore.java
+++ b/smtp-casing/src/com/untangle/app/smtp/quarantine/store/QuarantineStore.java
@@ -189,6 +189,10 @@ public class QuarantineStore
         logger.debug("Call to quarantine mail from file \"" + file + "\" into inbox \"" + inboxAddr + "\"");
 
         File dir = getInboxDir(inboxAddr, true);
+        if (dir == null) {
+            logger.warn("Unable to get or create inbox directory for \"" + inboxAddr + "\"");
+            return new Pair<>(AdditionStatus.FAILURE);
+        }
 
         // We need to hold the account lock for the whole
         // operation of addition and index update. This
@@ -300,7 +304,12 @@ public class QuarantineStore
                 // goofed).
             }
             // Read the index (it may not exist)
-            InboxIndex inboxIndex = QuarantineStorageManager.readQuarantine(account, getInboxPath(account));
+            String inboxPath = getInboxPath(account);
+            if (inboxPath == null) {
+                addressLock.unlock(account);
+                continue;
+            }
+            InboxIndex inboxIndex = QuarantineStorageManager.readQuarantine(account, inboxPath);
 
             boolean shouldDelete = false;
 
@@ -309,7 +318,7 @@ public class QuarantineStore
             }
 
             if (shouldDelete) {
-                IOUtil.rmDir(new File(getInboxPath(account)));
+                IOUtil.rmDir(new File(inboxPath));
                 // Note that this call implicitly causes any mails accounted for
                 // to be removed
                 masterTable.removeInbox(account);
@@ -331,13 +340,16 @@ public class QuarantineStore
         String account = address.toLowerCase();
         addressLock.lock(account);
 
-        GenericStatus ret = null;
+        String inboxPath = getInboxPath(account);
+        if (inboxPath == null) {
+            addressLock.unlock(account);
+            return GenericStatus.ERROR;
+        }
 
-        IOUtil.rmDir(new File(getInboxPath(account)));
+        IOUtil.rmDir(new File(inboxPath));
         masterTable.removeInbox(account);
-        ret = GenericStatus.SUCCESS;
         addressLock.unlock(account);
-        return ret;
+        return GenericStatus.SUCCESS;
     }
 
     /**
@@ -364,7 +376,12 @@ public class QuarantineStore
         // Read the index file.
         // Remove any mails from the in-memory index which are in our list and
         // add them to a new list
-        InboxIndex inboxIndex = QuarantineStorageManager.readQuarantine(address, getInboxPath(address));
+        String inboxPath = getInboxPath(address);
+        if (inboxPath == null) {
+            addressLock.unlock(address);
+            return new Pair<>(GenericStatus.ERROR);
+        }
+        InboxIndex inboxIndex = QuarantineStorageManager.readQuarantine(address, inboxPath);
         addressLock.unlock(address);
         if (inboxIndex == null) {
             logger.warn("Unable to read index for " + address);
@@ -480,7 +497,12 @@ public class QuarantineStore
 
         // Read the index file. Remove any mails from the in-memory
         // index which are in our list and add them to a new list
-        InboxIndex inboxIndex = QuarantineStorageManager.readQuarantine(address, getInboxPath(address));
+        String inboxPath = getInboxPath(address);
+        if (inboxPath == null) {
+            addressLock.unlock(address);
+            return new Pair<>(GenericStatus.ERROR);
+        }
+        InboxIndex inboxIndex = QuarantineStorageManager.readQuarantine(address, inboxPath);
 
         if (inboxIndex == null) {
             logger.warn("Unable to purge mails for " + address);
@@ -498,7 +520,7 @@ public class QuarantineStore
 
         // Update the index. We'll defer actual ejection until after we release
         // the lock
-        if (!QuarantineStorageManager.writeQuarantineIndex(address, inboxIndex, getInboxPath(address))) {
+        if (!QuarantineStorageManager.writeQuarantineIndex(address, inboxIndex, inboxPath)) {
             logger.warn("Unable to replace index for address \"" + address + "\".  Abort purge");
             addressLock.unlock(address);
             return new Pair<>(GenericStatus.ERROR);
@@ -545,9 +567,13 @@ public class QuarantineStore
             MailSummary summary)
     {
         // Update (append) to the index
+        String inboxPath = getInboxPath(inboxAddr);
+        if (inboxPath == null) {
+            return false;
+        }
         return QuarantineStorageManager.writeQuarantineRecord(inboxAddr,
                 new InboxRecord(fileNameInInbox, System.currentTimeMillis(), summary, recipients),
-                getInboxPath(inboxAddr));
+                inboxPath);
 
     }
 
@@ -619,13 +645,28 @@ public class QuarantineStore
     }
 
     /**
-     * Return inbox path.
+     * Return inbox path. Returns null if the resolved path escapes the
+     * quarantine inboxes directory (defense-in-depth against path traversal).
      * @param  address String of address.
-     * @return         Path for inbox.
+     * @return         Path for inbox, or null if containment check fails.
      */
     private String getInboxPath(String address)
     {
-        return rootDir.getAbsolutePath() + "/inboxes/" + address;
+        String candidate = rootDir.getAbsolutePath() + "/inboxes/" + address;
+        try {
+            String canonicalCandidate = new File(candidate).getCanonicalPath();
+            String canonicalInboxes = new File(rootDir, "inboxes").getCanonicalPath()
+                + File.separator;
+            if (!canonicalCandidate.startsWith(canonicalInboxes)) {
+                logger.warn("Path traversal blocked: inbox path for address escapes "
+                    + "quarantine directory");
+                return null;
+            }
+            return candidate;
+        } catch (IOException e) {
+            logger.warn("Unable to resolve canonical path for inbox", e);
+            return null;
+        }
     }
 
     /**
@@ -641,7 +682,11 @@ public class QuarantineStore
     {
 
         // RelativeFileName subDirName = m_masterTable.getInboxDir(lcAddress);
-        File baseDir = new File(getInboxPath(lcAddress));
+        String inboxPath = getInboxPath(lcAddress);
+        if (inboxPath == null) {
+            return null;
+        }
+        File baseDir = new File(inboxPath);
         if (!baseDir.exists()) {
             if (!autoCreate) {
                 logger.debug("No inbox for \"" + lcAddress + "\"");
@@ -663,7 +708,11 @@ public class QuarantineStore
     private File getOrCreateInboxDirWL(String lcAddress)
     {
 
-        File baseDir = new File(getInboxPath(lcAddress));
+        String inboxPath = getInboxPath(lcAddress);
+        if (inboxPath == null) {
+            return null;
+        }
+        File baseDir = new File(inboxPath);
 
         try {
             if (!baseDir.exists()) {
@@ -673,7 +722,7 @@ public class QuarantineStore
                 }
                 InboxIndex inboxIndex = new InboxIndex();
                 inboxIndex.setOwnerAddress(lcAddress);
-                QuarantineStorageManager.writeQuarantineIndex(lcAddress, inboxIndex, getInboxPath(lcAddress));
+                QuarantineStorageManager.writeQuarantineIndex(lcAddress, inboxIndex, inboxPath);
                 masterTable.addInbox(lcAddress);
             } else {
                 logger.debug("Inbox for \"" + lcAddress + "\" created by concurrent thread");

--- a/uvm/api/com/untangle/uvm/util/SafeType.java
+++ b/uvm/api/com/untangle/uvm/util/SafeType.java
@@ -271,6 +271,59 @@ public enum SafeType
         "must be an email address like user@example.com , local part must start with a letter or digit, domain must have at least one dot and a 2+ letter TLD (max 254 chars)"),
 
     /**
+     * Backend counterpart of the UI {@code email} vtype
+     * ({@code VTypes.js:111-114}, mask pattern at {@code VTypes.js:12}).
+     *
+     * <p><b>UI vtype:</b> {@code email} &mdash; used on Quarantine Forwards
+     * fields {@code addr1} and {@code addr2} ({@code email.js:986,997}).
+     * The UI mask is negation-based:
+     * {@code [^<>()\[\]\\.,;:\s@"]+} for the local part,
+     * {@code [a-zA-Z\-0-9\*]+} for domain labels (allows {@code *}
+     * for glob matching).</p>
+     *
+     * <p><b>Backend translation:</b> converts the UI negation class to
+     * an equivalent positive allowlist. The leading character allows
+     * {@code [A-Za-z0-9*_+\-]} to match the UI (which accepts
+     * {@code _user@}, {@code +tag@}, {@code -list@} via its
+     * negation class). Characters like {@code !} and {@code #} are
+     * excluded despite the UI accepting them because
+     * {@code SettingsManagerImpl.VALID_CHARACTERS} rejects them in
+     * filenames, causing empty quarantine inbox directories.
+     * IP-literal domains ({@code [1.2.3.4]}) are excluded for the
+     * same reason. Quoted local parts ({@code "foo"@bar.com}) are
+     * rejected to prevent path-traversal in quarantine inbox paths.</p>
+     *
+     * <p><b>Sink contract:</b> values are consumed by
+     * {@code GlobEmailAddressMapper} which converts {@code *} to
+     * {@code .*} for regex matching &mdash; never interpolated into
+     * shell commands.</p>
+     */
+    EMAIL_GLOB(
+        Pattern.compile("^[A-Za-z0-9*_+\\-][A-Za-z0-9._%+*\\-]*@[A-Za-z0-9*][A-Za-z0-9*.-]*\\.[A-Za-z]{2,}$"),
+        254,
+        "must be an email address or glob pattern like *@example.com , local part must start with a letter, digit, *, _, +, or -, domain must have at least one dot and a 2+ letter TLD (max 254 chars)"),
+
+    /**
+     * Backend counterpart of the UI {@code emailwildcard} vtype
+     * ({@code VTypes.js:117-120}).
+     *
+     * <p><b>UI vtype:</b> {@code emailwildcard} &mdash; used on the
+     * Quarantinable Addresses field ({@code email.js:938}).
+     * The UI logic is {@code v == '*' || mask.email.test(v)},
+     * accepting either a bare {@code *} (meaning "quarantine all
+     * addresses") or a full email / glob pattern.</p>
+     *
+     * <p><b>Backend translation:</b> standalone {@code *} <b>or</b>
+     * an email glob pattern identical to {@link #EMAIL_GLOB}.
+     * Same character restrictions apply. See {@link #EMAIL_GLOB}
+     * for details on excluded characters and sink contract.</p>
+     */
+    EMAIL_WILDCARD(
+        Pattern.compile("^(\\*|[A-Za-z0-9*_+\\-][A-Za-z0-9._%+*\\-]*@[A-Za-z0-9*][A-Za-z0-9*.-]*\\.[A-Za-z]{2,})$"),
+        254,
+        "must be a standalone wildcard (*) or an email address / glob pattern like *@example.com (max 254 chars)"),
+
+    /**
      * Username or email-address shape for credentials like PPPoE usernames
      * and dynamic-DNS login IDs. Pattern {@code ^[A-Za-z0-9][A-Za-z0-9._%+@-]*$}
      * -- the conservative subset that covers both plain usernames
@@ -713,6 +766,9 @@ public enum SafeType
             case EMAIL:
             case OAUTH_CODE:
                 return isAsciiAlnum(c);
+            case EMAIL_GLOB:
+            case EMAIL_WILDCARD:
+                return isAsciiAlnum(c) || c == '*' || c == '_' || c == '+' || c == '-';
             case ALPHANUM:
                 return isAsciiAlnum(c) || c == '_';
             case FILE_PATH:
@@ -761,6 +817,9 @@ public enum SafeType
                 // Local part is [A-Za-z0-9._%+-], domain adds nothing more
                 // dangerous; classify at char level only.
                 return isAsciiAlnum(c) || ".-_%+@".indexOf(c) >= 0;
+            case EMAIL_GLOB:
+            case EMAIL_WILDCARD:
+                return isAsciiAlnum(c) || "._+*%-".indexOf(c) >= 0;
             case USERNAME_OR_EMAIL:
                 return isAsciiAlnum(c) || "._-%+@".indexOf(c) >= 0;
             case OAUTH_CODE:

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_email.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_email.py
@@ -223,6 +223,237 @@ class EmailTests(NGFWTestCase):
             assert "Invalid value in" not in str(e), \
                 f"validator unexpectedly rejected a well-formed EMAIL: {e!r}"
 
+    @staticmethod
+    def _get_smtp_app():
+        """Return the smtp app handle, or None if not installed."""
+        try:
+            app = global_functions.uvmContext.appManager().app("smtp")
+            if app is None:
+                return None
+            return app
+        except Exception:
+            return None
+
+    def test_200_quarantine_path_traversal_deleteInbox(self):
+        """Quarantine deleteInbox must reject path-traversal addresses."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        quarantine = smtp_app.getQuarantineMaintenenceView()
+        traversal_addresses = [
+            "../../../etc/passwd",
+            "../../shadow",
+            "user@example.com/../../etc",
+            "user\\..\\..\\windows",
+        ]
+        for addr in traversal_addresses:
+            with pytest.raises(Exception):
+                quarantine.deleteInbox(addr)
+
+    def test_210_quarantine_path_traversal_getInboxRecords(self):
+        """Quarantine getInboxRecords must reject path-traversal addresses."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        quarantine = smtp_app.getQuarantineUserView()
+        traversal_addresses = [
+            "../../../etc/passwd",
+            "..%2f..%2fetc/shadow",
+            "evil/../../../root",
+        ]
+        for addr in traversal_addresses:
+            with pytest.raises(Exception):
+                quarantine.getInboxRecords(addr)
+
+    def test_220_quarantine_path_traversal_purge(self):
+        """Quarantine purge must reject path-traversal account addresses."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        quarantine = smtp_app.getQuarantineUserView()
+        with pytest.raises(Exception):
+            quarantine.purge("../../etc/passwd", ["fake-mail-id"])
+
+    def test_230_quarantine_path_traversal_rescue(self):
+        """Quarantine rescue must reject path-traversal account addresses."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        quarantine = smtp_app.getQuarantineUserView()
+        with pytest.raises(Exception):
+            quarantine.rescue("../../etc/shadow", ["fake-mail-id"])
+
+    def test_240_quarantine_control_char_rejection(self):
+        """Quarantine must reject addresses containing control characters."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        quarantine = smtp_app.getQuarantineMaintenenceView()
+        control_char_addresses = [
+            "user\x00@example.com",
+            "user\n@example.com",
+            "user\t@example.com",
+        ]
+        for addr in control_char_addresses:
+            with pytest.raises(Exception):
+                quarantine.deleteInbox(addr)
+
+    def test_250_quarantine_slash_rejection(self):
+        """Quarantine must reject addresses with slashes even without '..'."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        quarantine = smtp_app.getQuarantineMaintenenceView()
+        with pytest.raises(Exception):
+            quarantine.deleteInbox("user/subdir@example.com")
+        with pytest.raises(Exception):
+            quarantine.deleteInbox("user\\subdir@example.com")
+
+    def test_260_quarantine_valid_address_accepted(self):
+        """Quarantine operations with valid addresses must not be blocked
+        by the security validator (they may raise NoSuchInboxException which
+        is the expected non-security error)."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        quarantine = smtp_app.getQuarantineMaintenenceView()
+        valid_addresses = [
+            "user@example.com",
+            "admin+tag@test.example.org",
+            "dotted.name@company.co.uk",
+            "_user@example.com",
+            "+tag@example.com",
+            "-list@example.com",
+            "user_name@example.com",
+            "user%tag@example.com",
+        ]
+        for addr in valid_addresses:
+            try:
+                quarantine.deleteInbox(addr)
+            except Exception as e:
+                err = str(e)
+                assert "Invalid" not in err and "path traversal" not in err.lower(), \
+                    f"valid address '{addr}' wrongly rejected by security validator: {e!r}"
+
+    def test_270_quarantine_remap_traversal(self):
+        """Quarantine remapSelfService must reject path-traversal targets."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        quarantine = smtp_app.getQuarantineUserView()
+        with pytest.raises(Exception):
+            quarantine.remapSelfService("legit@example.com", "../../../etc/passwd")
+
+    def test_300_safecheck_email_address_rule_injection(self):
+        """@SafeCheck(EMAIL_WILDCARD) on EmailAddressRule must reject
+        addresses with shell metacharacters not in the allowed charset."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        settings = smtp_app.getSmtpSettings()
+        orig_settings = copy.deepcopy(settings)
+        try:
+            injections = [
+                "admin;rm -rf /@example.com",
+                "user$(id)@example.com",
+                "../../../etc/passwd",
+            ]
+            for injection_addr in injections:
+                settings = copy.deepcopy(orig_settings)
+                settings['quarantineSettings']['allowedAddressPatterns'] = {
+                    "javaClass": "java.util.LinkedList",
+                    "list": [{
+                        "javaClass": "com.untangle.app.smtp.EmailAddressRule",
+                        "addr": injection_addr
+                    }]
+                }
+                with pytest.raises(Exception):
+                    smtp_app.setSmtpSettings(settings)
+        finally:
+            smtp_app.setSmtpSettings(orig_settings)
+
+    def test_310_safecheck_email_address_rule_valid(self):
+        """@SafeCheck(EMAIL_WILDCARD) must accept valid wildcard addresses."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        settings = smtp_app.getSmtpSettings()
+        orig_settings = copy.deepcopy(settings)
+        try:
+            valid_addrs = [
+                "*",
+                "*@example.com",
+                "*@hhs.com",
+                "*@*.com",
+                "admin@example.org",
+                "_user@example.com",
+                "+tag@example.com",
+                "-list@example.com",
+            ]
+            for valid_addr in valid_addrs:
+                settings = copy.deepcopy(orig_settings)
+                settings['quarantineSettings']['allowedAddressPatterns'] = {
+                    "javaClass": "java.util.LinkedList",
+                    "list": [{
+                        "javaClass": "com.untangle.app.smtp.EmailAddressRule",
+                        "addr": valid_addr
+                    }]
+                }
+                try:
+                    smtp_app.setSmtpSettings(settings)
+                except Exception as e:
+                    assert "Invalid value in" not in str(e), \
+                        f"valid wildcard address '{valid_addr}' rejected: {e!r}"
+        finally:
+            smtp_app.setSmtpSettings(orig_settings)
+
+    def test_315_safecheck_email_pair_rule_valid(self):
+        """@SafeCheck(EMAIL_GLOB) on EmailAddressPairRule must accept valid
+        email and glob addresses in quarantine forwards."""
+        smtp_app = self._get_smtp_app()
+        if smtp_app is None:
+            raise unittest.SkipTest("smtp app not installed")
+
+        settings = smtp_app.getSmtpSettings()
+        orig_settings = copy.deepcopy(settings)
+        try:
+            valid_pairs = [
+                ("user@example.com", "admin@example.com"),
+                ("*@example.com", "admin@example.com"),
+                ("*@hhs.com", "admin@example.com"),
+                ("*@*.com", "admin@example.com"),
+                ("_user@example.com", "admin@example.com"),
+                ("+tag@example.com", "admin@example.com"),
+                ("-list@example.com", "admin@example.com"),
+            ]
+            for addr1, addr2 in valid_pairs:
+                settings = copy.deepcopy(orig_settings)
+                settings['quarantineSettings']['addressRemaps'] = {
+                    "javaClass": "java.util.LinkedList",
+                    "list": [{
+                        "javaClass": "com.untangle.app.smtp.EmailAddressPairRule",
+                        "address1": addr1,
+                        "address2": addr2
+                    }]
+                }
+                try:
+                    smtp_app.setSmtpSettings(settings)
+                except Exception as e:
+                    assert "Invalid value in" not in str(e), \
+                        f"valid forward pair ('{addr1}', '{addr2}') rejected: {e!r}"
+        finally:
+            smtp_app.setSmtpSettings(orig_settings)
+
     @classmethod
     def final_extra_tear_down(cls):
         if EmailTests.original_mail_settings is not None:


### PR DESCRIPTION
Quarantine inbox directories are derived from email addresses without sanitization, allowing crafted addresses with ".." or "/" to write files outside the quarantine root. Add defense-in-depth validation atthe store, API, and servlet layers, and annotate config model fields with @SafeCheck to enforce email format on JSON-RPC input.

## Summary

- Add `QuarantineAddressValidator` to reject email addresses containing
  path traversal sequences (`..`), directory separators (`/`, `\`), and
  control characters before they reach the filesystem
- Harden `QuarantineStore.getInboxPath()` with canonical-path containment
  check as defense-in-depth — returns null if the resolved path escapes
  the quarantine inboxes directory
- Add null-safety for all `getInboxPath()` call sites to gracefully fail
  instead of creating directories outside the quarantine root
- Validate account address in `Quarantine` public API methods (`purge`,
  `rescue`, `getInboxIndex`, `deleteInbox`, `getAccountFromToken`,
  `remapSelfService`) and in `JsonInterfaceImpl` servlet
- Validate addresses during `MasterTable.visit()` directory scan to skip
  any existing inbox directories with suspicious names
- Add `@SafeCheck(SafeType.EMAIL_GLOB)` to `EmailAddressPairRule.addr1/addr2`
  and `@SafeCheck(SafeType.EMAIL_WILDCARD)` to `EmailAddressRule.addr` to
  enforce email format validation on quarantine forwards and quarantinable
  address config via JSON-RPC
- Add `EMAIL_GLOB` and `EMAIL_WILDCARD` SafeType variants supporting `*`
  glob patterns for address-matching rules
- Add upgrade script in `postinst` to archive (not delete) any existing
  inbox directories with path-traversal names to `inboxes-archive/`

## Known limitation

`EMAIL_GLOB` allows RFC 5321 atext characters (e.g. `!#$%&'`) that
`SettingsManagerImpl.VALID_CHARACTERS` does not accept in filenames.
Addresses like `jack!@test.com` pass input validation but fail when the
quarantine store writes the inbox index through `SettingsManager.save()`,
resulting in an empty inbox directory. This is a pre-existing issue — not
introduced by this change. A follow-up ticket should either widen
`VALID_CHARACTERS` for quarantine paths or tighten `EMAIL_GLOB` to the
intersection of RFC atext and `VALID_CHARACTERS`.

<img width="763" height="522" alt="Screenshot from 2026-06-29 18-25-44" src="https://github.com/user-attachments/assets/c2d27ac6-b979-417a-b4e3-e6796f53e6e4" />
