### PR TITLE
NGFW-15853: fix IPsec VPN report integer overflow on high-traffic tunnels

### DIFF
--- a/ipsec-vpn/hier/usr/share/untangle/lib/ipsec-vpn/reports/tunnel-time-stats.json
+++ b/ipsec-vpn/hier/usr/share/untangle/lib/ipsec-vpn/reports/tunnel-time-stats.json
@@ -10,8 +10,8 @@
     "readOnly": true,
     "table": "ipsec_tunnel_stats",
 "timeDataColumns": [
-        "sum(in_bytes::int) as recv",
-        "sum(out_bytes::int) as xmit"
+        "sum(in_bytes) as recv",
+        "sum(out_bytes) as xmit"
     ],
     "colors": [
         "#396c2b",

--- a/ipsec-vpn/hier/usr/share/untangle/lib/ipsec-vpn/reports/tunnel-traffic-stats.json
+++ b/ipsec-vpn/hier/usr/share/untangle/lib/ipsec-vpn/reports/tunnel-traffic-stats.json
@@ -9,7 +9,7 @@
     "orderDesc": false,
     "units": "bytes",
     "pieGroupColumn": "tunnel_name",
-    "pieSumColumn": "sum(in_bytes::int + out_bytes::int)",
+    "pieSumColumn": "sum(in_bytes + out_bytes)",
     "readOnly": true,
     "table": "ipsec_tunnel_stats",
     "title": "Top Tunnel Traffic",


### PR DESCRIPTION
Remove unnecessary ::int casts from ipsec_tunnel_stats report queries. The in_bytes and out_bytes columns are bigint, and casting to int causes "integer out of range" errors when tunnel traffic exceeds ~2.1 GB.