### PR TITLE
NGFW-15877 New OpenVPN field for fallback ciphers

### DIFF
--- a/openvpn/hier/usr/lib/python3/dist-packages/tests/test_openvpn.py
+++ b/openvpn/hier/usr/lib/python3/dist-packages/tests/test_openvpn.py
@@ -1650,6 +1650,7 @@ class OpenVpnTests(NGFWTestCase):
         orig_settings = copy.deepcopy(app_data)
         try:
             new_settings = copy.deepcopy(app_data)
+            new_settings["serverEnabled"] = True  # writeServerSettings early-returns if false
             new_settings["cipher"] = "AES-256-GCM:AES-128-CBC"
             new_settings["dataCiphersFallback"] = "AES-128-CBC"
             self._app.setSettings(new_settings)
@@ -1681,6 +1682,7 @@ class OpenVpnTests(NGFWTestCase):
         orig_settings = copy.deepcopy(app_data)
         try:
             new_settings = copy.deepcopy(app_data)
+            new_settings["serverEnabled"] = True  # writeServerSettings early-returns if false
             new_settings["cipher"] = "AES-256-GCM"
             new_settings["dataCiphersFallback"] = "AES-128-CBC"
             self._app.setSettings(new_settings)
@@ -1720,6 +1722,7 @@ class OpenVpnTests(NGFWTestCase):
         orig_settings = copy.deepcopy(app_data)
         try:
             new_settings = copy.deepcopy(app_data)
+            new_settings["serverEnabled"] = True  # writeServerSettings early-returns if false
             new_settings["cipher"] = "AES-128-CBC"
             # Bypasses UI validation - simulates hand-edit / older RPC caller
             new_settings["dataCiphersFallback"] = "AES-256-GCM:AES-128-CBC"
@@ -1747,6 +1750,7 @@ class OpenVpnTests(NGFWTestCase):
         orig_settings = copy.deepcopy(app_data)
         try:
             new_settings = copy.deepcopy(app_data)
+            new_settings["serverEnabled"] = True  # writeServerSettings early-returns if false
             new_settings["cipher"] = "AES-128-CBC"
             new_settings["dataCiphersFallback"] = ":AES-256-GCM"
             self._app.setSettings(new_settings)

--- a/openvpn/hier/usr/lib/python3/dist-packages/tests/test_openvpn.py
+++ b/openvpn/hier/usr/lib/python3/dist-packages/tests/test_openvpn.py
@@ -1640,6 +1640,166 @@ class OpenVpnTests(NGFWTestCase):
         finally:
             self._app.setSettings(orig_settings)
 
+    def test_096_cipher_and_fallback_written_separately_to_server_conf(self):
+        """OpenVpnManager.buildCommonConfiguration must emit data-ciphers and
+        data-ciphers-fallback from separate settings fields (cipher / dataCiphersFallback),
+        not the same value twice. Prevents invalid fallback lines that abort the daemon
+        with M_FATAL when the Cipher field holds a colon-list."""
+        import copy
+        app_data = self._app.getSettings()
+        orig_settings = copy.deepcopy(app_data)
+        try:
+            new_settings = copy.deepcopy(app_data)
+            new_settings["cipher"] = "AES-256-GCM:AES-128-CBC"
+            new_settings["dataCiphersFallback"] = "AES-128-CBC"
+            self._app.setSettings(new_settings)
+
+            with open("/etc/openvpn/server.conf", "r") as f:
+                conf = f.read()
+
+            assert "data-ciphers AES-256-GCM:AES-128-CBC" in conf, (
+                "server.conf missing expected data-ciphers list. Full content:\n" + conf
+            )
+            assert "data-ciphers-fallback AES-128-CBC" in conf, (
+                "server.conf missing expected single-value data-ciphers-fallback. Full content:\n" + conf
+            )
+            assert "data-ciphers-fallback AES-256-GCM:AES-128-CBC" not in conf, (
+                "server.conf still has the invalid colon-list fallback line - the split fix did not take effect"
+            )
+        finally:
+            self._app.setSettings(orig_settings)
+
+    def test_097_cipher_and_fallback_round_trip_via_settings(self):
+        """setSettings(cipher=X, dataCiphersFallback=Y) must persist both fields
+        independently, getSettings() must return them unchanged, and the generated
+        server.conf must contain both directives with those exact distinct values.
+        Guards against a regression where the .conf emitter reverts to writing the
+        same value to both directives - round-trip alone would silently pass such
+        a regression, so the .conf inspection is essential."""
+        import copy
+        app_data = self._app.getSettings()
+        orig_settings = copy.deepcopy(app_data)
+        try:
+            new_settings = copy.deepcopy(app_data)
+            new_settings["cipher"] = "AES-256-GCM"
+            new_settings["dataCiphersFallback"] = "AES-128-CBC"
+            self._app.setSettings(new_settings)
+
+            saved = self._app.getSettings()
+            assert saved["cipher"] == "AES-256-GCM", (
+                f"cipher did not round-trip: got {saved.get('cipher')!r}"
+            )
+            assert saved["dataCiphersFallback"] == "AES-128-CBC", (
+                f"dataCiphersFallback did not round-trip: got {saved.get('dataCiphersFallback')!r}"
+            )
+
+            with open("/etc/openvpn/server.conf", "r") as f:
+                conf = f.read()
+            assert "data-ciphers AES-256-GCM" in conf, (
+                "server.conf missing expected data-ciphers value from cipher field. Full content:\n" + conf
+            )
+            assert "data-ciphers-fallback AES-128-CBC" in conf, (
+                "server.conf missing expected data-ciphers-fallback value from dataCiphersFallback field. Full content:\n" + conf
+            )
+            # Regression guard: if the emitter reverts to writing cipher to both, the fallback
+            # line would show AES-256-GCM (the cipher value) rather than AES-128-CBC.
+            assert "data-ciphers-fallback AES-256-GCM" not in conf, (
+                "server.conf fallback line has the cipher value, not the dataCiphersFallback value - "
+                "emitter regression: it is writing cipher to both directives"
+            )
+        finally:
+            self._app.setSettings(orig_settings)
+
+    def test_098_fallback_defensive_normalization_on_colon(self):
+        """OpenVpnManager defensive normalization must strip colon-lists from
+        dataCiphersFallback at emit time so server.conf is never syntactically
+        invalid, even when a colon slips past UI validation (hand-edited settings
+        JSON, older API caller, etc.). Backend takes the first colon-token."""
+        import copy
+        app_data = self._app.getSettings()
+        orig_settings = copy.deepcopy(app_data)
+        try:
+            new_settings = copy.deepcopy(app_data)
+            new_settings["cipher"] = "AES-128-CBC"
+            # Bypasses UI validation - simulates hand-edit / older RPC caller
+            new_settings["dataCiphersFallback"] = "AES-256-GCM:AES-128-CBC"
+            self._app.setSettings(new_settings)
+
+            with open("/etc/openvpn/server.conf", "r") as f:
+                conf = f.read()
+
+            assert "data-ciphers-fallback AES-256-GCM" in conf, (
+                "defensive normalization should have emitted the first colon-token as fallback. Full content:\n" + conf
+            )
+            assert "data-ciphers-fallback AES-256-GCM:AES-128-CBC" not in conf, (
+                "defensive normalization failed - full colon-list still present in server.conf"
+            )
+        finally:
+            self._app.setSettings(orig_settings)
+
+    def test_099_fallback_defensive_normalization_on_leading_colon(self):
+        """Pathological leading colon (e.g. ':AES-128-CBC') would produce an empty
+        first-token if we only did split-and-take-first. OpenVpnManager must detect
+        the empty result and fall back to the DEFAULT_CIPHER so server.conf never
+        contains an empty 'data-ciphers-fallback' line."""
+        import copy
+        app_data = self._app.getSettings()
+        orig_settings = copy.deepcopy(app_data)
+        try:
+            new_settings = copy.deepcopy(app_data)
+            new_settings["cipher"] = "AES-128-CBC"
+            new_settings["dataCiphersFallback"] = ":AES-256-GCM"
+            self._app.setSettings(new_settings)
+
+            with open("/etc/openvpn/server.conf", "r") as f:
+                conf = f.read()
+
+            assert "data-ciphers-fallback AES-128-CBC" in conf, (
+                "leading-colon fallback should have fallen back to default AES-128-CBC. Full content:\n" + conf
+            )
+            # server.conf must not contain a line with empty cipher value (trailing space + newline)
+            assert "data-ciphers-fallback \n" not in conf and "data-ciphers-fallback\n" not in conf, (
+                "server.conf contains an empty data-ciphers-fallback line - defensive normalization missed the leading-colon edge"
+            )
+        finally:
+            self._app.setSettings(orig_settings)
+
+    def test_100_settings_schema_invariants_post_migration(self):
+        """Post-migration schema invariants: settings on any installed box must be at
+        SETTINGS_CURRENT_VERSION (3) and must expose the dataCiphersFallback key with
+        a non-null string value. Catches regressions where SETTINGS_CURRENT_VERSION
+        wasn't bumped, the migration branch never populated the new field, or the
+        Java getter was accidentally renamed/removed.
+
+        NOTE: the migration LOGIC branching itself (single cipher preserved vs
+        colon-list defaulted to AES-128-CBC vs empty/null defaulted) cannot be
+        exercised from an integration test because updateSettings() runs only from
+        postInit() when a settings file is first loaded from disk. Triggering that
+        codepath requires either a full uvm restart (would break the test harness
+        connection) or app destroy+instantiate (assigns a new app id, so the pre-
+        written v2 settings fixture is orphaned). No other test in the NGFW repo
+        tests settings migration at integration level - this is a codebase-wide
+        limitation. The migration logic is verified manually per the plan's
+        Verification section (steps 7-9): write a v2 fixture with each cipher
+        shape, restart uvm, assert the migrated state, and inspect server.conf."""
+        saved = self._app.getSettings()
+        assert saved.get("version", 0) >= 3, (
+            f"settings version regressed - expected >= 3, got {saved.get('version')!r}. "
+            "Either SETTINGS_CURRENT_VERSION was un-bumped or the v3 migration never ran."
+        )
+        assert "dataCiphersFallback" in saved, (
+            "dataCiphersFallback key absent from getSettings() JSON - "
+            "check the Java getter/setter and the serializer."
+        )
+        assert isinstance(saved["dataCiphersFallback"], str) and saved["dataCiphersFallback"], (
+            f"dataCiphersFallback is null or non-string: {saved['dataCiphersFallback']!r}. "
+            "Migration should have populated a non-empty default."
+        )
+        assert ":" not in saved["dataCiphersFallback"], (
+            f"dataCiphersFallback contains a colon: {saved['dataCiphersFallback']!r}. "
+            "Migration should have defaulted colon-lists to AES-128-CBC."
+        )
+
     @classmethod
     def final_extra_tear_down(cls):
         global appWeb, appDC, tunnelApp

--- a/openvpn/js/view/Advanced.js
+++ b/openvpn/js/view/Advanced.js
@@ -66,6 +66,22 @@ Ext.define('Ung.apps.openvpn.view.Advanced', {
         xtype: 'container',
         layout: 'column',
         items: [{
+            xtype: 'textfield',
+            fieldLabel: 'Fallback Cipher'.t(),
+            labelWidth: 180,
+            bind: '{settings.dataCiphersFallback}',
+            maskRe: /[A-Za-z0-9\-]/,
+            regex: /^[A-Za-z0-9\-]+$/,
+            regexText: 'Fallback Cipher accepts a single cipher only - no colons allowed.'.t()
+        }, {
+            xtype: 'displayfield',
+            margin: '0 0 0 10',
+            value: '(default = AES-128-CBC)'.t()
+        }]
+    },{
+        xtype: 'container',
+        layout: 'column',
+        items: [{
             xtype: 'checkbox',
             fieldLabel: 'Client To Client Allowed'.t(),
             labelWidth: 180,

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
@@ -55,7 +55,7 @@ import com.untangle.uvm.util.Constants;
 public class OpenVpnAppImpl extends AppBase
 {
 
-    private static final Integer SETTINGS_CURRENT_VERSION = 2;
+    private static final Integer SETTINGS_CURRENT_VERSION = 3;
 
     private final Logger logger = LogManager.getLogger(getClass());
 
@@ -460,6 +460,9 @@ public class OpenVpnAppImpl extends AppBase
         // Cipher changes
         if (!oldSettings.getCipher().equals(newSettings.getCipher())) { logger.debug("Server Cipher has changed."); return true;}
 
+        // Fallback cipher changes
+        if (!Objects.equals(oldSettings.getDataCiphersFallback(), newSettings.getDataCiphersFallback())) { logger.debug("Server Fallback Cipher has changed."); return true;}
+
         // Client to client enabled/disabled
         if (oldSettings.getClientToClient() != newSettings.getClientToClient()) { logger.debug("Server Client to Client has changed."); return true;}
 
@@ -479,13 +482,14 @@ public class OpenVpnAppImpl extends AppBase
      * @return          Nothing
      */
     private void updateSettings(OpenVpnSettings settings){
-        if(settings.getVersion() < SETTINGS_CURRENT_VERSION){
-            logger.info("OpenVPN Settings require an update...");
+        if(settings.getVersion() >= SETTINGS_CURRENT_VERSION) return;
 
+        logger.info("OpenVPN Settings require an update...");
+
+        if (settings.getVersion() < 2) {
             /**
              * Fix up the "compress lz4" compression settings for the server
              */
-
             for (OpenVpnConfigItem serverConfig : settings.getServerConfiguration()) {
                 if ( serverConfig.getOptionName() != null && Objects.equals(serverConfig.getOptionName(), "compress lz4")) {
                     serverConfig.setOptionName("compress");
@@ -502,10 +506,32 @@ public class OpenVpnAppImpl extends AppBase
                     clientConfig.setOptionValue("lz4");
                 }
             }
-
-            settings.setVersion(SETTINGS_CURRENT_VERSION);
-            this.setSettings( settings );
         }
+
+        if (settings.getVersion() < 3) {
+            /**
+             * Populate dataCiphersFallback from the existing cipher value.
+             * data-ciphers-fallback accepts only a single cipher name (see OpenVPN manpage
+             * and crypto.c:init_key_type which M_FATALs on invalid names). For pre-v3 installs
+             * whose cipher field held a colon-separated list, that would produce an invalid
+             * fallback line and abort the daemon; fall back to the static default in that case.
+             * For single-cipher installs, copy verbatim so server.conf output is byte-identical
+             * to pre-migration.
+             */
+            String cipher = settings.getCipher();
+            String fallback;
+            if (cipher == null || cipher.trim().isEmpty()) {
+                fallback = OpenVpnSettings.DEFAULT_CIPHER;
+            } else if (cipher.trim().contains(":")) {
+                fallback = OpenVpnSettings.DEFAULT_CIPHER;
+            } else {
+                fallback = cipher.trim();
+            }
+            settings.setDataCiphersFallback(fallback);
+        }
+
+        settings.setVersion(SETTINGS_CURRENT_VERSION);
+        this.setSettings( settings );
     }
 
     /**

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
@@ -9,8 +9,6 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.List;
-import java.util.Arrays;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.io.File;
 import java.io.FileReader;
@@ -34,7 +32,6 @@ import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.HookCallback;
 import com.untangle.uvm.network.NetworkSettings;
 import com.untangle.uvm.network.InterfaceSettings;
-import com.untangle.uvm.network.InterfaceStatus;
 import com.untangle.uvm.util.I18nUtil;
 import com.untangle.uvm.app.AppSettings;
 import com.untangle.uvm.app.AppMetric;
@@ -44,7 +41,6 @@ import com.untangle.uvm.vnet.Affinity;
 import com.untangle.uvm.vnet.Fitting;
 import com.untangle.uvm.app.AppBase;
 import com.untangle.uvm.vnet.PipelineConnector;
-import com.untangle.uvm.util.Constants;
 
 /**
  * The OpenVPN application
@@ -78,7 +74,7 @@ public class OpenVpnAppImpl extends AppBase
     private final OpenVpnPreHookCallback openVpnPreHookCallback;
 
     private List<OpenVpnExport> localExports = null;
-    private String localHostName = "";
+    private String localHostName = StringUtils.EMPTY;
 
     private OpenVpnSettings settings;
 
@@ -109,7 +105,7 @@ public class OpenVpnAppImpl extends AppBase
         this.addMetric(new AppMetric(STAT_PASS, I18nUtil.marktr("Sessions passed")));
         this.addMetric(new AppMetric(STAT_CONNECT, I18nUtil.marktr("Clients Connected")));
 
-        this.connector = UvmContextFactory.context().pipelineFoundry().create("openvpn", this, null, handler, Fitting.OCTET_STREAM, Fitting.OCTET_STREAM, Affinity.CLIENT, 10, false);
+        this.connector = UvmContextFactory.context().pipelineFoundry().create(NETSPACE_OWNER, this, null, handler, Fitting.OCTET_STREAM, Fitting.OCTET_STREAM, Affinity.CLIENT, 10, false);
         this.connectors = new PipelineConnector[] { connector };
     }
 
@@ -152,7 +148,9 @@ public class OpenVpnAppImpl extends AppBase
             logger.info("Loading Settings...");
             this.settings = readSettings;
             updateNetworkReservations(readSettings.getAddressSpace(), readSettings.getRemoteClients());
-            logger.debug("Settings: {}", this.settings.toJSONString());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Settings: {}", this.settings.toJSONString());
+            }
         }
 
         /**
@@ -328,7 +326,9 @@ public class OpenVpnAppImpl extends AppBase
         }
         updateNetworkReservations(newSettings.getAddressSpace(), newSettings.getRemoteClients());
         try {
-            logger.debug("New Settings: \n {} ", new org.json.JSONObject(this.settings).toString(2));
+            if (logger.isDebugEnabled()) {
+                logger.debug("New Settings: \n {} ", new org.json.JSONObject(this.settings).toString(2));
+            }
         } catch (Exception e) {
         }
 
@@ -467,10 +467,10 @@ public class OpenVpnAppImpl extends AppBase
         if (oldSettings.getClientToClient() != newSettings.getClientToClient()) { logger.debug("Server Client to Client has changed."); return true;}
 
         // Server config settings (Use data stream to compare a json string of the entire list)
-        if(oldSettings.getServerConfiguration().stream().map(u -> u.toJSONString()).collect(Collectors.joining("")).compareTo(newSettings.getServerConfiguration().stream().map(u -> u.toJSONString()).collect(Collectors.joining(""))) != 0) { logger.debug("Custom Server Configuration Items have changed."); return true; }
+        if(oldSettings.getServerConfiguration().stream().map(u -> u.toJSONString()).collect(Collectors.joining(StringUtils.EMPTY)).compareTo(newSettings.getServerConfiguration().stream().map(u -> u.toJSONString()).collect(Collectors.joining(StringUtils.EMPTY))) != 0) { logger.debug("Custom Server Configuration Items have changed."); return true; }
 
         // Exported networks (Use data stream to compare a json string of the entire list)
-        if(oldSettings.getExports().stream().map(u -> u.toJSONString()).collect(Collectors.joining("")).compareTo(newSettings.getExports().stream().map(u -> u.toJSONString()).collect(Collectors.joining(""))) != 0) {logger.debug("Exported network items have changed."); return true;}
+        if(oldSettings.getExports().stream().map(u -> u.toJSONString()).collect(Collectors.joining(StringUtils.EMPTY)).compareTo(newSettings.getExports().stream().map(u -> u.toJSONString()).collect(Collectors.joining(StringUtils.EMPTY))) != 0) {logger.debug("Exported network items have changed."); return true;}
 
         return false;
     }
@@ -519,13 +519,12 @@ public class OpenVpnAppImpl extends AppBase
              * to pre-migration.
              */
             String cipher = settings.getCipher();
+            String trimmedCipher = StringUtils.trimToEmpty(cipher);
             String fallback;
-            if (cipher == null || cipher.trim().isEmpty()) {
-                fallback = OpenVpnSettings.DEFAULT_CIPHER;
-            } else if (cipher.trim().contains(":")) {
+            if (StringUtils.isBlank(cipher) || trimmedCipher.contains(":")) {
                 fallback = OpenVpnSettings.DEFAULT_CIPHER;
             } else {
-                fallback = cipher.trim();
+                fallback = trimmedCipher;
             }
             settings.setDataCiphersFallback(fallback);
         }
@@ -591,8 +590,8 @@ public class OpenVpnAppImpl extends AppBase
                 // well try both for authentication. See bug #7951
                 String originalUsername = username;
                 String strippedUsername = username;
-                strippedUsername = strippedUsername.replaceAll(".*\\\\", "");
-                strippedUsername = strippedUsername.replaceAll("@.*", "");
+                strippedUsername = strippedUsername.replaceAll(".*\\\\", StringUtils.EMPTY);
+                strippedUsername = strippedUsername.replaceAll("@.*", StringUtils.EMPTY);
 
                 DirectoryConnector directoryConnector = (DirectoryConnector) UvmContextFactory.context().appManager().app("directory-connector");
                 if (directoryConnector == null) break;
@@ -1142,7 +1141,7 @@ public class OpenVpnAppImpl extends AppBase
     private synchronized void deployWebApp()
     {
         if (!isWebAppDeployed) {
-            if (null != UvmContextFactory.context().tomcatManager().loadServlet("/openvpn", "openvpn", true)) {
+            if (null != UvmContextFactory.context().tomcatManager().loadServlet("/openvpn", NETSPACE_OWNER, true)) {
                 logger.debug("Deployed openvpn web app");
             } else logger.warn("Unable to deploy openvpn web app");
         }
@@ -1173,7 +1172,7 @@ public class OpenVpnAppImpl extends AppBase
     {
         boolean setNewSettings = false;
         String currentSiteName = this.settings.getSiteName();
-        String currentExportsString = this.settings.getExports().stream().map(u -> u.toJSONString()).collect(Collectors.joining(""));
+        String currentExportsString = this.settings.getExports().stream().map(OpenVpnExport::toJSONString).collect(Collectors.joining(StringUtils.EMPTY));
 
         // refresh iptables rules in case WAN config has changed
         logger.info("Network Settings have changed. Syncing new settings...");
@@ -1183,10 +1182,10 @@ public class OpenVpnAppImpl extends AppBase
          * but doesn't match the new local network list, then update the
          * openvpn exported networks list to match the new network settings
          */
-        if(this.localExports.stream().map(u -> u.toJSONString()).collect(Collectors.joining("")).compareTo(currentExportsString) == 0) {
+        if(this.localExports.stream().map(OpenVpnExport::toJSONString).collect(Collectors.joining(StringUtils.EMPTY)).compareTo(currentExportsString) == 0) {
             List<OpenVpnExport> newExports = getCurrentExportList();
 
-            if(newExports.stream().map(u -> u.toJSONString()).collect(Collectors.joining("")).compareTo(currentExportsString) != 0) {
+            if(newExports.stream().map(OpenVpnExport::toJSONString).collect(Collectors.joining(StringUtils.EMPTY)).compareTo(currentExportsString) != 0) {
                 this.settings.setExports(newExports);
                 setNewSettings = true;
             }

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
@@ -621,7 +622,7 @@ public class OpenVpnManager
 
         String fallbackRaw = settings.getDataCiphersFallback();
         String fallback;
-        if (fallbackRaw == null || fallbackRaw.trim().isEmpty()) {
+        if (StringUtils.isBlank(fallbackRaw)) {
             fallback = OpenVpnSettings.DEFAULT_CIPHER;
         } else {
             fallback = fallbackRaw.split(":", 2)[0].trim();
@@ -709,7 +710,7 @@ public class OpenVpnManager
     private void deleteFiles()
     {
         try {
-            File baseDirectory = new File("/etc/openvpn");
+            File baseDirectory = new File(OPENVPN_CONF_DIR);
             if (baseDirectory.exists()) {
                 for (File f : baseDirectory.listFiles()) {
                     if (f.getName() == null) continue;
@@ -817,7 +818,7 @@ public class OpenVpnManager
 
                     serverPassword = PasswordUtil.getDecryptPassword(server.getRemoteServerEncryptedPassword());
                     if(serverPassword == null){
-                        logger.warn("Error occured while decrypting the encrypted passowrd for server : { }", name);
+                        logger.warn("Error occurred while decrypting the encrypted password for server : {}", name);
                         continue;
                     }
                     
@@ -1207,7 +1208,7 @@ public class OpenVpnManager
 
         for (OpenVpnConfigItem item : argList) {
             if (item.getOptionName() == null) continue;
-            if (item.getOptionName().trim().toLowerCase().equals(findName.trim().toLowerCase())) return (item);
+            if (item.getOptionName().trim().equalsIgnoreCase(findName.trim())) return (item);
         }
 
         return (null);
@@ -1229,9 +1230,9 @@ public class OpenVpnManager
         if (findName == null) return (null);
 
         for (OpenVpnConfigItem item : argList) {
-            if (item.getReadOnly() == true) continue;
+            if (item.getReadOnly()) continue;
             if (item.getOptionName() == null) continue;
-            if (item.getOptionName().trim().toLowerCase().equals(findName.trim().toLowerCase())) return (item);
+            if (item.getOptionName().trim().equalsIgnoreCase(findName.trim())) return (item);
         }
 
         return (null);

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
@@ -618,7 +618,22 @@ public class OpenVpnManager
         sb.append("proto" + SPACE).append(settings.getProtocol()).append(LINE_BREAK);
         sb.append("port" + SPACE).append(settings.getPort()).append(LINE_BREAK);
         sb.append("data-ciphers" + SPACE).append(settings.getCipher()).append(LINE_BREAK);
-        sb.append("data-ciphers-fallback" + SPACE).append(settings.getCipher()).append(LINE_BREAK);
+
+        String fallbackRaw = settings.getDataCiphersFallback();
+        String fallback;
+        if (fallbackRaw == null || fallbackRaw.trim().isEmpty()) {
+            fallback = OpenVpnSettings.DEFAULT_CIPHER;
+        } else {
+            fallback = fallbackRaw.split(":", 2)[0].trim();
+            if (fallback.isEmpty()) {
+                // Pathological input like ":X" - first colon-token is empty; use default so .conf stays valid.
+                logger.warn("data-ciphers-fallback started with a colon ('{}') - falling back to default '{}'", fallbackRaw, OpenVpnSettings.DEFAULT_CIPHER);
+                fallback = OpenVpnSettings.DEFAULT_CIPHER;
+            } else if (fallbackRaw.contains(":")) {
+                logger.warn("data-ciphers-fallback contained a colon ('{}') - normalized to '{}' (fallback accepts one cipher only)", fallbackRaw, fallback);
+            }
+        }
+        sb.append("data-ciphers-fallback" + SPACE).append(fallback).append(LINE_BREAK);
     }
 
     /**

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnSettings.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnSettings.java
@@ -33,10 +33,12 @@ public class OpenVpnSettings implements java.io.Serializable, JSONString
     private static final int DEFAULT_PING_TIMEOUT = 10;
     private static final int DEFAULT_VERBOSITY    = 1;
     static final int MANAGEMENT_PORT              = 1195;
+    static final String DEFAULT_CIPHER            = "AES-128-CBC";
 
     private String protocol = "udp"; /* "tcp" or "udp" */
     private int port = 1194;
-    private String cipher = "AES-128-CBC";
+    private String cipher = DEFAULT_CIPHER;
+    private String dataCiphersFallback = DEFAULT_CIPHER;
     private boolean clientToClient = true;
     
     @SafeCheck(SafeType.ALPHANUM)
@@ -180,6 +182,9 @@ public class OpenVpnSettings implements java.io.Serializable, JSONString
 
     public String getCipher() { return this.cipher; }
     public void setCipher( String newValue ) { this.cipher = newValue; }
+
+    public String getDataCiphersFallback() { return this.dataCiphersFallback; }
+    public void setDataCiphersFallback( String newValue ) { this.dataCiphersFallback = newValue; }
 
     public boolean getClientToClient() { return this.clientToClient; }
     public void setClientToClient( boolean newValue ) { this.clientToClient = newValue; }


### PR DESCRIPTION
- Added a separate Fallback Cipher field on UI Advanced tab.
- For the users having colan separated ciphers in Cipher field, the Fallback Cipher will get the default fallback value, and not the last cipher from the colan list (as suggested by the forum user), since we cannot make that decision in general for all boxes.
- If single cipher value is present in Cipher field, then same is replicated in Fallback Cipher.
- ATS test cases for test coverage.
<img width="872" height="375" alt="image" src="https://github.com/user-attachments/assets/99c3f6ca-9563-42d3-bb25-607f57f6f5b8" />
