### PR TITLE
NGFW-15862: prune old devices.js version files to prevent disk exhaustion

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/unit_tests/test_settings_version_pruning.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/unit_tests/test_settings_version_pruning.py
@@ -1,0 +1,226 @@
+import os
+import tempfile
+import unittest
+
+
+MAX_VERSION_FILES = 20
+DEVICES_FILE_NAME = "devices.js"
+
+VERSION_PATTERN = "{base}-version-{timestamp}{ext}"
+
+TIMESTAMPS = [
+    "2026-01-01-000000.000",
+    "2026-01-02-000000.000",
+    "2026-01-03-000000.000",
+    "2026-01-04-000000.000",
+    "2026-01-05-000000.000",
+    "2026-01-06-000000.000",
+    "2026-01-07-000000.000",
+    "2026-01-08-000000.000",
+    "2026-01-09-000000.000",
+    "2026-01-10-000000.000",
+    "2026-01-11-000000.000",
+    "2026-01-12-000000.000",
+    "2026-01-13-000000.000",
+    "2026-01-14-000000.000",
+    "2026-01-15-000000.000",
+    "2026-01-16-000000.000",
+    "2026-01-17-000000.000",
+    "2026-01-18-000000.000",
+    "2026-01-19-000000.000",
+    "2026-01-20-000000.000",
+    "2026-01-21-000000.000",
+    "2026-01-22-000000.000",
+    "2026-01-23-000000.000",
+    "2026-01-24-000000.000",
+    "2026-01-25-000000.000",
+]
+
+
+def should_prune(file_name):
+    """Check if this settings file is subject to version pruning."""
+    return file_name.endswith(DEVICES_FILE_NAME)
+
+
+def prune_old_versions(file_name, max_versions=MAX_VERSION_FILES):
+    """
+    Python equivalent of SettingsManagerImpl._pruneOldVersions().
+    Prunes old versioned settings files, keeping only the most recent max_versions.
+    Only called for devices.js (checked by caller via should_prune()).
+    """
+    base_file = os.path.basename(file_name)
+    parent_dir = os.path.dirname(file_name)
+
+    if not parent_dir or not os.path.isdir(parent_dir):
+        return 0
+
+    prefix = base_file + "-version-"
+
+    version_files = sorted(
+        f for f in os.listdir(parent_dir)
+        if f.startswith(prefix)
+    )
+
+    if len(version_files) <= max_versions:
+        return 0
+
+    delete_count = len(version_files) - max_versions
+    for f in version_files[:delete_count]:
+        os.remove(os.path.join(parent_dir, f))
+
+    return delete_count
+
+
+def create_version_files(directory, base_name, ext, timestamps):
+    """Helper to create mock versioned settings files."""
+    created = []
+    for ts in timestamps:
+        name = VERSION_PATTERN.format(base=base_name, timestamp=ts, ext=ext)
+        path = os.path.join(directory, name)
+        with open(path, 'w') as f:
+            f.write("test content for " + ts)
+        created.append(name)
+    return created
+
+
+class TestSettingsVersionPruning(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.base_name = "devices.js"
+        self.file_name = os.path.join(self.tmpdir, self.base_name)
+
+    def tearDown(self):
+        for f in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, f))
+        os.rmdir(self.tmpdir)
+
+    def _list_version_files(self):
+        prefix = self.base_name + "-version-"
+        return sorted(
+            f for f in os.listdir(self.tmpdir)
+            if f.startswith(prefix)
+        )
+
+    def test_prune_over_limit(self):
+        """When version count exceeds MAX_VERSION_FILES, oldest are deleted."""
+        create_version_files(self.tmpdir, self.base_name, ".js", TIMESTAMPS[:25])
+        self.assertEqual(len(self._list_version_files()), 25)
+
+        deleted = prune_old_versions(self.file_name)
+
+        remaining = self._list_version_files()
+        self.assertEqual(len(remaining), MAX_VERSION_FILES)
+        self.assertEqual(deleted, 5)
+        for f in remaining:
+            self.assertNotIn("2026-01-01", f)
+            self.assertNotIn("2026-01-02", f)
+            self.assertNotIn("2026-01-03", f)
+            self.assertNotIn("2026-01-04", f)
+            self.assertNotIn("2026-01-05", f)
+
+    def test_no_prune_under_limit(self):
+        """When version count is under MAX_VERSION_FILES, nothing is deleted."""
+        create_version_files(self.tmpdir, self.base_name, ".js", TIMESTAMPS[:5])
+        self.assertEqual(len(self._list_version_files()), 5)
+
+        deleted = prune_old_versions(self.file_name)
+
+        self.assertEqual(len(self._list_version_files()), 5)
+        self.assertEqual(deleted, 0)
+
+    def test_no_prune_at_limit(self):
+        """When version count equals MAX_VERSION_FILES, nothing is deleted."""
+        create_version_files(self.tmpdir, self.base_name, ".js", TIMESTAMPS[:MAX_VERSION_FILES])
+        self.assertEqual(len(self._list_version_files()), MAX_VERSION_FILES)
+
+        deleted = prune_old_versions(self.file_name)
+
+        self.assertEqual(len(self._list_version_files()), MAX_VERSION_FILES)
+        self.assertEqual(deleted, 0)
+
+    def test_empty_directory(self):
+        """No version files — should handle gracefully."""
+        deleted = prune_old_versions(self.file_name)
+        self.assertEqual(deleted, 0)
+
+    def test_symlink_preserved(self):
+        """The base symlink should not be touched during pruning."""
+        create_version_files(self.tmpdir, self.base_name, ".js", TIMESTAMPS[:25])
+        latest = VERSION_PATTERN.format(
+            base=self.base_name, timestamp=TIMESTAMPS[24], ext=".js"
+        )
+        os.symlink(
+            "./" + latest,
+            self.file_name
+        )
+        self.assertTrue(os.path.islink(self.file_name))
+
+        prune_old_versions(self.file_name)
+
+        self.assertTrue(os.path.islink(self.file_name))
+        self.assertTrue(os.path.exists(self.file_name))
+        remaining = self._list_version_files()
+        self.assertEqual(len(remaining), MAX_VERSION_FILES)
+        self.assertIn(latest, remaining)
+
+    def test_mixed_settings_files(self):
+        """Version files for different settings should not interfere."""
+        create_version_files(self.tmpdir, self.base_name, ".js", TIMESTAMPS[:25])
+        create_version_files(self.tmpdir, "network.js", ".js", TIMESTAMPS[:10])
+
+        prune_old_versions(self.file_name)
+
+        devices_remaining = self._list_version_files()
+        self.assertEqual(len(devices_remaining), MAX_VERSION_FILES)
+
+        network_prefix = "network.js-version-"
+        network_remaining = [
+            f for f in os.listdir(self.tmpdir)
+            if f.startswith(network_prefix)
+        ]
+        self.assertEqual(len(network_remaining), 10)
+
+    def test_newest_files_kept(self):
+        """Verify that the newest files are the ones kept after pruning."""
+        create_version_files(self.tmpdir, self.base_name, ".js", TIMESTAMPS[:25])
+
+        prune_old_versions(self.file_name)
+
+        remaining = self._list_version_files()
+        expected_timestamps = TIMESTAMPS[5:25]
+        for ts in expected_timestamps:
+            expected_name = VERSION_PATTERN.format(
+                base=self.base_name, timestamp=ts, ext=".js"
+            )
+            self.assertIn(expected_name, remaining)
+
+    def test_invalid_directory(self):
+        """Non-existent directory should not raise."""
+        deleted = prune_old_versions("/nonexistent/path/devices.js")
+        self.assertEqual(deleted, 0)
+
+    def test_only_devices_js_eligible(self):
+        """Only devices.js should be eligible for pruning."""
+        self.assertTrue(should_prune("/usr/share/untangle/settings/untangle-vm/devices.js"))
+        self.assertFalse(should_prune("/usr/share/untangle/settings/untangle-vm/network.js"))
+        self.assertFalse(should_prune("/usr/share/untangle/settings/untangle-vm/admin.js"))
+        self.assertFalse(should_prune("/usr/share/untangle/settings/untangle-vm/events.js"))
+
+    def test_non_devices_not_pruned(self):
+        """Non-devices.js files should not be pruned even if over limit."""
+        create_version_files(self.tmpdir, "network.js", ".js", TIMESTAMPS[:25])
+        network_file = os.path.join(self.tmpdir, "network.js")
+
+        self.assertFalse(should_prune(network_file))
+
+        network_prefix = "network.js-version-"
+        network_files = [
+            f for f in os.listdir(self.tmpdir)
+            if f.startswith(network_prefix)
+        ]
+        self.assertEqual(len(network_files), 25)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uvm/impl/com/untangle/uvm/SettingsManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SettingsManagerImpl.java
@@ -17,6 +17,7 @@ import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -80,6 +81,17 @@ public class SettingsManagerImpl implements SettingsManager
     public static final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd-HHmmss.SSS");
 
     public static final int MAX_DIFF_SIZE = 5242880;
+
+    /**
+     * Maximum number of versioned settings files to retain for devices.js.
+     * Older versions beyond this limit are automatically pruned on each save.
+     */
+    public static final int MAX_VERSION_FILES = 20;
+
+    /**
+     * Settings file subject to version pruning due to high save frequency.
+     */
+    private static final String DEVICES_FILE_NAME = "devices.js";
 
     /**
      * This is the actual JSON serializer
@@ -616,8 +628,12 @@ public class SettingsManagerImpl implements SettingsManager
             //old way
             //String linkCmd = "ln -sf ./"+filename + " " + link.toString();
             //UvmContextImpl.context().execManager().exec(linkCmd);
+
+            if ( fileName.endsWith( DEVICES_FILE_NAME ) ) {
+                _pruneOldVersions( fileName );
+            }
         }
-        
+
     }
 
     /**
@@ -682,6 +698,45 @@ public class SettingsManagerImpl implements SettingsManager
         }
 
         return null;
+    }
+
+    /**
+     * Prune old versioned settings files, keeping only the most recent MAX_VERSION_FILES.
+     * Versioned files use the naming pattern: {baseName}-version-{timestamp}{extension}
+     * where the timestamp format (yyyy-MM-dd-HHmmss.SSS) sorts chronologically.
+     *
+     * @param fileName
+     *          The base settings file path (e.g., /usr/share/.../devices.js)
+     */
+    private void _pruneOldVersions( String fileName )
+    {
+        try {
+            File baseFile = new File( fileName );
+            File parentDir = baseFile.getParentFile();
+            if ( parentDir == null || !parentDir.isDirectory() ) {
+                return;
+            }
+
+            String baseName = baseFile.getName();
+            String prefix = baseName + "-version-";
+
+            File[] versionFiles = parentDir.listFiles( (dir, name) -> name.startsWith( prefix ) );
+            if ( versionFiles == null || versionFiles.length <= MAX_VERSION_FILES ) {
+                return;
+            }
+
+            Arrays.sort( versionFiles, (a, b) -> a.getName().compareTo( b.getName() ) );
+
+            int deleteCount = versionFiles.length - MAX_VERSION_FILES;
+            for ( int i = 0; i < deleteCount; i++ ) {
+                if ( !versionFiles[i].delete() ) {
+                    logger.warn( "Failed to prune old version file: " + versionFiles[i].getAbsolutePath() );
+                }
+            }
+            logger.info( "Pruned " + deleteCount + " old version(s) of " + baseName + ", kept " + MAX_VERSION_FILES );
+        } catch ( Exception e ) {
+            logger.warn( "Failed to prune old version files for: " + fileName, e );
+        }
     }
 
     /**


### PR DESCRIPTION
SettingsManagerImpl retains every versioned settings file indefinitely. DeviceTableImpl saves devices.js 15-20+ times/day on busy networks with MAC-randomized clients, causing unbounded disk growth (observed 9.8G on one device, 59.8G on another). Add _pruneOldVersions() to automatically delete all but the most recent 20 versions of devices.js after each save.