### PR TITLE
Ngfw 15870 block page css modify

### DIFF
--- a/uvm/hier/usr/share/untangle/web/skins/common/css/user.css
+++ b/uvm/hier/usr/share/untangle/web/skins/common/css/user.css
@@ -1,264 +1,336 @@
-@font-face {
-    font-family: 'PT Sans';
-    font-style: normal;
-    font-weight: 400;
-    src: local('PT Sans'), local('PTSans-Regular'), url(../fonts/PTSans.woff) format('woff');
+/*
+ * Block Page — user-facing page styles.
+ * Brand tokens copied from the Vue UI theme:
+ *   pkgs_vuntangle/vuntangle/src/config/theme.js
+ *   pkgs_vuntangle/vuntangle/src/scss/variables.scss
+ * Resync manually if those values change.
+ */
+
+:root {
+    --bp-arista-blue:        #16325B;
+    --bp-arista-medium-blue: #146095;
+    --bp-arista-light-blue:  #4473A9;
+    --bp-arista-orange:      #D47122;
+    --bp-arista-dark-gray:   #58585B;
+    --bp-arista-light-gray:  #BBBDC0;
+    --bp-arista-medium-gray: #969696;
+    --bp-bg:                 #F5F5F5;
+    --bp-card-bg:            #FFFFFF;
+    --bp-card-radius:        4px;
+    --bp-card-shadow:        0 2px 4px rgba(0, 0, 0, 0.10), 0 1px 2px rgba(0, 0, 0, 0.06);
+    --bp-content-margin:     20px;
+    --bp-font:               "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI",
+                             "Helvetica Neue", Arial, sans-serif;
 }
+
+* {
+    box-sizing: border-box;
+}
+
+/* ---------- Body ---------- */
 
 body.blockpage {
-    color: #FFF;
-    background-color: #C0C0C0;
+    margin: 0;
+    padding: 48px 16px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    background: var(--bp-bg);
+    color: var(--bp-arista-dark-gray);
+    font-family: var(--bp-font);
+    font-size: 14px;
+    line-height: 1.5;
     text-align: center;
-    margin: 0 10px;
-    padding: 0;
-    font-family: 'PT Sans', Tahoma, Arial, Helvetica, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
+
+/* ---------- Card container ---------- */
 
 .block {
+    width: 100%;
     max-width: 500px;
-    margin: 10px auto;
-    border-radius: 10px;
-    padding: 30px 10px;
-    background-color: #505050;
+    margin: 0 auto;
+    padding: 0;
+    background: var(--bp-card-bg);
+    border-radius: var(--bp-card-radius);
+    box-shadow: var(--bp-card-shadow);
+    overflow: hidden;
+    text-align: center;
 }
+
+/* ---------- Header band (logo area) ---------- */
+
+.block > a {
+    display: block;
+    background: var(--bp-arista-blue);
+    padding: 24px 20px;
+    text-align: center;
+}
+
+.company-logo {
+    display: block;
+    margin: 0 auto;
+    max-width: 240px;
+    max-height: 48px;
+}
+
+/* ---------- Headings ---------- */
 
 .block h1 {
-    color: #67BD4A;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+    margin: 0;
+    padding: 16px var(--bp-content-margin);
+    font-size: 24px;
+    font-weight: 500;
+    color: var(--bp-arista-blue);
+    letter-spacing: 0.2px;
 }
 
-.block p {
-    margin: 5px;
-}
+/* ---------- Horizontal rules ---------- */
 
 .block hr {
     border: 0;
-    margin: 20px 0;
+    margin: 16px var(--bp-content-margin);
     height: 1px;
-    background-image: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0));
+    background: rgba(0, 0, 0, 0.12);
 }
+
+/* ---------- Details tables ---------- */
+
+.bp-details-table {
+    width: calc(100% - var(--bp-content-margin) * 2);
+    margin: 0 var(--bp-content-margin);
+    text-align: left;
+    border-collapse: collapse;
+}
+
+.bp-details-table td {
+    vertical-align: top;
+    padding: 4px 0;
+}
+
+.bp-details-table td:first-child {
+    width: 52px;
+    padding-right: 12px;
+    vertical-align: top;
+    padding-top: 8px;
+}
+
+/* ---------- Text styles ---------- */
+
+.block p {
+    margin: 4px 0;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.bp-description {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--bp-arista-dark-gray);
+}
+
+.bp-contact {
+    font-size: 11px;
+    color: var(--bp-arista-medium-gray);
+}
+
+.bp-contact a {
+    color: var(--bp-arista-medium-blue);
+    text-decoration: none;
+}
+
+.bp-contact a:hover {
+    text-decoration: underline;
+}
+
+.block strong {
+    font-weight: 500;
+    color: var(--bp-arista-dark-gray);
+}
+
+/* ---------- Icons (inline SVG via background-image) ---------- */
+
+.bp-icon {
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    min-width: 40px;
+    min-height: 40px;
+    vertical-align: middle;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.bp-icon-block {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23D47122'%3E%3Cpath d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-4.42 3.58-8 8-8 1.85 0 3.55.63 4.9 1.69L5.69 16.9A7.902 7.902 0 0 1 4 12zm8 8c-1.85 0-3.55-.63-4.9-1.69L18.31 7.1A7.902 7.902 0 0 1 20 12c0 4.42-3.58 8-8 8z'/%3E%3C/svg%3E");
+}
+
+.bp-icon-link {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23969696'%3E%3Cpath d='M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z'/%3E%3C/svg%3E");
+}
+
+/* ---------- Buttons ---------- */
 
 .block button {
     display: inline-block;
-    font-size: 13px;
-    padding: 4px 12px;
-    font-weight: 400;
-    margin: 5px;
-    text-align: center;
+    margin: 8px var(--bp-content-margin) 24px;
+    padding: 10px 20px;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: #FFFFFF;
+    background: var(--bp-arista-blue);
+    border: none;
+    border-radius: var(--bp-card-radius);
+    cursor: pointer;
+    transition: background 0.15s ease, box-shadow 0.15s ease;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+    outline: none;
     white-space: nowrap;
     vertical-align: middle;
-    cursor: pointer;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    outline: none;
-    background-color: #67BD4A;
-    color: #FFF;
-    transition: all ease-in-out .15s;
 }
 
-.block button:hover {
-    background-color: rgba(103,189,74,.8);
+.block button:hover,
+.block button:focus {
+    background: var(--bp-arista-medium-blue);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);
 }
+
 .block button:active {
-    -webkit-box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
-    box-shadow: inset 0 3px 5px rgba(0,0,0,.2);
+    background: var(--bp-arista-blue);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.18) inset;
 }
 
-.company-logo {
-    max-width: 150px;
-    max-height: 140px;
-}
+/* ---------- Form elements (password unblock field) ---------- */
 
-@media ( max-width : 320px) {
-    .block .company-logo {
-        height: 60px;
-    }
-}
-
-
-/* user pages content container */
-#content {
-    padding: 17px 12px 12px 12px;
-}
-/* blockpage body*/
-body.blockpage {
-    background-color: #C0C0C0;
-}
-/* blockpage content */
-body.blockpage #content {
-    width: 627px;
-    height: 505px;
-    position: relative;
-    margin-left: auto;
-    margin-right: auto;
-    text-align: left;
-    border: 1px solid #888888;
-    margin-top: 30px;
-    margin-bottom: 30px;
-    background: #505050;
-    -webkit-border-radius: 15px;
-    -moz-border-radius: 15px;
-    border-radius: 15px;
-}
-
-/* blockpage body*/
-body.blockpage {
-    font-size: 10pt;
-}
-
-/* blockpage description text*/
-body.blockpage .description {
-    margin-bottom: 30px;
-    color: #FFFFFF;
-}
-
-/* blockpage contact text*/
-body.blockpage p.contact {
-    position: absolute;
-    bottom: 15px;
-    left: 20px;
-    font-size: 8pt;
-}
-/* header container */
-#header {
-    margin-bottom: 0px;
-}
-/* block page title */
-.title-block-page {
-    padding-left: 30px;
-    vertical-align: bottom;
-    text-align: left;
-    font: bold 36px arial, tahoma, helvetica, sans-serif;
-    color: #67686B;
-}
-/* blocked page icon*/
-.icon-block {
-    background: transparent url(../images/user/icon_block.png) no-repeat center center;
-    height: 130px;
-}
-/* quarantined messages toolbar message*/
-.message,.message-2 {
-    padding: 5px 5px 5px 28px;
-    border: 1px solid #60BB3F;
-    font-size: 8pt;
-    background: #FEFEDD url(../images/user/icon_message.png) no-repeat scroll 7px center !important;
-    color: #333;
-}
-
-.message-2 {
-    display: block;
-    margin-bottom: 10px;
-}
-
-.message-container {
-    padding: 2px;
-}
-
-.white-background {
-    background-color: #FFF;
-    background-image: none;
-}
-
-.description {
-    font-size: larger;
-}
-/* block page main container */
-body.blockpage #main {
-    position: absolute;
-    left: 15px;
-    top: 130px;
-    width: 620px;
-    height: 380px;
-    text-align: center;
-    /* This is to place this above the border */
-    z-index: 100;
-}
-
-body.blockpage #extra-div-1 {
-    position: absolute;
-    left: 15px;
-    top: 130px;
-    width: 620px;
-    height: 380px;
-    background: transparent;
-}
-
-body.blockpage #extra-div-2 {
-    position: absolute;
-    left: 15px;
-    bottom: 20px;
-    width: 620px;
-    height: 12px;
-    background: transparent;
-}
-
-#header {
-    position: relative;
-}
-/* block page title */
-body.blockpage #header .title {
-    position: absolute;
-    left: 180px;
-    bottom: 8px;
-    font: bold 36px arial, tahoma, helvetica, sans-serif;
-    color: #67BD4A;
-}
-/* block page information list container*/
-.info-list {
-    margin-top: 10px;
-    margin-bottom: 20px;
-    width: 340px;
-    margin-left: auto;
-    margin-right: auto;
-    text-align: left;
-    background-color: #505050;
-    color: white;
-}
-/* block page information list element */
-.info-list div {
-    padding: 5px 5px 5px 5px;
-}
-/* block page footer */
-body.blockpage #footer {
-    font-size: small;
-    text-align: right;
-    position: absolute;
-    left: 490px;
-    top: 520px;
-    display: none;
-}
-/* block page */
 .u-form-item {
-    margin: 5px 0;
+    margin: 12px 0;
     text-align: left;
-    width: 340px;
 }
 
 .u-form-item-label {
-    float: left;
-    font-weight: bold;
+    display: block;
+    margin-bottom: 4px;
+    font-weight: 500;
+    font-size: 13px;
+    color: var(--bp-arista-dark-gray);
+}
+
+.bp-input-wrapper {
+    position: relative;
+}
+
+.bp-input-icon {
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    background-color: #9098A1;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    pointer-events: none;
+}
+
+.bp-input-icon-lock {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%239098A1'%3E%3Cpath d='M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z'/%3E%3C/svg%3E");
+    background-color: transparent;
+}
+
+.bp-input-wrapper:focus-within .bp-input-icon-lock {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%234473A9'%3E%3Cpath d='M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z'/%3E%3C/svg%3E");
+}
+
+.u-form-text,
+.u-form-field {
+    display: block;
+    width: 100%;
+    padding: 12px 14px 12px 42px;
+    margin: 0;
+    font-family: inherit;
+    font-size: 14px;
+    line-height: 1.4;
+    color: var(--bp-arista-dark-gray);
+    background: #FFFFFF;
+    border: 1px solid var(--bp-arista-light-gray);
+    border-radius: var(--bp-card-radius);
+    outline: none;
     text-align: left;
-    color: white;
-    padding: 2px 5px;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-#unblockNowButton {
-    margin-left: 0px;
-    font-size: 11px;
-    font-family: Tahoma, Helvetica, Arial, sans-serif;
+.u-form-text:focus,
+.u-form-field:focus {
+    border-color: var(--bp-arista-light-blue);
+    box-shadow: 0 0 0 3px rgba(68, 115, 169, 0.18);
 }
 
-#unblockGlobalButton {
-    margin-left: 5px;
-    font-size: 11px;
-    font-family: Tahoma, Helvetica, Arial, sans-serif;
+.u-form-field::placeholder {
+    color: #9098A1;
+    opacity: 1;
+}
+
+.u-form-field:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0px 1000px #FFFFFF inset;
+    -webkit-text-fill-color: var(--bp-arista-dark-gray);
 }
 
 #invalid-password {
-    color: coral;
-    margin-left: 60px;
+    margin-top: 8px;
+    color: var(--bp-arista-orange);
+    font-size: 13px;
+    font-weight: 500;
+}
+
+/* ---------- Small screens ---------- */
+
+@media (max-width: 480px) {
+    body.blockpage {
+        padding: 16px 12px;
+    }
+
+    .block > a {
+        padding: 20px 16px;
+    }
+
+    .company-logo {
+        max-height: 40px;
+        max-width: 200px;
+    }
+
+    .block h1 {
+        padding: 16px 18px 0;
+        font-size: 18px;
+    }
+
+    .block hr {
+        margin: 12px 18px;
+    }
+
+    .bp-details-table {
+        margin: 0 18px;
+    }
+
+    .bp-icon {
+        width: 36px;
+        height: 36px;
+    }
+
+    .block button {
+        margin: 8px 18px 20px 4px;
+        padding: 10px 16px;
+        font-size: 13px;
+    }
 }

--- a/uvm/hier/usr/share/untangle/web/skins/common/css/user.css
+++ b/uvm/hier/usr/share/untangle/web/skins/common/css/user.css
@@ -147,8 +147,12 @@ body.blockpage {
 }
 
 .block strong {
-    font-weight: 500;
+    font-weight: 700;
     color: var(--bp-arista-dark-gray);
+}
+
+.bp-details-table p {
+    font-weight: 400;
 }
 
 /* ---------- Icons (inline SVG via background-image) ---------- */

--- a/uvm/servlets/blockpage/root/blockpage_template.jspx
+++ b/uvm/servlets/blockpage/root/blockpage_template.jspx
@@ -30,9 +30,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
     <meta content="IE=7.0000" http-equiv="X-UA-Compatible"/>
     <link rel="icon" type="image/png" href="/images/block-favicon.png"/>
-    <link href="/ext6.2/fonts/font-awesome/css/font-awesome.min.css" rel="stylesheet" />
     <title><c:out value="${pageTitle}"/></title>
-    <uvm:skin src="user.css" name="${skinName}"/>
+    <link type="text/css" rel="stylesheet" href="/skins/common/css/user.css" />
 
     <uvm:inlineScript>
       <![CDATA[
@@ -52,22 +51,22 @@
 
   <body class="blockpage">
     <div class="block">
-      <a href="${companyUrl}"><img src="/images/BrandingLogo.png" alt="Logo" class="company-logo" style="max-width: 300px; max-height: 48px;"/></a>
+      <a href="${companyUrl}"><img src="/images/BrandingLogo.png" alt="Logo" class="company-logo"/></a>
       <hr/>
 
       <h1><c:out value="${title}" escapeXml="false"/></h1>
-      <table style="margin: 0 20px; text-align: left;">
+      <table class="bp-details-table">
         <tr>
-          <td><i class="fa fa-ban" style="font-size: 64px; color: red; vertical-align: top;"></i></td>
-          <td><p style="font-weight: bold;">${description}</p><p style="font-size: 12px; color: #CCC;">${contact}</p></td>
+          <td><span class="bp-icon bp-icon-block" aria-hidden="true"></span></td>
+          <td><p class="bp-description">${description}</p><p class="bp-contact">${contact}</p></td>
         </tr>
       </table>
 
       <hr/>
 
-      <table style="margin: 0 20px; text-align: left;">
+      <table class="bp-details-table">
         <tr>
-          <td><i class="fa fa-link" style="font-size: 64px; color: #999; vertical-align: middle;"></i></td>
+          <td><span class="bp-icon bp-icon-link" aria-hidden="true"></span></td>
           <td>
             <p><strong><uvm:i18n>Host:</uvm:i18n></strong> <c:out value=" ${bd.formattedHost}"/></p>
             <p><strong><uvm:i18n>URL:</uvm:i18n></strong> <c:out value=" ${bd.formattedUrl}"/></p>

--- a/web-filter-base/servlets/web-filter/src/com/untangle/app/web_filter/WebFilterBlockPageServlet.java
+++ b/web-filter-base/servlets/web-filter/src/com/untangle/app/web_filter/WebFilterBlockPageServlet.java
@@ -146,7 +146,7 @@ public class WebFilterBlockPageServlet extends com.untangle.app.web_filter.Block
             }
 
             String errorText = I18nUtil.tr("The password you entered is incorrect.", i18n_map);
-            returnFields += "<div class=\"u-form-item\"><label class=\"u-form-item-label\">Password:</label><input class=\"u-form-text u-form-field\" type=\"password\" id=\"unblockPassword\"/></div><div id=\"invalid-password\" style=\"display: none\">" + errorText + "</div>";
+            returnFields += "<div class=\"u-form-item\"><div class=\"bp-input-wrapper\"><span class=\"bp-input-icon bp-input-icon-lock\" aria-hidden=\"true\"></span><input class=\"u-form-text u-form-field\" type=\"password\" id=\"unblockPassword\" placeholder=\"" + I18nUtil.tr("Enter password", i18n_map) + "\"/></div></div><div id=\"invalid-password\" style=\"display: none\">" + errorText + "</div>";
 
             return returnFields;
         }


### PR DESCRIPTION
## Summary

Restyle the NGFW block page (served to end-users when traffic is blocked by Web Filter, Virus Blocker, or Threat Prevention) to match the Vue UI (vuntangle) design language — consistent with the captive portal restyling done in `0e1c86f59b`.

## Motivation

The admin UI is migrating from ExtJS to Vue/Vuetify. The block page still used old Untangle-era styling: PT Sans font, gray/dark-gray color scheme, green (#67BD4A) accents, and Font Awesome icons loaded from the ExtJS directory tree (`/ext6.2/`). This change aligns it with the Arista/vuntangle design system (colors, typography, layout) and removes the ExtJS dependency.

## Changes

### Block Page Template (`blockpage_template.jspx`)
- Removed Font Awesome CSS link from `/ext6.2/fonts/font-awesome/` — eliminates ExtJS directory dependency
- Replaced `<uvm:skin>` tag with a direct `<link>` to `/skins/common/css/user.css` — bypasses skin name indirection and Apache rewrite fallback
- Replaced Font Awesome `<i class="fa fa-ban">` and `<i class="fa fa-link">` with `<span class="bp-icon bp-icon-block/link">` elements styled via CSS SVG data URIs
- Removed all inline `style` attributes (icon colors, font sizes, table margins, logo sizing) — moved to CSS classes (`bp-details-table`, `bp-description`, `bp-contact`)

### Block Page CSS (`common/css/user.css`)
- Full rewrite using CSS custom properties (`--bp-arista-blue`, `--bp-arista-medium-blue`, etc.) sourced from `vuntangle/src/config/theme.js` and `variables.scss`
- Light theme: `#F5F5F5` background, white card with shadow, Arista Blue (`#16325B`) headings and buttons
- Roboto font with system fallback stack (no self-hosted font files, matching captive portal approach)
- SVG data URI icons via `background-image` for the ban and link icons — zero external font dependencies
- Vuetify-style buttons: uppercase, 500 weight, letter-spacing, blue background with hover transition
- Password input field with lock icon overlay (matching captive portal's `input-wrapper` + `input-icon-lock` pattern), focus ring, placeholder text, and autofill styling
- Responsive breakpoint at 480px for mobile viewports
- Removed ~130 lines of dead CSS for the unused `simple.jspx` template

### Password Field HTML (`WebFilterBlockPageServlet.java`)
- Wrapped the password `<input>` in a `<div class="bp-input-wrapper">` with a `<span class="bp-input-icon bp-input-icon-lock">` lock icon — matching captive portal pattern
- Removed the external "Password:" label (the placeholder text "Enter password" inside the input is sufficient)
- Added i18n wrapping for the placeholder text

## Testing

Manually verified all block page flows on NGFW (LAN: 192.168.56.186) with client (192.168.56.175):

1. **HTTP URL block** (unblock mode: None) — card, header, icons, title, description, contact, Host/URL/Reason/Details all render correctly
2. **HTTP URL block** (unblock mode: Temporary) — "UNBLOCK FOR NOW" button visible, click unblocks site
3. **Temporary + password required** — password input with lock icon appears, styled matching captive portal
4. **Wrong password** — orange error message "The password you entered is incorrect." displayed
5. **Correct password** — redirects to unblocked site
6. **Permanent and Global mode** — both "UNBLOCK FOR NOW" and "UNBLOCK PERMANENTLY" buttons visible, permanent unblock adds to Pass Sites
7. **Category block** (Shopping → amazon.com) — category name shown as reason
8. **Search term block** — search term shown in details
9. **HTTPS SNI block** — same block page rendered via SSL-wrapped redirect
10. **Custom block page URL** — redirects to configured external URL
11. **Image request** — returns 1x1 transparent GIF (HTTP 403), no block page
12. **Virus Blocker** (EICAR test file) — block page with "Virus Blocker" title, no unblock buttons
13. **Threat Prevention** — block page with "Threat Prevention" title, no unblock buttons
14. **Mobile viewport** (375px) — responsive layout, no overflow

## Screenshots

<img width="1280" height="879" alt="Screenshot from 2026-07-10 20-29-43" src="https://github.com/user-attachments/assets/2681b159-d3d6-4c30-902e-ac9e0ae46de1" />
<img width="1280" height="879" alt="Screenshot from 2026-07-10 20-30-22" src="https://github.com/user-attachments/assets/bdfafca7-0104-434e-8304-603836a972db" />
<img width="1280" height="879" alt="Screenshot from 2026-07-10 20-31-27" src="https://github.com/user-attachments/assets/71e5bb5e-d2ac-4d7c-9b8c-7c62eeec5aaf" />
<img width="1280" height="879" alt="Screenshot from 2026-07-10 20-31-58" src="https://github.com/user-attachments/assets/053c7c1a-584c-4534-a19a-0e08d6185f40" />
<img width="1280" height="879" alt="Screenshot from 2026-07-10 20-27-54" src="https://github.com/user-attachments/assets/920f22c7-acc2-4691-9aa6-a8dd85444bd6" />
<img width="1280" height="879" alt="Screenshot from 2026-07-10 20-27-47" src="https://github.com/user-attachments/assets/7a2c25b8-d60e-4946-85d9-4b015f48e9d1" />


## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
