### PR TITLE
ngfw-15852 : Fixed :  admin root arbitrary file overwrite via crafted backup tarball containing  symlink members (UNT-19)

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py
@@ -2156,4 +2156,142 @@ class UvmTests(NGFWTestCase):
             subprocess.call(f"rm -rf {work_dir}", shell=True)
 
 
+    def test_140_backup_restore_symlink_member_blocked(self):
+        """
+        UNT-19: Verify that a crafted backup containing a symlink member
+        (with a valid name under usr/share/untangle/settings/) is rejected
+        by ut-restore.sh before extraction.
+        """
+        backup_file = "/tmp/test_backup_symlink.backup"
+        work_dir = "/tmp/symlink_test_workdir"
+        symlink_target = "/tmp/unt19_symlink_target"
+        subprocess.call(f"rm -f {backup_file} {symlink_target}", shell=True)
+        subprocess.call(f"rm -rf {work_dir}", shell=True)
+
+        try:
+            # Step 1: Download a legitimate backup
+            result = subprocess.call(
+                global_functions.build_wget_command(
+                    output_file=backup_file,
+                    post_data='type=backup',
+                    uri="http://localhost/admin/download"),
+                shell=True)
+            assert result == 0, "Failed to download backup"
+
+            # Step 2: Craft a malicious backup with a symlink inside settings/
+            os.makedirs(work_dir, exist_ok=True)
+
+            # Extract the outer tar
+            subprocess.call(f"tar xzf {backup_file} -C {work_dir}", shell=True)
+
+            # Find the inner files tarball
+            inner_tarball = glob.glob(f"{work_dir}/files-*.tar.gz")[0]
+            inner_name = os.path.basename(inner_tarball)
+
+            # Extract inner tarball, inject symlink, repack
+            inner_dir = f"{work_dir}/inner"
+            os.makedirs(inner_dir, exist_ok=True)
+            subprocess.call(f"tar xzf {inner_tarball} -C {inner_dir}", shell=True)
+
+            # Add a symlink member under settings/ that points outside
+            symlink_path = f"{inner_dir}/usr/share/untangle/settings/untangle-vm/system.js"
+            if os.path.exists(symlink_path):
+                os.remove(symlink_path)
+            os.symlink(symlink_target, symlink_path)
+
+            # Repack inner tarball WITHOUT -h so the symlink is preserved as a symlink.
+            # Must use explicit path 'usr/' (not '.') to avoid './' prefix on entries,
+            # which would fail the NGFW-15703 name-prefix check before reaching the type check.
+            subprocess.call(
+                f"tar czf {work_dir}/{inner_name} -C {inner_dir} usr/",
+                shell=True)
+
+            # Repack outer backup with explicit member names (no './' prefix)
+            subprocess.call(
+                f"tar czf {backup_file} -C {work_dir} PUBVERSION {inner_name}",
+                shell=True)
+
+            # Step 3: Run ut-restore.sh in check-only mode
+            restore_result = subprocess.run(
+                ["/usr/share/untangle/bin/ut-restore.sh", "-i", backup_file, "-v", "-c"],
+                capture_output=True, text=True, timeout=30)
+
+            # Step 4: Validate restore script rejected the file
+            assert restore_result.returncode != 0, \
+                "Restore script should have rejected backup with symlink members"
+            assert "symbolic links, hard links, or special file" in restore_result.stderr, \
+                f"Expected symlink rejection message, got: {restore_result.stderr}"
+
+        finally:
+            subprocess.call(f"rm -f {backup_file} {symlink_target}", shell=True)
+            subprocess.call(f"rm -rf {work_dir}", shell=True)
+
+    def test_141_backup_restore_hardlink_member_blocked(self):
+        """
+        UNT-19: Verify that a crafted backup containing a hardlink member
+        is rejected by ut-restore.sh.
+        """
+        backup_file = "/tmp/test_backup_hardlink.backup"
+        work_dir = "/tmp/hardlink_test_workdir"
+        subprocess.call(f"rm -f {backup_file}", shell=True)
+        subprocess.call(f"rm -rf {work_dir}", shell=True)
+
+        try:
+            # Step 1: Download a legitimate backup
+            result = subprocess.call(
+                global_functions.build_wget_command(
+                    output_file=backup_file,
+                    post_data='type=backup',
+                    uri="http://localhost/admin/download"),
+                shell=True)
+            assert result == 0, "Failed to download backup"
+
+            # Step 2: Craft a malicious backup with a hardlink inside settings/
+            os.makedirs(work_dir, exist_ok=True)
+            subprocess.call(f"tar xzf {backup_file} -C {work_dir}", shell=True)
+
+            inner_tarball = glob.glob(f"{work_dir}/files-*.tar.gz")[0]
+            inner_name = os.path.basename(inner_tarball)
+
+            inner_dir = f"{work_dir}/inner"
+            os.makedirs(inner_dir, exist_ok=True)
+            subprocess.call(f"tar xzf {inner_tarball} -C {inner_dir}", shell=True)
+
+            # Find any existing settings file to use as hardlink source
+            settings_files = glob.glob(
+                f"{inner_dir}/usr/share/untangle/settings/untangle-vm/*.js")
+            assert len(settings_files) > 0, "No settings files found in backup"
+
+            source_file = settings_files[0]
+            hardlink_path = f"{inner_dir}/usr/share/untangle/settings/untangle-vm/hardlink_test.js"
+            os.link(source_file, hardlink_path)
+
+            # Repack inner tarball — tar stores files sharing an inode as hardlink entries
+            # by default. Must use explicit path 'usr/' (not '.') to match the expected
+            # entry name format without './' prefix.
+            subprocess.call(
+                f"tar czf {work_dir}/{inner_name} -C {inner_dir} usr/",
+                shell=True)
+
+            # Repack outer backup with explicit member names (no './' prefix)
+            subprocess.call(
+                f"tar czf {backup_file} -C {work_dir} PUBVERSION {inner_name}",
+                shell=True)
+
+            # Step 3: Run ut-restore.sh in check-only mode
+            restore_result = subprocess.run(
+                ["/usr/share/untangle/bin/ut-restore.sh", "-i", backup_file, "-v", "-c"],
+                capture_output=True, text=True, timeout=30)
+
+            # Step 4: Validate restore script rejected the file
+            assert restore_result.returncode != 0, \
+                "Restore script should have rejected backup with hardlink members"
+            assert "symbolic links, hard links, or special file" in restore_result.stderr, \
+                f"Expected hardlink rejection message, got: {restore_result.stderr}"
+
+        finally:
+            subprocess.call(f"rm -f {backup_file}", shell=True)
+            subprocess.call(f"rm -rf {work_dir}", shell=True)
+
+
 test_registry.register_module("uvm", UvmTests)

--- a/uvm/hier/usr/share/untangle/bin/ut-restore.sh
+++ b/uvm/hier/usr/share/untangle/bin/ut-restore.sh
@@ -55,9 +55,9 @@ function doRestore()
     debug "Restoring files..."
 
     if [ "true" == $VERBOSE ]; then
-      tar zxfv $WORKING_DIR/$TARBALL_FILE -C /
+      tar zxfv $WORKING_DIR/$TARBALL_FILE --no-overwrite-dir --no-same-owner -C /
     else
-      tar zxf $WORKING_DIR/$TARBALL_FILE -C /
+      tar zxf $WORKING_DIR/$TARBALL_FILE --no-overwrite-dir --no-same-owner -C /
     fi
 
     # update date on all files
@@ -167,6 +167,19 @@ function expandFile()
     if [ ! -z "$UNSAFE_ENTRIES" ]; then
         err "Backup file contains files outside /usr/share/untangle/settings/ (invalid backup):"
         err "$UNSAFE_ENTRIES"
+        err "Aborting restore."
+        return 1
+    fi
+
+    # UNT-19 Reject non-regular-file/non-directory members (symlinks, hardlinks, devices, FIFOs).
+    # A symlink member with a valid name bypasses the NGFW-15703 name check above;
+    # tar zxf -C / then creates the symlink, and subsequent root writes follow it.
+    # tar tzvf verbose output starts with the file-type character: '-'=file, 'd'=dir,
+    # 'l'=symlink, 'h'=hardlink, 'b'=block, 'c'=char, 'p'=FIFO. Whitelist only '-' and 'd'.
+    UNSAFE_TYPE_ENTRIES=$(tar tzvf $WORKING_DIR/$TARBALL_FILE | grep -vE '^[-d]')
+    if [ ! -z "$UNSAFE_TYPE_ENTRIES" ]; then
+        err "Backup file contains symbolic links, hard links, or special file members (invalid backup):"
+        err "$UNSAFE_TYPE_ENTRIES"
         err "Aborting restore."
         return 1
     fi


### PR DESCRIPTION

## Summary

- Fixed :  admin root arbitrary file overwrite via crafted backup tarball containing
  symlink members (UNT-19, CVSS 7.2 HIGH)
- The existing NGFW-15703 path-prefix check in `ut-restore.sh` validates tarball
  member **names** only; a symlink member with a valid name like
  `usr/share/untangle/settings/untangle-vm/system.js` pointing to `/etc/cron.d/x`
  passes the name check, then `tar zxf -C /` creates the symlink on disk.
  Subsequent NGFW settings writes (running as root) follow the symlink and
  overwrite the target — achieving root file write.
- Add a whitelist-based member-type check using `tar tzvf` verbose output:
  only regular files (`-`) and directories (`d`) are allowed. Symlinks (`l`),
  hardlinks (`h`), block/char devices (`b`/`c`), and FIFOs (`p`) are rejected
  before extraction.
- Add `--no-overwrite-dir` and `--no-same-owner` defensive flags to the tar
  extraction command to prevent directory metadata tampering and attacker-
  controlled file ownership.
- Add integration tests for symlink and hardlink member rejection.

**No regression risk**: `ut-backup.sh` has used `cp -L` + `tar zcfh`
(double symlink dereferencing) since 2013. Every backup from any accepted
version (17.5+) contains only regular files and directories. Older versions
that lacked `-h` are rejected by the version check before reaching the
type check.

## Files changed

- `uvm/hier/usr/share/untangle/bin/ut-restore.sh` — member-type validation +
  defensive extraction flags
- `uvm/hier/usr/lib/python3/dist-packages/tests/test_uvm.py` — test_140
  (symlink rejection) + test_141 (hardlink rejection)


**BEFORE :** 

<img width="1851" height="537" alt="Screenshot from 2026-07-09 16-23-06" src="https://github.com/user-attachments/assets/824607c7-71b6-4b5c-a435-877c456199e0" />


**AFTER :**

<img width="1851" height="537" alt="Screenshot from 2026-07-09 16-22-18" src="https://github.com/user-attachments/assets/a85243e5-b248-4b76-b851-96ee0acfd842" />
