### PR TITLE
NGFW-15885 Migrated Reports exec() unsafe operations

### DIFF
--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
@@ -447,9 +447,23 @@ public class IpsecVpnApp extends AppBase
     private void waitForCharonStart() {
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
         Runnable task = () -> {
-            String processes = IpsecVpnApp.execManager().execOutput("ps aux | grep charon");
-            logger.debug("ps aux | grep charon : {}", processes);
-            if (processes.contains(CHARON_DAEMON_PATH)) {
+            // NGFW-15855: argv form via pgrep -f avoids the shell pipe from
+            // "ps aux | grep charon". Semantically equivalent: pgrep -f matches
+            // any process whose full command line contains CHARON_DAEMON_PATH,
+            // which is exactly what the OLD contains(CHARON_DAEMON_PATH) test
+            // did on ps-aux output.
+            //
+            // NOTE: pgrep -f treats PATTERN as a POSIX extended regex, NOT a
+            // literal string. CHARON_DAEMON_PATH has no regex metacharacters
+            // today (. [ ] ( ) + ? * | ^ $ \), so regex-matching behaves
+            // identically to literal substring matching. If the constant is
+            // ever changed to include a regex metacharacter, revisit this call
+            // to preserve the OLD literal-substring semantics.
+            int rc = IpsecVpnApp.execManager()
+                .execCommand("/usr/bin/pgrep", List.of("-f", CHARON_DAEMON_PATH))
+                .getResult();
+            logger.debug("pgrep -f {} : exit={}", CHARON_DAEMON_PATH, rc);
+            if (rc == 0) {
                 scheduler.shutdown();
             }
         };

--- a/reports/hier/usr/share/untangle/bin/ut-reports-clean-tables
+++ b/reports/hier/usr/share/untangle/bin/ut-reports-clean-tables
@@ -1,0 +1,10 @@
+#!/bin/bash
+# NGFW-15855 UNT-50: replaces the inline shell string
+#   REPORTS_CLEAN_TABLES_SCRIPT ... | logger -t uvmreports
+# from ReportsApp.checkDbRetentionChange() so the Java caller can use
+# execCommand() argv form. Preserves the syslog tag "uvmreports" behavior
+# and last-cmd exit-code semantics (NO pipefail).
+#
+# Do NOT add `set -o pipefail` without also updating the caller: today, if
+# the cleanup script fails but logger succeeds, this exits 0 (matches OLD).
+/usr/share/untangle/bin/reports-clean-tables.py "$@" | /usr/bin/logger -t uvmreports

--- a/reports/src/com/untangle/app/reports/ReportsApp.java
+++ b/reports/src/com/untangle/app/reports/ReportsApp.java
@@ -1034,7 +1034,6 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
      */
     private void checkDbRetentionChange( ReportsSettings newSettings )
     {
-        String execStr;
         int currHourly, currDaily, newHourly, newDaily;
 
         if (this.settings == null) {
@@ -1048,12 +1047,20 @@ public class ReportsApp extends AppBase implements Reporting, HostnameLookup
 
         if(newDaily != currDaily ||
            newHourly != currHourly) {
+            // NGFW-15855: migrated from shell pipeline
+            //   REPORTS_CLEAN_TABLES_SCRIPT ... | logger -t uvmreports
+            // to argv form via a wrapper script (ut-reports-clean-tables) that
+            // preserves the "| logger -t uvmreports" syslog tag pipeline internally.
+            // Exit-code semantics preserved: wrapper has no set -o pipefail, so
+            // its exit code is logger's (typically 0) just like the original.
+            List<String> argsList;
             if(newHourly > 0) {
-                execStr = REPORTS_CLEAN_TABLES_SCRIPT + " -d " + ReportsApp.dbDriver + " -h " + newHourly + " 0 | logger -t uvmreports";
+                argsList = List.of("-d", ReportsApp.dbDriver, "-h", String.valueOf(newHourly), "0");
             } else {
-                execStr = REPORTS_CLEAN_TABLES_SCRIPT + " -d " + ReportsApp.dbDriver + " " + newDaily + " | logger -t uvmreports";
+                argsList = List.of("-d", ReportsApp.dbDriver, String.valueOf(newDaily));
             }
-            UvmContextFactory.context().execManager().execResult( execStr );
+            UvmContextFactory.context().execManager().execCommand(
+                "/usr/share/untangle/bin/ut-reports-clean-tables", argsList);
         }
     }
 

--- a/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
+++ b/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
@@ -1214,15 +1214,23 @@ public class ReportsManagerImpl implements ReportsManager
                 app.getEventWriter().stop();
             }
             String pgCleanupCmd = "/usr/share/untangle/bin/reports-reinitialize-database.sh";
-            String pgStopCmd = "/etc/init.d/postgresql stop >/dev/null 2>&1";
+            // NGFW-15855: dropped ">/dev/null 2>&1" suffix. The launcher already
+            // captures stdout/stderr into ExecManagerResult.output which this caller
+            // never reads (execResult only returns the exit code).
+            String pgStopCmd = "/etc/init.d/postgresql stop";
             String pgStatusCmd = "/etc/init.d/postgresql status";
-            String pgStartCmd = "/etc/init.d/postgresql start >/dev/null 2>&1";
+            String pgStartCmd = "/etc/init.d/postgresql start";
             String generateReportTablesCmd = "/usr/share/untangle/bin/reports-generate-tables.py";
             UvmContextFactory.context().execManager().execResult(pgStopCmd);
-            int pgStatus = UvmContextFactory.context().execManager().execResult(pgStatusCmd + " | grep Stopped");
+            // NGFW-15855: the original code assigned this to pgStatus but overwrote
+            // the value on line below before ever reading it. The exec call is
+            // preserved (roughly 100-300ms) as a coincidental timing buffer between
+            // stop and cleanup. Migrated to argv form to drop the "| grep Stopped"
+            // shell pipe; the grep filter's exit code was dead-value anyway.
+            UvmContextFactory.context().execManager().execCommand("/etc/init.d/postgresql", List.of("status"));
             UvmContextFactory.context().execManager().execOutput(pgCleanupCmd);
             UvmContextFactory.context().execManager().execResult(pgStartCmd);
-            pgStatus = UvmContextFactory.context().execManager().execResult(pgStatusCmd);
+            int pgStatus = UvmContextFactory.context().execManager().execResult(pgStatusCmd);
             logger.info("Postgress Status Response {}", pgStatus);
             if (pgStatus == 0) {
                 UvmContextFactory.context().execManager().execOutput(generateReportTablesCmd);

--- a/uvm/api/com/untangle/uvm/ExecManager.java
+++ b/uvm/api/com/untangle/uvm/ExecManager.java
@@ -95,7 +95,29 @@ public interface ExecManager
      * Called "execEvil" because it calls fork which can cause issues
      */
     Process execEvilProcess(String cmd[]);
-    
+
+    /**
+     * Fire-and-forget process launch with stdout/stderr redirected to /dev/null
+     * and SIGHUP ignored by the child, so the spawned process survives when
+     * the JVM exits. Behaviorally equivalent to shell
+     * "nohup CMD &gt;/dev/null 2&gt;&amp;1 &amp;" without invoking a shell.
+     *
+     * Differs from execEvilProcess() which uses Runtime.exec() and leaves the
+     * child's stdout/stderr connected as pipes into the JVM.
+     *
+     * Internally prepends /usr/bin/nohup to the argv so the child inherits
+     * SIG_IGN for SIGHUP. Required because the UVM JVM is started under
+     * start-stop-daemon --background, which makes it a session leader; when
+     * the JVM exits, the kernel sends SIGHUP to every process in its session.
+     * Without nohup the spawned child would die on JVM exit, matching the
+     * OLD shell "nohup ... &amp;" semantics.
+     *
+     * @param cmd
+     *        argv array (element 0 is the executable, rest are its arguments)
+     * @return the spawned Process, or null if launch failed
+     */
+    Process execEvilProcessDetached(String cmd[]);
+
     /**
      * Close this instance of exec manager
      * This shuts down the "launcher" process

--- a/uvm/api/com/untangle/uvm/WebBrowser.java
+++ b/uvm/api/com/untangle/uvm/WebBrowser.java
@@ -107,7 +107,15 @@ public class WebBrowser
 
         try{
             UvmContextFactory.context().execManager().exec("pkill -f \"" + this.xCommand+ "\"");
-            UvmContextFactory.context().execManager().execOutput("nohup " + this.xCommand + " >/dev/null 2>&1 &");
+            // NGFW-15855: replaced shell "nohup ... >/dev/null 2>&1 &" with
+            // execEvilProcessDetached. Redirect.DISCARD attaches /dev/null at
+            // the OS fd layer (equivalent to >/dev/null 2>&1), so Xvfb won't
+            // get SIGPIPE when the JVM exits. start() returns immediately
+            // (equivalent to trailing &). nohup is a no-op here because the
+            // JVM child has no controlling terminal.
+            // xCommand is built from fixed tokens (Xvfb, :N, -screen, S, WxHxD)
+            // with no embedded spaces, so split("\\s+") is safe.
+            UvmContextFactory.context().execManager().execEvilProcessDetached(this.xCommand.split("\\s+"));
 
             ChromeDriverService service = new ChromeDriverService.Builder()
                 .usingDriverExecutable(new File(chromeDriver))

--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
@@ -494,6 +494,64 @@ class AdministrationTests(NGFWTestCase):
         #  certificates list should be unchanged after test execution
         assert(len(initial_certificates_list['list']) == len(final_certificates_list['list']))
 
+    def test_026_upload_root_certificate(self):
+        """
+        NGFW-15886: verify uploadCertificate("ROOT", ...) creates the root-cert
+        directory correctly via the migrated Files.* calls (Site 7). Exercises
+        Files.createDirectories (== mkdir -p), Files.writeString (== echo >),
+        and Files.createFile-with-exists-guard (== touch).
+
+        Asserts on the four files Site 7 produces (untangle.crt, untangle.key,
+        serial.txt, index.txt), their permissions, serial.txt's byte content,
+        and index.txt's zero-byte state.
+        """
+        import subprocess
+        cert_mgr = global_functions.uvmContext.certificateManager()
+        certificates_dir = '/usr/share/untangle/settings/untangle-certificates'
+        initial_root_dirs = set(glob(join(certificates_dir, '[0-9]*/')))
+
+        try:
+            resp = cert_mgr.uploadCertificate("ROOT", certData, keyData, "")
+            assert resp is not None
+            # ROOT branch returns success msg per CertificateManagerImpl:847
+            assert "Root Certificate successfully uploaded" in resp.get("output", "")
+
+            # Find the newly-created baseName directory
+            new_root_dirs = list(set(glob(join(certificates_dir, '[0-9]*/'))) - initial_root_dirs)
+            assert len(new_root_dirs) == 1, f"expected exactly 1 new dir, got {new_root_dirs}"
+            new_root = new_root_dirs[0]
+
+            # All four expected files present with 0644 permissions
+            for fname in ('untangle.crt', 'untangle.key', 'serial.txt', 'index.txt'):
+                fpath = join(new_root, fname)
+                assert os.path.isfile(fpath), f"missing {fpath}"
+                mode = os.stat(fpath).st_mode & 0o777
+                assert mode == 0o644, f"{fpath} mode is 0o{mode:o}, expected 0o644"
+
+            # index.txt is empty (Files.createFile produces zero-byte file;
+            # matches touch's semantic on a fresh directory)
+            assert os.path.getsize(join(new_root, 'index.txt')) == 0, \
+                "index.txt should be empty"
+
+            # serial.txt content matches BigInteger.toString(16) of the CRT's serial + "\n"
+            with open(join(new_root, 'serial.txt'), 'rb') as f:
+                serial_bytes = f.read()
+            assert serial_bytes.endswith(b'\n'), \
+                "serial.txt should end with LF (explicit '\\n' preserved)"
+            # openssl pads serials to even hex chars; BigInteger.toString(16) does not.
+            # Strip leading zeros on both sides before comparing.
+            crt_serial = subprocess.check_output(
+                ["openssl", "x509", "-in", join(new_root, "untangle.crt"),
+                 "-noout", "-serial"], text=True).split("=")[1].strip().lower().lstrip("0")
+            file_serial = serial_bytes.strip().decode().lower().lstrip("0")
+            assert crt_serial == file_serial, \
+                f"serial content mismatch: crt={crt_serial} file={file_serial}"
+
+        finally:
+            # Cleanup - removeCertificate("ROOT") takes absolute path to untangle.crt
+            for d in set(glob(join(certificates_dir, '[0-9]*/'))) - initial_root_dirs:
+                cert_mgr.removeCertificate("ROOT", join(d, "untangle.crt"))
+
     def test_030_skin_upload_deprecated(self):
         """Verify skin upload to /admin/upload is rejected (handleFile deprecated)"""
         import zipfile

--- a/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
+++ b/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
@@ -57,6 +57,11 @@ ALLOWED_EXECUTABLES = {
     "/usr/share/untangle/bin/wan-failover-pingable-hosts.sh",
     "/usr/share/untangle/bin/ut-wireguard-helpers.sh",
     "/usr/share/untangle/bin/fetch_ip_list.py",
+    # NGFW-15855 additions
+    "/bin/sed",
+    "/etc/init.d/postgresql",
+    "/usr/share/untangle/bin/ut-reports-clean-tables",
+    "/usr/share/untangle/bin/ut-verify-cert-chain",
 
 }
 

--- a/uvm/hier/usr/share/untangle/bin/ut-verify-cert-chain
+++ b/uvm/hier/usr/share/untangle/bin/ut-verify-cert-chain
@@ -1,0 +1,9 @@
+#!/bin/bash
+# NGFW-15855 UNT-50: replaces the inline openssl pipeline in
+# CertificateManagerImpl.validateUploadedCertificate() to avoid shell-string
+# exec. Exit code intentionally matches last-cmd semantics (NO pipefail) to
+# preserve the exact behavior of the original shell pipeline. Do NOT add
+# `set -o pipefail` without also updating CertificateManagerImpl's exit-code
+# expectations: the current caller tolerates crl2pkcs7 silent failure iff
+# pkcs7 exits 0 on empty stdin.
+openssl crl2pkcs7 -nocrl -certfile "$1" | openssl pkcs7 -print_certs -noout

--- a/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/CertificateManagerImpl.java
@@ -827,19 +827,42 @@ public class CertificateManagerImpl implements CertificateManager
             var newRootKey = newRootPath + "untangle.key";
             var newRootCrt = newRootPath + "untangle.crt";
 
-            // create the root cert dir using the basename
-            UvmContextFactory.context().execManager().exec("mkdir -p " + newRootPath);
+            // NGFW-15855: replaced the mkdir/echo-redirect/touch trio with
+            // java.nio.file.Files equivalents. Files.createDirectories == mkdir -p
+            // (creates intermediates, silent on exists). Files.writeString with
+            // default options == echo > (CREATE + TRUNCATE_EXISTING). The
+            // index.txt path uses Files.exists guard + createFile to match touch
+            // semantics of "create-if-absent, don't-truncate-if-present".
+            java.nio.file.Path rootDir = Paths.get(newRootPath);
+            try {
+                Files.createDirectories(rootDir);
+            } catch (IOException e) {
+                logger.warn("Failed to create root cert dir " + newRootPath, e);
+            }
 
             storeData(keyData, newRootKey);
-            
+
             storeData(certData, newRootCrt);
 
             // we use this certInfo to get the serial and add it to serial.txt
             var certInfo = get509CertFromString(certData);
 
             // Root certs also need an index and serial
-            UvmContextFactory.context().execManager().exec("echo " + certInfo.getSerialNumber().toString(16) + ">"+newRootPath+"serial.txt");
-            UvmContextFactory.context().execManager().exec("touch " + newRootPath + "index.txt");
+            try {
+                Files.writeString(
+                    rootDir.resolve("serial.txt"),
+                    certInfo.getSerialNumber().toString(16) + "\n");
+            } catch (IOException e) {
+                logger.warn("Failed to write serial.txt for " + newRootPath, e);
+            }
+            try {
+                java.nio.file.Path indexPath = rootDir.resolve("index.txt");
+                if (!Files.exists(indexPath)) {
+                    Files.createFile(indexPath);
+                }
+            } catch (IOException e) {
+                logger.warn("Failed to create index.txt for " + newRootPath, e);
+            }
 
             // symlinks key, cert, index, serial to the untangle-certificates directory
             symlinkRootCerts(CERT_STORE_PATH, newRootPath, false);
@@ -905,8 +928,21 @@ public class CertificateManagerImpl implements CertificateManager
         // make a copy of the server key file in the certificate key file
         UvmContextFactory.context().execManager().exec("cp " + LOCAL_KEY_FILE + " " + csrBaseKey);
 
-        // next create the certificate PEM file from the certificate KEY and CRT files
-        UvmContextFactory.context().execManager().exec("cat " + csrBaseCrt + " " + csrBaseKey + " > " + csrBasePem);
+        // NGFW-15855: replaced shell "cat crt key > pem" with byte-identical
+        // Java concat. Failure path logs a warning and continues, matching the
+        // OLD silent-continue behavior when cat failed. Downstream sed on the
+        // next line independently writes the same pem, so a failure here is
+        // masked at the flow level today.
+        try {
+            byte[] crtBytes = Files.readAllBytes(Paths.get(csrBaseCrt));
+            byte[] keyBytes = Files.readAllBytes(Paths.get(csrBaseKey));
+            byte[] combined = new byte[crtBytes.length + keyBytes.length];
+            System.arraycopy(crtBytes, 0, combined, 0, crtBytes.length);
+            System.arraycopy(keyBytes, 0, combined, crtBytes.length, keyBytes.length);
+            Files.write(Paths.get(csrBasePem), combined);
+        } catch (IOException e) {
+            logger.warn("Failed to build PEM from " + csrBaseCrt + " + " + csrBaseKey, e);
+        }
 
         // use sed to combine the CRT and KEY to create the PEM
         // note that there is NO space following the w argument
@@ -1156,8 +1192,14 @@ public class CertificateManagerImpl implements CertificateManager
                 logger.warn("Certificate key validation exit code: " + exitValue);
             }
             if (extraLen > 0 & exitValue == 0) {
+                // NGFW-15855: replaced the inline openssl pipeline with a wrapper
+                // script (ut-verify-cert-chain) that runs the same pipeline. The
+                // wrapper deliberately has NO set -o pipefail, preserving the
+                // OLD last-cmd exit-code semantics (openssl pkcs7's exit code).
                 // validate intermediate chain certificates
-                exitValue = UvmContextFactory.context().execManager().execResult("openssl crl2pkcs7 -nocrl -certfile " + fileLocation + " | openssl pkcs7 -print_certs -noout");
+                exitValue = UvmContextFactory.context().execManager().execCommand(
+                    "/usr/share/untangle/bin/ut-verify-cert-chain",
+                    java.util.List.of(fileLocation)).getResult();
                 logger.warn("Intermediate chain certificates validation exit code: " + exitValue);
             }
         } catch (Exception exn) {

--- a/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
@@ -307,7 +307,13 @@ public class ConfigManagerImpl implements ConfigManager
             @Override
             public void run()
             {
-                context.execManager().exec("nohup " + FACTORY_RESET_SCRIPT + " force-reboot >/dev/null 2>&1 &");
+                // NGFW-15855: replaced shell "nohup ... >/dev/null 2>&1 &" with
+                // execEvilProcessDetached. Redirect.DISCARD attaches /dev/null at
+                // the OS fd layer so the script's later echoes (running AFTER
+                // systemctl stop untangle-vm kills the JVM) do not hit a broken
+                // pipe. start() returns immediately (equivalent to trailing &);
+                // no controlling terminal on a Timer thread so nohup is a no-op.
+                context.execManager().execEvilProcessDetached(new String[]{FACTORY_RESET_SCRIPT, "force-reboot"});
             }
         }, 1000);
 

--- a/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
@@ -42,6 +42,23 @@ public class ExecManagerImpl implements ExecManager
 {
     private final Logger logger = LogManager.getLogger(getClass());
 
+    /**
+     * Shell metacharacters that make exec(String) unsafe. Any command containing
+     * one of these is refused by the filter (see exec(cmd, rateLimit, safe, ...)).
+     *
+     * NGFW-15855 / UNT-50: the filter is a defense-in-depth backstop; the real
+     * defense is migrating callers to execCommand(exe, argsList) argv form per
+     * ngfw-rce-architecture.md L3. Do NOT introduce new exec(String) callers
+     * whose command string embeds user-controlled input.
+     *
+     * "||" is functionally redundant with "|" for substring matching (any
+     * string containing "||" also contains "|"), kept in the list for source
+     * clarity and to match the T-18 canonical metachar set.
+     */
+    private static final String[] SUSPICIOUS_METAS = {
+        ";", "&&", "||", "|", ">", "<", "$(", "`"
+    };
+
     private JSONSerializer serializer = null;
 
     private Process proc = null;
@@ -159,8 +176,24 @@ public class ExecManagerImpl implements ExecManager
     }
 
     /**
+     * Returns true if cmd contains any shell metacharacter that would make
+     * exec(String) unsafe. See SUSPICIOUS_METAS for the current list.
+     *
+     * @param cmd
+     *        The command string to inspect
+     * @return true if any metacharacter in SUSPICIOUS_METAS is a substring of cmd
+     */
+    private static boolean containsSuspicious(String cmd)
+    {
+        for (String meta : SUSPICIOUS_METAS) {
+            if (cmd.contains(meta)) return true;
+        }
+        return false;
+    }
+
+    /**
      * Executes a command and returns the result object
-     * 
+     *
      * @param cmd
      *        The String command to execute and optionally the rate limit flag
      * @return The execution result object
@@ -219,13 +252,19 @@ public class ExecManagerImpl implements ExecManager
         cmd = cmd.replace("\n", "");
         cmd = cmd.replace("\r", "");
 
-        if (cmd.contains(";") || cmd.contains("&&") || cmd.contains("|") || cmd.contains(">") || cmd.contains("$(")) {
-            if(safe){
-                logger.log(this.level, "Suspicious command (" + cmd + "), blocked");
-                return new ExecManagerResult();
-            }else{
-                logger.log(this.level, "Suspicious command (" + cmd + "), allowing");
+        // NGFW-15855 / UNT-50: always block on suspicious metacharacters, regardless
+        // of the `safe` flag. Previously safe=false (the default for exec/execOutput/
+        // execResult) logged and continued, providing zero protection. The `safe`
+        // flag now only controls log severity so the two paths can be triaged
+        // separately during the ongoing migration to execCommand(exe, argsList).
+        // See ngfw-rce-architecture.md L3.
+        if (containsSuspicious(cmd)) {
+            if (safe) {
+                logger.warn("Refusing suspicious command: " + cmd);
+            } else {
+                logger.error("Refusing suspicious command (caller must migrate to execCommand(exe, args) or fix template): " + cmd);
             }
+            return new ExecManagerResult(-1, "");
         }
 
         try {
@@ -502,7 +541,7 @@ public class ExecManagerImpl implements ExecManager
 
     /**
      * Execute a command in a new process and return the process
-     * 
+     *
      * @param cmd
      *        The command to execute
      * @return The process
@@ -516,6 +555,56 @@ public class ExecManagerImpl implements ExecManager
         }
 
         return execEvilProcess(cmdArray);
+    }
+
+    /**
+     * Fire-and-forget process launch with stdout/stderr redirected to /dev/null
+     * at the OS file-descriptor layer, and SIGHUP ignored by the child.
+     * Behaviorally equivalent to shell "nohup CMD &gt;/dev/null 2&gt;&amp;1 &amp;"
+     * without invoking a shell.
+     *
+     * Differs from execEvilProcess() which uses Runtime.exec() and leaves the
+     * child's stdout/stderr connected as pipes into the JVM. Those pipes break
+     * when the JVM exits, delivering SIGPIPE to the child.
+     *
+     * SIGHUP handling: this method prepends /usr/bin/nohup to the argv so the
+     * child inherits SIG_IGN for SIGHUP via exec. Required because the UVM JVM
+     * is started under start-stop-daemon --background (see
+     * /etc/init.d/untangle-vm), which makes it a session leader. When a session
+     * leader exits, the kernel delivers SIGHUP to every process in its session,
+     * including any children spawned via ProcessBuilder. Without nohup, the
+     * spawned child would die on JVM exit (observed with ut-factory-defaults,
+     * which aborted before reaching `shutdown -r now`). The nohup wrapper
+     * matches the semantics of the OLD shell form "nohup CMD &amp;".
+     *
+     * @param cmd
+     *        The argv array to execute (element 0 is the executable, rest are
+     *        its arguments). No shell involvement.
+     * @return The spawned Process (representing the nohup wrapper, which exec's
+     *         the target), or null if launch failed. Caller typically discards
+     *         the Process reference; the child continues running and reparents
+     *         to init after the JVM exits.
+     */
+    public Process execEvilProcessDetached(String[] cmd)
+    {
+        // NGFW-15855: prepend nohup so the child ignores SIGHUP and survives JVM
+        // (session-leader) exit. See method Javadoc for the full rationale.
+        String[] withNohup = new String[cmd.length + 1];
+        withNohup[0] = "/usr/bin/nohup";
+        System.arraycopy(cmd, 0, withNohup, 1, cmd.length);
+
+        if (logger.isInfoEnabled()) {
+            logger.info("ExecManager.execEvilProcessDetached( " + String.join(" ", withNohup) + " )");
+        }
+        try {
+            return new ProcessBuilder(withNohup)
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start();
+        } catch (IOException e) {
+            logger.warn("Detached process launch failed:", e);
+            return null;
+        }
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/MailSenderImpl.java
+++ b/uvm/impl/com/untangle/uvm/MailSenderImpl.java
@@ -558,12 +558,20 @@ public class MailSenderImpl implements MailSender
              * Substitute the port in the exim template Set it back to 25 in
              * case it was previously configured to something else in smarthost
              */
+            // NGFW-15855: migrated to argv form via execCommand. Note the "\\n"
+            // in the replacement pattern below MUST remain a 2-char literal
+            // (backslash + n) in Java source, so sed receives the 2-char sequence
+            // "\n" in argv and interprets it as a newline in the replacement.
+            // Using Java "\n" (1-char real newline) would terminate sed's `s`
+            // command mid-parse.
             // remove all "  port = xx"
-            String cmd1 = "/bin/sed -e \"/..port.=.[0-9].*$/d\" -i " + EXIM_TEMPLATE_FILE;
-            UvmContextFactory.context().execManager().exec(cmd1);
+            UvmContextFactory.context().execManager().execCommand("/bin/sed", List.of(
+                "-e", "/..port.=.[0-9].*$/d",
+                "-i", EXIM_TEMPLATE_FILE));
             // insert new "  port = xx"
-            String cmd2 = "/bin/sed -e \"s|  driver = smtp|  driver = smtp\\n  port = " + 25 + "|g\" -i " + EXIM_TEMPLATE_FILE;
-            UvmContextFactory.context().execManager().exec(cmd2);
+            UvmContextFactory.context().execManager().execCommand("/bin/sed", List.of(
+                "-e", "s|  driver = smtp|  driver = smtp\\n  port = " + 25 + "|g",
+                "-i", EXIM_TEMPLATE_FILE));
         } else {
             /**
              * Send mail to smarthost
@@ -624,12 +632,15 @@ public class MailSenderImpl implements MailSender
             if (settings.getSendMethod() == MailSettings.SendMethod.CUSTOM) targetPort = settings.getSmtpPort();
             if (settings.getSendMethod() == MailSettings.SendMethod.RELAY) targetPort = STUNNEL_RELAY_PORT;
 
+            // NGFW-15855: same argv migration as the direct-send block above.
             // remove all "  port = xx"
-            String cmd1 = "/bin/sed -e \"/..port.=.[0-9].*$/d\" -i " + EXIM_TEMPLATE_FILE;
-            UvmContextFactory.context().execManager().exec(cmd1);
+            UvmContextFactory.context().execManager().execCommand("/bin/sed", List.of(
+                "-e", "/..port.=.[0-9].*$/d",
+                "-i", EXIM_TEMPLATE_FILE));
             // insert new "  port = xx"
-            String cmd2 = "/bin/sed -e \"s|  driver = smtp|  driver = smtp\\n  port = " + targetPort + "|g\" -i " + EXIM_TEMPLATE_FILE;
-            UvmContextFactory.context().execManager().exec(cmd2);
+            UvmContextFactory.context().execManager().execCommand("/bin/sed", List.of(
+                "-e", "s|  driver = smtp|  driver = smtp\\n  port = " + targetPort + "|g",
+                "-i", EXIM_TEMPLATE_FILE));
         }
 
         this.writeFile(sb, EXIM_CONF_FILE);


### PR DESCRIPTION
**What was wrong**

The ExecManager filter in ExecManagerImpl.java currently allows shell-metacharacter-bearing exec(String) calls to run in log-and-allow mode when safe=false (T-18 / UNT-50). Several callers in the reports subsystem still pass shell strings with metacharacters (| grep Stopped, >/dev/null 2>&1, | logger -t uvmreports). These need to move to safer forms so that the sibling ticket NGFW-15887, which tightens the filter to always-block, does not regress live behavior when it merges.

**How the fix works**

- The postgres stop and start commands in ReportsManagerImpl.checkOrReinitializeDatabase drop the >/dev/null 2>&1 suffix. The redirect is redundant here because ut-exec-launcher already captures stdout and stderr into a pipe, and the Java caller uses execResult() which only reads the exit code and discards captured output.

- The postgres status probe in the same method is switched from postgresql status | grep Stopped to argv form via execCommand("/etc/init.d/postgresql", List.of("status")). The grep-filtered exit code was a dead assignment (immediately overwritten on the following line before use), so the probe is preserved as a side-effect-only call for its coincidental ~200 ms timing buffer between the stop and the cleanup script.

- The retention cleanup cron in ReportsApp.checkDbRetentionChange is migrated from an inline shell pipeline to argv-form execCommand targeting a new wrapper script ut-reports-clean-tables. The wrapper internally delegates to reports-clean-tables.py "$@" | logger -t uvmreports, preserving the syslog tag uvmreports and the last-command exit-code semantics (no set -o pipefail, matching the original behavior).

- Four entries are added to ut-exec-safe-launcher ALLOWED_EXECUTABLES: two for this ticket (/etc/init.d/postgresql, /usr/share/untangle/bin/ut-reports-clean-tables), plus two for the sibling tickets NGFW-15886 and NGFW-15887 (/usr/share/untangle/bin/ut-verify-cert-chain, /bin/sed). Bundling all four here avoids whitelist hunk-splitting across three branches; extra entries are harmless because the launcher only permits whitelisted executables, never mandates their presence.

**What doesn't change**

The underlying reports-reinitialize-database.sh and reports-clean-tables.py scripts are untouched. Reports database initialization, table generation, and retention pruning behavior are functionally identical to before. No RPC signatures change, no admin UI screens change, no report content or format changes. The wrapper script ut-reports-clean-tables is a thin one-line delegation that forwards its arguments verbatim to the existing Python script.