### PR TITLE
ngfw-15854: Fixed Branding Manager contactEmail/contactName Stored XSS into Block Pages

### DIFF
--- a/branding-manager/hier/usr/lib/python3/dist-packages/tests/test_branding_manager.py
+++ b/branding-manager/hier/usr/lib/python3/dist-packages/tests/test_branding_manager.py
@@ -112,6 +112,54 @@ class BrandingManagerTests(NGFWTestCase):
         assert(default_company_url in matchText)
         
     @pytest.mark.failure_behind_ngfw
+    def test_019_xss_contactEmail_rejected(self):
+        """UNT-41: @SafeCheck(EMAIL) must reject XSS payload in contactEmail"""
+        global app, appData
+        saved_email = appData['contactEmail']
+        xss_payload = 'x"></a><img/src/onerror=document.title="XSS41"><a href="'
+        appData['contactEmail'] = xss_payload
+        try:
+            app.setSettings(appData)
+            assert False, "setSettings should have rejected XSS in contactEmail"
+        except Exception:
+            pass
+        finally:
+            appData['contactEmail'] = saved_email
+
+    @pytest.mark.failure_behind_ngfw
+    def test_019_xss_contactName_rejected(self):
+        """UNT-41: @SafeCheck(NATURAL_NAME) must reject XSS payload in contactName"""
+        global app, appData
+        saved_name = appData['contactName']
+        xss_payload = '<script>alert("XSS")</script>'
+        appData['contactName'] = xss_payload
+        try:
+            app.setSettings(appData)
+            assert False, "setSettings should have rejected XSS in contactName"
+        except Exception:
+            pass
+        finally:
+            appData['contactName'] = saved_name
+
+    @pytest.mark.failure_behind_ngfw
+    def test_019_valid_contact_renders_on_blockpage(self):
+        """UNT-41: Valid contactEmail/contactName render correctly on block page"""
+        global app, appData
+        saved_email = appData['contactEmail']
+        saved_name = appData['contactName']
+        appData['contactEmail'] = "security@example.com"
+        appData['contactName'] = "John O'Brien"
+        try:
+            app.setSettings(appData)
+            result = remote_control.run_command(global_functions.build_wget_command(output_file="-", ignore_certificate=True, all_parameters=True, uri="www.playboy.com"), stdout=True)
+            assert "security@example.com" in result, "Valid email not found on block page"
+            assert "John O" in result, "Valid contact name not found on block page"
+        finally:
+            appData['contactEmail'] = saved_email
+            appData['contactName'] = saved_name
+            app.setSettings(appData)
+
+    @pytest.mark.failure_behind_ngfw
     def test_020_check_login_page_branding(self):
         # Check login page for branding
         result = remote_control.run_command(global_functions.build_wget_command(output_file="-", ignore_certificate=True, all_parameters=True, uri=global_functions.get_http_url()),stdout=True)

--- a/branding-manager/src/com/untangle/app/branding_manager/BrandingManagerSettings.java
+++ b/branding-manager/src/com/untangle/app/branding_manager/BrandingManagerSettings.java
@@ -6,6 +6,9 @@ package com.untangle.app.branding_manager;
 import java.io.Serializable;
 
 import com.untangle.uvm.util.I18nUtil;
+import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
+import com.untangle.uvm.StringEscaperUtil;
 import org.json.JSONObject;
 import org.json.JSONString;
 
@@ -21,7 +24,9 @@ public class BrandingManagerSettings implements Serializable, JSONString
     private byte[] logo = null;
     private String companyName = DEFAULT_COMPANY_NAME;
     private String companyUrl = DEFAULT_COMPANY_URL;
+    @SafeCheck(SafeType.NATURAL_NAME)
     private String contactName = I18nUtil.marktr(DEFAULT_CONTACT_NAME);
+    @SafeCheck(SafeType.EMAIL)
     private String contactEmail = "";
     private boolean defaultLogo = true;
     private String bannerMessage = "";
@@ -122,9 +127,11 @@ public class BrandingManagerSettings implements Serializable, JSONString
     public String grabContactHtml()
     {
         if (null != contactEmail && !contactEmail.trim().equals("")) {
-            return "<a href='mailto:" + contactEmail + "'>" + contactName + "</a>";
+            String safeEmail = StringEscaperUtil.escapeHtml4(contactEmail);
+            String safeName  = StringEscaperUtil.escapeHtml4(contactName != null ? contactName : "");
+            return "<a href=\"mailto:" + safeEmail + "\">" + safeName + "</a>";
         } else {
-            return contactName;
+            return StringEscaperUtil.escapeHtml4(contactName != null ? contactName : "");
         }
     }
 

--- a/http-casing/src/com/untangle/app/http/BlockPageUtil.java
+++ b/http-casing/src/com/untangle/app/http/BlockPageUtil.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.LogManager;
 import com.untangle.uvm.BrandingManager;
 import com.untangle.uvm.UvmContext;
 import com.untangle.uvm.UvmContextFactory;
+import com.untangle.uvm.StringEscaperUtil;
 import com.untangle.uvm.util.I18nUtil;
 
 /**
@@ -86,7 +87,9 @@ public class BlockPageUtil
             } catch (java.io.UnsupportedEncodingException exc) {
                 logger.warn("unsupported encoding", exc);
             }
-            contactHtml = "<a href='mailto:" + bm.getContactEmail() + "?subject=" + emailSubject + "&body=" + emailBody + "'>" + bm.getContactName() + "</a>";
+            String safeEmail = StringEscaperUtil.escapeHtml4(bm.getContactEmail());
+            String safeName  = StringEscaperUtil.escapeHtml4(bm.getContactName() != null ? bm.getContactName() : "");
+            contactHtml = "<a href=\"mailto:" + safeEmail + "?subject=" + emailSubject + "&body=" + emailBody + "\">" + safeName + "</a>";
         }
 
         request.setAttribute( "contact", I18nUtil.tr("If you have any questions, Please contact {0}.", contactHtml, i18n_map));


### PR DESCRIPTION

**Vulnerability**
Admin-controlled branding fields contactEmail and contactName are injected as raw HTML into every block page served to unauthenticated LAN users. There are two independent injection points — one in the POJO settings class and one in the block page servlet utility:

Injection Point 1 — BrandingManagerSettings.grabContactHtml() (line 125):

return "<a href='mailto:" + contactEmail + "'>" + contactName + "</a>";
Used when block pages call bm.grabContactHtml() directly.

Injection Point 2 — BlockPageUtil.handle() (line 89):

contactHtml = "<a href='mailto:" + bm.getContactEmail() + "?subject=" + emailSubject + "&body=" + emailBody + "'>" + bm.getContactName() + "</a>";

This is the primary block page rendering path — every Web Filter, Threat Prevention, Virus Blocker, and Captive Portal block page goes through BlockPageUtil.handle(). It reads contactEmail and contactName from BrandingManager and concatenates them into raw HTML with no escaping. Both injection points use single-quoted attribute delimiters.

**Impact:** 
Admin sets the malicious value once via Config → Branding Manager → setSettings. The XSS payload then fires in the browser of every user who views any block page — including unauthenticated LAN users, captive-portal users, and end users hitting Web Filter blocks. Compromised-admin or insider-threat scenarios make this realistic.


**Root Cause**
No HTML escaping on either field before concatenation into HTML at both injection points
No input validation (@SafeCheck) on either POJO field at the JSON-RPC boundary
Single-quoted attribute delimiter (href='...') — escapeHtml4() does not escape single quotes, so even with escaping the attribute context would remain breakable without switching delimiters

**Fix Applied**

**File 1:** branding-manager/src/com/untangle/app/branding_manager/BrandingManagerSettings.java

**Defense-in-depth input validation (field annotations):**

- **@SafeCheck(SafeType.EMAIL) on contactEmail** — only accepts RFC 5321-style email addresses (user@domain.tld); XSS payloads cannot match this pattern. Rejects at the JSON-RPC boundary before the value is ever stored.
- **@SafeCheck(SafeType.NATURAL_NAME) on contactName** — allows Unicode letters, digits, spaces, and safe punctuation including apostrophes (for names like O'Brien, Smith & Co) but blocks <, >, ", $, ;, |, \, backtick, and newlines. Chosen over SIMPLE_TEXT because SIMPLE_TEXT rejects apostrophes, which are common in real contact names.
- grabContactHtml() rewritten (lines 127-136):
- **Both fields escaped via StringEscaperUtil.escapeHtml4()** — converts " → &quot;, & → &amp;, < → &lt;, > → &gt;
- Attribute quoting switched from single-quote to double-quote — so escapeHtml4's &quot; encoding covers the attribute delimiter context
- **Null contactName handled gracefully** — returns empty string instead of literal "null"
- **else branch also escapes contactName** — previously a contactName containing <script> would inject directly even without an email set


**File 2:** http-casing/src/com/untangle/app/http/BlockPageUtil.java
Import added: StringEscaperUtil

handle() method contact HTML construction rewritten (lines 90-92):

- Both bm.getContactEmail() and bm.getContactName() escaped via StringEscaperUtil.escapeHtml4() before concatenation
- Attribute quoting switched from single-quote to double-quote
- Null contactName handled gracefully
- emailSubject and emailBody are already URL-encoded via URLEncoder.encode() (safe in attribute context)

**Regression Risk: None**
- escapeHtml4() is a no-op on normal email addresses (security@acme.com contains no escapable chars)
- Normal names like John O'Brien pass through unchanged (' is not in the escape map)
- Switching ' to " around href is standard HTML — all browsers handle it identically
- Names with & (e.g. Smith & Co) now correctly render as Smith &amp; Co — this was actually a latent HTML bug before
- NATURAL_NAME accepts all characters that real-world contact names use; EMAIL accepts all valid email formats
- emailSubject and emailBody in BlockPageUtil were already URL-encoded and remain unchanged
- Null contactName now renders as empty string instead of "null"

<img width="811" height="684" alt="Screenshot from 2026-07-01 15-21-58" src="https://github.com/user-attachments/assets/37afad24-7a95-4cba-936d-1781f1c79814" />
