### PR TITLE
NGFW-15875: broaden notification HTML whitelist for license server me…

### DIFF
--- a/uvm/servlets/admin/app/view/main/MainController.js
+++ b/uvm/servlets/admin/app/view/main/MainController.js
@@ -61,7 +61,10 @@ Ext.define('Ung.view.main.MainController', {
                 for (i = 0; i < result.list.length; i += 1) {
                     var safe = Ext.String.htmlEncode(result.list[i]);
                     safe = safe.replace(/&lt;br\/&gt;/g, '<br/>');
-                    safe = safe.replace(/&lt;a href=&#39;(\/admin\/[^&]*)&#39;&gt;(.*?)&lt;\/a&gt;/g, '<a href="$1">$2</a>');
+                    safe = safe.replace(/&lt;strong&gt;/g, '<strong>');
+                    safe = safe.replace(/&lt;\/strong&gt;/g, '</strong>');
+                    safe = safe.replace(/&lt;a href=&quot;((?:\/[^&]*|https:\/\/[a-zA-Z0-9.-]+\.arista\.com\/[^&]*)?)&quot;(?:\s*target=&quot;_blank&quot;)?&gt;(.*?)&lt;\/a&gt;/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$2</a>');
+                    safe = safe.replace(/&lt;a href=&#39;((?:\/[^&]*|https:\/\/[a-zA-Z0-9.-]+\.arista\.com\/[^&]*)?)&#39;(?:\s*target=&#39;_blank&#39;)?&gt;(.*?)&lt;\/a&gt;/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$2</a>');
                     notificationArr += '<li>' + safe + '</li>';
                 }
                 notificationArr += '</ul>';

--- a/uvm/servlets/admin/app/widget/Notifications.js
+++ b/uvm/servlets/admin/app/widget/Notifications.js
@@ -53,7 +53,10 @@ Ext.define('Ung.widget.Notifications', {
                     for (i = 0; i < result.list.length; i += 1) {
                         var safe = Ext.String.htmlEncode(result.list[i]);
                         safe = safe.replace(/&lt;br\/&gt;/g, '<br/>');
-                        safe = safe.replace(/&lt;a href=&#39;(\/admin\/[^&]*)&#39;&gt;(.*?)&lt;\/a&gt;/g, '<a href="$1">$2</a>');
+                        safe = safe.replace(/&lt;strong&gt;/g, '<strong>');
+                        safe = safe.replace(/&lt;\/strong&gt;/g, '</strong>');
+                        safe = safe.replace(/&lt;a href=&quot;((?:\/[^&]*|https:\/\/[a-zA-Z0-9.-]+\.arista\.com\/[^&]*)?)&quot;(?:\s*target=&quot;_blank&quot;)?&gt;(.*?)&lt;\/a&gt;/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$2</a>');
+                        safe = safe.replace(/&lt;a href=&#39;((?:\/[^&]*|https:\/\/[a-zA-Z0-9.-]+\.arista\.com\/[^&]*)?)&#39;(?:\s*target=&#39;_blank&#39;)?&gt;(.*?)&lt;\/a&gt;/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$2</a>');
                         notificationArr += '<li>' + safe + '</li>';
                     }
                     notificationArr += '</ul>';


### PR DESCRIPTION
…ssages

The NGFW-15836 XSS fix added htmlEncode + regex whitelist to the notification widget, but the regex only matched single-quoted <a> tags with /admin/ paths. License server userMessages and LicenseManagerImpl use double-quoted hrefs, https://edge.arista.com URLs, target="_blank", and <strong> tags — all of which were rendered as raw HTML text.

Broaden the whitelist in both MainController.js and Notifications.js:
- Support both single-quoted and double-quoted href attributes
- Allow local paths (/admin/...) and *.arista.com HTTPS URLs
- Allow <strong>/<br/> tags
- Handle optional target="_blank" attribute
- Add rel="noopener noreferrer" on all target="_blank" links
- Block javascript:/data:/vbscript: and non-arista external URLs