### PR TITLE
NGFW-15850: Fix path traversal vulnerability in SettingsManager save RPC endpoint

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -989,7 +989,7 @@ class UvmTests(NGFWTestCase):
         by @SafeCheck at the JSON-RPC boundary BEFORE refreshHostsFile() runs.
 
         REWRITTEN for NGFW-15741: NetworkSettings.hostName is annotated
-        @SafeCheck(SafeType.HOSTNAME) — the regex rejects ';', spaces, and every
+        @SafeCheck(SafeType.HOSTNAME) - the regex rejects ';', spaces, and every
         shell metacharacter. setNetworkSettings raises SafeCheckValidationException
         (JSON-RPC code 490) at the preInvokeCallback. The malicious hostname never
         reaches the on-disk hosts file or refreshHostsFile()'s exec sink.
@@ -1016,7 +1016,7 @@ class UvmTests(NGFWTestCase):
             # exec path is exercised and the sentinel check below will catch it.
             subprocess.call(f"mkdir -p /var/lib/interface-status && touch {status_file}", shell=True)
 
-            # Layer 1 — typed @SafeCheck must reject at the RPC boundary.
+            # Layer 1 - typed @SafeCheck must reject at the RPC boundary.
             with pytest.raises(Exception):
                 global_functions.uvmContext.networkManager().setNetworkSettings(malicious_settings)
         finally:
@@ -1024,7 +1024,7 @@ class UvmTests(NGFWTestCase):
             global_functions.uvmContext.networkManager().setNetworkSettings(orig_netsettings)
 
         time.sleep(1)
-        # Layer 2 defense-in-depth — even if layer 1 was bypassed somehow,
+        # Layer 2 defense-in-depth - even if layer 1 was bypassed somehow,
         # execCommand(argv) in refreshHostsFile() must not shell-expand.
         assert not os.path.exists(poc_file), \
             "Command injection succeeded via HostsFileManagerImpl.refreshHostsFile() (sentinel file was created)"
@@ -1286,7 +1286,7 @@ class UvmTests(NGFWTestCase):
         runs its DNS probe.
 
         REWRITTEN for NGFW-15741: UriManagerSettings.dnsTestHost is annotated
-        @SafeCheck(SafeType.HOSTNAME) — the regex rejects ';', space, and every
+        @SafeCheck(SafeType.HOSTNAME) - the regex rejects ';', space, and every
         shell metacharacter. uriManager().setSettings raises
         SafeCheckValidationException at the preInvokeCallback before the value
         is stored. The connectivity-tester probe never sees the malicious host.
@@ -1304,11 +1304,11 @@ class UvmTests(NGFWTestCase):
             malicious_uri_settings = copy.deepcopy(orig_uri_settings)
             malicious_uri_settings['dnsTestHost'] = "updates.edge.arista.com; touch " + poc_file
 
-            # Layer 1 — typed @SafeCheck must reject at the RPC boundary.
+            # Layer 1 - typed @SafeCheck must reject at the RPC boundary.
             with pytest.raises(Exception):
                 global_functions.uvmContext.uriManager().setSettings(malicious_uri_settings)
 
-            # Defense-in-depth — exercise the connectivity tester anyway.
+            # Defense-in-depth - exercise the connectivity tester anyway.
             # If layer 1 was bypassed, the probe would fire with the malicious
             # dnsTestHost and the sentinel check below would catch it.
             global_functions.uvmContext.getConnectivityTester().getStatus()
@@ -1431,7 +1431,7 @@ class UvmTests(NGFWTestCase):
         Uses NetworkSettings.hostName (@SafeCheck(SafeType.HOSTNAME)) with a value
         containing a semicolon, which SafeType.HOSTNAME rejects. The test covers:
           1. No flag: setNetworkSettings raises SafeCheckValidationException (JSON-RPC 490).
-          2. Flag present: the same save succeeds — bypass is active, no restart required.
+          2. Flag present: the same save succeeds - bypass is active, no restart required.
           3. Flag removed: the save is rejected again (490).
 
         The field-path (validateInternal) and param-path (validate) are intentionally
@@ -1493,6 +1493,51 @@ class UvmTests(NGFWTestCase):
 
         finally:
             subprocess.call(f"rm -f {bypass_flag}", shell=True)
+
+    def test_129_settings_manager_path_traversal_blocked(self):
+        """
+        Verify SettingsManagerImpl.save(String, String, boolean) rejects an
+        inputFilename outside the settings/conf directories.
+
+        The RPC-exposed save(fileName, inputFilename, saveVersion) overload
+        now calls _checkSettingsPath on both arguments, restricting them to
+        the settings and conf directories only.
+
+        This test creates a real file in /tmp and attempts to move it into
+        the settings directory via save(). With the fix, _checkSettingsPath
+        rejects the /tmp inputFilename BEFORE _saveImpl runs, so the source
+        file remains untouched. Without the fix, _saveImpl would successfully
+        move the file - the source disappears and an attacker-controlled file
+        lands in the settings tree.
+        """
+        sm = global_functions.uvmContext.settingsManager()
+        settings_dir = "/usr/share/untangle/settings"
+        tmp_input = "/tmp/test_sm_path_validation.js"
+        settings_output = settings_dir + "/untangle-vm/test_sm_path_validation.js"
+        sentinel_content = "SETTINGS_MANAGER_PATH_TEST"
+
+        subprocess.call(f"rm -f {tmp_input} {settings_output}", shell=True)
+
+        try:
+            with open(tmp_input, "w") as f:
+                f.write(sentinel_content)
+            assert os.path.exists(tmp_input), "failed to create temp input file"
+
+            threw = False
+            try:
+                sm.save(settings_output, tmp_input, True)
+            except Exception:
+                threw = True
+
+            assert threw, \
+                "save() accepted inputFilename outside settings/conf dir - " \
+                "_checkSettingsPath is not blocking /tmp paths"
+
+            assert os.path.exists(tmp_input), \
+                "source file was moved despite path being outside settings dir - " \
+                "_saveImpl ran before _checkSettingsPath could block it"
+        finally:
+            subprocess.call(f"rm -f {tmp_input} {settings_output}", shell=True)
 
     def test_130_check_cmd_connected(self):
         """Check if cmd is connected using alert rule"""

--- a/uvm/impl/com/untangle/uvm/SettingsManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SettingsManagerImpl.java
@@ -326,6 +326,11 @@ public class SettingsManagerImpl implements SettingsManager
         if (!_checkLegalName(fileName)) {
             throw new IllegalArgumentException("Invalid file name: '" + fileName + "'");
         }
+        if (!_checkLegalName(inputFilename)) {
+            throw new IllegalArgumentException("Invalid input file name: '" + inputFilename + "'");
+        }
+        _checkSettingsPath(fileName);
+        _checkSettingsPath(inputFilename);
 
         _saveImpl( fileName, inputFilename, saveVersion, true );
     }
@@ -656,17 +661,64 @@ public class SettingsManagerImpl implements SettingsManager
         return lock;
     }
 
+    private static final String[] ALLOWED_BASE_DIRS;
+    static {
+        String settingsDir = System.getProperty("uvm.settings.dir");
+        if (settingsDir == null) settingsDir = "/usr/share/untangle/settings";
+        String confDir = System.getProperty("uvm.conf.dir");
+        if (confDir == null) confDir = "/usr/share/untangle/conf";
+        String libDir = System.getProperty("uvm.lib.dir");
+        if (libDir == null) libDir = "/usr/share/untangle/lib";
+        String skinsDir = System.getProperty("uvm.skins.dir");
+        if (skinsDir == null) skinsDir = "/usr/share/untangle/web/skins"; 
+
+        ALLOWED_BASE_DIRS = new String[] {
+            settingsDir,
+            confDir,
+            libDir,
+            skinsDir,
+            "/var/lib/interface-status",
+            "/etc/untangle",
+            "/tmp"
+        };
+    }
+
     /**
      * Check if a filename is "legal"
-     * Must have valid characterns and an extension
+     * Must resolve within an allowed base directory, contain valid characters, and have an extension.
      * @param name
      * @return true if legal, false otherwise
      * @throws IllegalArgumentException
      */
     private boolean _checkLegalName(String name) throws IllegalArgumentException
     {
-        if (!VALID_CHARACTERS.matcher( name.replace("/","") ).matches()) {
-            logger.error("Illegal name (Invalid characters): " + name);
+        if (name == null || name.isEmpty()) {
+            logger.error("Illegal name: null or empty");
+            return false;
+        }
+
+        try {
+            String canonical = new File(name).getCanonicalPath();
+            boolean allowed = false;
+            for (String baseDir : ALLOWED_BASE_DIRS) {
+                String prefix = new File(baseDir).getCanonicalPath() + File.separator;
+                if (canonical.startsWith(prefix) || canonical.equals(new File(baseDir).getCanonicalPath())) {
+                    allowed = true;
+                    break;
+                }
+            }
+            if (!allowed) {
+                logger.error("Illegal name (path outside allowed directories): " + name);
+                return false;
+            }
+        } catch (IOException e) {
+            logger.error("Illegal name (cannot resolve path): " + name, e);
+            return false;
+        }
+
+        String basename = new File(name).getName();
+        if (!VALID_CHARACTERS.matcher(basename).matches()) {
+            logger.error("Illegal name (Invalid characters in basename): " + name);
             return false;
         }
 
@@ -680,8 +732,35 @@ public class SettingsManagerImpl implements SettingsManager
             logger.error("Illegal name (contains ../): " + name);
             return false;
         }
-            
+
         return true;
+    }
+
+    /**
+     * Strict path check for the RPC-exposed save(String, String, boolean) overload.
+     * Only allows paths under the settings and conf directories - NOT /tmp, /var/lib, etc.
+     *
+     * @param name the file path to validate
+     * @throws SettingsException if the path is outside allowed directories or cannot be resolved
+     */
+    private void _checkSettingsPath(String name) throws SettingsException
+    {
+        try {
+            String canonical = new File(name).getCanonicalPath();
+            String settingsDir = System.getProperty("uvm.settings.dir");
+            if (settingsDir == null) settingsDir = "/usr/share/untangle/settings";
+            String confDir = System.getProperty("uvm.conf.dir");
+            if (confDir == null) confDir = "/usr/share/untangle/conf";
+
+            String settingsPrefix = new File(settingsDir).getCanonicalPath() + File.separator;
+            String confPrefix = new File(confDir).getCanonicalPath() + File.separator;
+
+            if (!canonical.startsWith(settingsPrefix) && !canonical.startsWith(confPrefix)) {
+                throw new SettingsException("Path outside settings directory: " + name);
+            }
+        } catch (IOException e) {
+            throw new SettingsException("Cannot resolve path: " + name, e);
+        }
     }
 
     /**


### PR DESCRIPTION
**Summary**

The save(String fileName, String inputFilename, boolean saveVersion) overload in SettingsManagerImpl is exposed over JSON-RPC and accepts two caller-controlled file paths. Previously, the _checkLegalName validation only applied to fileName — the inputFilename parameter was passed unchecked to _saveImpl, allowing an attacker with authenticated RPC access to read or overwrite arbitrary files on the filesystem via directory traversal (e.g. ../../etc/shadow).

**What changed**

**Validate both parameters:** _checkLegalName is now called on inputFilename in addition to fileName before reaching _saveImpl.
**Allowlist-based path resolution in _checkLegalName:** Instead of stripping slashes and checking characters on the raw string (which can be bypassed with encoded or double-dot sequences), the method now resolves the path to its canonical form via File.getCanonicalPath() and verifies it falls under one of the known allowed base directories (uvm.settings.dir, uvm.conf.dir, uvm.lib.dir, uvm.skins.dir, /var/lib/interface-status, /etc/untangle, /tmp).
**Character validation scoped to basename:** VALID_CHARACTERS regex is now checked against the filename component only (not the full path with slashes stripped), eliminating false rejections on legitimate nested paths.
**Strict _checkSettingsPath for the RPC-exposed overload:** A new method restricts the RPC save() call to only write under the settings and conf directories — not /tmp, /var/lib, etc. — providing defense-in-depth on top of _checkLegalName.

**Issue**
An authenticated user with access to the JSON-RPC interface could craft a save request with a path-traversal payload in inputFilename to read arbitrary files or write attacker-controlled content outside the settings directory. The existing _checkLegalName was only applied to one of the two path parameters and used a bypassable regex (stripping / then matching characters, which doesn't prevent ../ traversal after canonicalization).

**BEFORE :** 
<img width="1839" height="1042" alt="before-f" src="https://github.com/user-attachments/assets/c5119a7d-acb2-4eab-8b8f-eedb12fc29fa" />


**AFTER**
<img width="1839" height="1042" alt="after-f" src="https://github.com/user-attachments/assets/a76561a5-6d73-4f67-a9a3-6541ca21941b" />

