### PR TITLE
NGFW-15851: Fix IPsec ipsec.conf newline injection (UNT-16, CVSS 7.2 )

### DIFF
--- a/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
+++ b/ipsec-vpn/hier/usr/lib/python3/dist-packages/tests/test_ipsec_vpn.py
@@ -1197,7 +1197,7 @@ class IPsecTests(NGFWTestCase):
           - rightNextHop       (IP_OR_CIDR)
 
         Sink: ipsec_manager.py writes these into /etc/ipsec.conf where
-        leftupdown= references an executable script — newline + script-name
+        leftupdown= references an executable script -- newline + script-name
         injection yields root RCE.
 
         The validator is fail-fast; bad values raise an exception from
@@ -1206,11 +1206,11 @@ class IPsecTests(NGFWTestCase):
         ipsec_settings = self._app.getSettings()
         orig_tunnel_list = copy.deepcopy(ipsec_settings["tunnels"]["list"])
         try:
-            # Build a minimal positive baseline tunnel INLINE — do NOT use
+            # Build a minimal positive baseline tunnel INLINE -- do NOT use
             # build_ipsec_tunnel() because it SkipTest's when the host WAN IP
             # isn't in IPSEC_CONFIGURED_HOST_IPS. The SafeCheck validator fires
             # at the JSON-RPC boundary BEFORE any tunnel-up logic, so the tunnel
-            # never needs to actually work — it only needs to be a structurally
+            # never needs to actually work -- it only needs to be a structurally
             # valid IpsecVpnTunnel dict that setSettings will accept.
             base_tunnel = {
                 "active":         False,  # disabled so strongSwan doesn't try to bring it up
@@ -1252,7 +1252,7 @@ class IPsecTests(NGFWTestCase):
             positive_settings["tunnels"]["list"] = [base_tunnel]
             self._app.setSettings(positive_settings)
 
-            # `left` dual-type — both IP literal and DNS hostname must round-trip.
+            # `left` dual-type -- both IP literal and DNS hostname must round-trip.
             for left_value in ("203.0.113.10", "vpn.example.com"):
                 t = copy.deepcopy(base_tunnel)
                 t["left"] = left_value
@@ -1263,7 +1263,7 @@ class IPsecTests(NGFWTestCase):
 
             baseline = self._app.getSettings()
 
-            # Negative payloads — historically-confirmed RCE classes.
+            # Negative payloads -- historically-confirmed RCE classes.
             # Dead fields (leftProtoPort/rightProtoPort/leftNextHop/rightNextHop)
             # removed per audit: zero callers outside the POJO getter, no sink.
             negative_payloads = {
@@ -1330,6 +1330,220 @@ class IPsecTests(NGFWTestCase):
                 assert stored.get(field) != payload, (
                     f"NGFW-15768: allowlist-shaped negative {field}={payload!r} "
                     f"survived rejection; got {stored.get(field)!r}"
+                )
+        finally:
+            ipsec_settings["tunnels"]["list"] = orig_tunnel_list
+            self._app.setSettings(ipsec_settings)
+
+    def test_091_safecheck_settings_fields(self):
+        """Verify @SafeCheck annotations on IpsecVpnSettings top-level fields.
+
+        Covers fields added by the stripLineBreaks / @SafeCheck hardening:
+          - uniqueIds          (ALPHANUM)
+          - charonDebug        (SIMPLE_TEXT)
+          - virtualAddressPool (IP_OR_CIDR)
+          - virtualNetworkPool (IP_OR_CIDR)
+          - virtualDnsOne      (IP_OR_CIDR)
+          - virtualDnsTwo      (IP_OR_CIDR)
+          - phase1Cipher       (ALPHANUM)
+          - phase1Hash         (ALPHANUM)
+          - phase1Group        (ALPHANUM)
+          - phase1Lifetime     (ALPHANUM)
+          - phase2Cipher       (ALPHANUM)
+          - phase2Hash         (ALPHANUM)
+          - phase2Group        (ALPHANUM)
+          - phase2Lifetime     (ALPHANUM)
+          - phase1DefaultLifetime (ALPHANUM)
+          - phase2DefaultLifetime (ALPHANUM)
+
+        Sink: IpsecVpnManager writes these into /etc/ipsec.conf and
+        xl2tpd config files -- newline injection yields conf directive
+        injection or root RCE via leftupdown= scripts.
+        """
+        orig_settings = self._app.getSettings()
+        try:
+            # Positive: valid settings should round-trip cleanly.
+            pos = copy.deepcopy(orig_settings)
+            pos["uniqueIds"] = "yes"
+            pos["charonDebug"] = "ike 2, knl 2"
+            pos["virtualAddressPool"] = "198.18.0.0/16"
+            pos["virtualNetworkPool"] = "10.10.0.0/24"
+            pos["virtualDnsOne"] = "8.8.8.8"
+            pos["virtualDnsTwo"] = "8.8.4.4"
+            pos["phase1Cipher"] = "aes128"
+            pos["phase1Hash"] = "sha1"
+            pos["phase1Group"] = "modp2048"
+            pos["phase1Lifetime"] = "28800"
+            pos["phase2Cipher"] = "aes256"
+            pos["phase2Hash"] = "sha256"
+            pos["phase2Group"] = "modp2048"
+            pos["phase2Lifetime"] = "3600"
+            pos["phase1DefaultLifetime"] = "8h"
+            pos["phase2DefaultLifetime"] = "1h"
+            self._app.setSettings(pos)
+
+            baseline = self._app.getSettings()
+
+            # Negative: injection payloads must be rejected.
+            negative_payloads = {
+                "uniqueIds":          "yes\nleftupdown=/bin/sh",
+                "charonDebug":        "ike 2\nconn evil",
+                "virtualAddressPool": "198.18.0.0/16; rm -rf /",
+                "virtualNetworkPool": "10.10.0.0/24`id`",
+                "virtualDnsOne":      "8.8.8.8\necho INJECT",
+                "virtualDnsTwo":      "8.8.4.4; whoami",
+                "phase1Cipher":       "aes128\nconn pwned",
+                "phase1Hash":         "sha1; touch /tmp/x",
+                "phase1Group":        "modp2048`id`",
+                "phase1Lifetime":     "28800\necho INJECT",
+                "phase2Cipher":       "aes256; id",
+                "phase2Hash":         "sha256|whoami",
+                "phase2Group":        "modp2048\r\nconn evil",
+                "phase2Lifetime":     "3600; /bin/sh",
+                "phase1DefaultLifetime": "8h\nleftupdown=/evil",
+                "phase2DefaultLifetime": "1h`id`",
+            }
+            for field, payload in negative_payloads.items():
+                bad = copy.deepcopy(baseline)
+                bad[field] = payload
+                with pytest.raises(Exception):
+                    self._app.setSettings(bad)
+                current = self._app.getSettings()
+                assert current.get(field) != payload, (
+                    f"IpsecVpnSettings.{field} stored rejected payload: "
+                    f"{current.get(field)!r}"
+                )
+        finally:
+            self._app.setSettings(orig_settings)
+
+    def test_092_safecheck_virtual_listen_address(self):
+        """Verify @SafeCheck(IP_OR_CIDR) on VirtualListen.address.
+
+        Sink: IpsecVpnManager writes listen.getAddress() into ipsec.conf
+        left= directives for L2TP/IKEv2/xauth VPN listeners -- newline
+        injection yields conf directive injection.
+        """
+        orig_settings = self._app.getSettings()
+        try:
+            # Positive: valid IP address in virtualListenList.
+            pos = copy.deepcopy(orig_settings)
+            pos["virtualListenList"] = {"javaClass": "java.util.LinkedList", "list": [
+                {"address": "10.0.0.1", "javaClass": "com.untangle.app.ipsec_vpn.VirtualListen", "id": 0}
+            ]}
+            self._app.setSettings(pos)
+
+            baseline = self._app.getSettings()
+
+            # Negative: injection payload in listen address.
+            injection_payloads = [
+                "10.0.0.1\nleftupdown=/bin/sh",
+                "10.0.0.1; rm -rf /",
+                "10.0.0.1`id`",
+                "evil.example.com",
+            ]
+            for payload in injection_payloads:
+                bad = copy.deepcopy(baseline)
+                bad["virtualListenList"]["list"] = [
+                    {"address": payload, "javaClass": "com.untangle.app.ipsec_vpn.VirtualListen", "id": 0}
+                ]
+                with pytest.raises(Exception):
+                    self._app.setSettings(bad)
+                current = self._app.getSettings()
+                stored_list = current.get("virtualListenList", {}).get("list", [])
+                if stored_list:
+                    assert stored_list[0].get("address") != payload, (
+                        f"VirtualListen.address stored rejected payload: "
+                        f"{stored_list[0].get('address')!r}"
+                    )
+        finally:
+            self._app.setSettings(orig_settings)
+
+    def test_093_safecheck_tunnel_phase_dpd_fields(self):
+        """Verify @SafeCheck annotations on IpsecVpnTunnel phase/DPD fields.
+
+        Covers the newly annotated fields (complement to test_090):
+          - dpddelay        (ALPHANUM)
+          - dpdtimeout      (ALPHANUM)
+          - phase1Cipher    (ALPHANUM)
+          - phase1Hash      (ALPHANUM)
+          - phase1Group     (ALPHANUM)
+          - phase1Lifetime  (ALPHANUM)
+          - phase2Cipher    (ALPHANUM)
+          - phase2Hash      (ALPHANUM)
+          - phase2Group     (ALPHANUM)
+          - phase2Lifetime  (ALPHANUM)
+
+        Sink: IpsecVpnManager writes these into /etc/ipsec.conf ike=,
+        esp=, ikelifetime=, lifetime=, dpddelay=, dpdtimeout= directives.
+        """
+        ipsec_settings = self._app.getSettings()
+        orig_tunnel_list = copy.deepcopy(ipsec_settings["tunnels"]["list"])
+        try:
+            base_tunnel = {
+                "active":         False,
+                "adapter":        "- Custom -",
+                "conntype":       "tunnel",
+                "description":    "safecheck phase/dpd test",
+                "id":             1,
+                "javaClass":      "com.untangle.app.ipsec_vpn.IpsecVpnTunnel",
+                "left":           "203.0.113.10",
+                "leftId":         "left-id-1",
+                "leftSourceIp":   "10.0.0.1",
+                "leftSubnet":     "10.0.0.0/24",
+                "right":          "198.51.100.10",
+                "rightId":        "right-id-1",
+                "rightSourceIp":  "10.0.1.1",
+                "rightSubnet":    "10.0.1.0/24",
+                "runmode":        "start",
+                "secret":         "supersecret",
+                "dpddelay":       "30",
+                "dpdtimeout":     "120",
+                "phase1Manual":   True,
+                "phase1Lifetime": "28800",
+                "phase1Group":    "modp2048",
+                "phase1Hash":     "sha1",
+                "phase1Cipher":   "aes128",
+                "phase2Manual":   True,
+                "phase2Lifetime": "3600",
+                "phase2Group":    "modp2048",
+                "phase2Hash":     "sha1",
+                "phase2Cipher":   "aes256gcm128",
+                "ikeVersion":     2,
+                "pfs":            True,
+            }
+
+            # Positive: valid tunnel should be accepted.
+            positive_settings = copy.deepcopy(ipsec_settings)
+            positive_settings["tunnels"]["list"] = [base_tunnel]
+            self._app.setSettings(positive_settings)
+
+            baseline = self._app.getSettings()
+
+            # Negative: injection payloads for phase/DPD fields.
+            negative_payloads = {
+                "dpddelay":       "30\nconn evil",
+                "dpdtimeout":     "120; rm -rf /",
+                "phase1Cipher":   "aes128\nleftupdown=/bin/sh",
+                "phase1Hash":     "sha1`id`",
+                "phase1Group":    "modp2048; whoami",
+                "phase1Lifetime": "28800\r\nconn pwned",
+                "phase2Cipher":   "aes256gcm128|cat /etc/passwd",
+                "phase2Hash":     "sha1\necho INJECT",
+                "phase2Group":    "modp2048; touch /tmp/x",
+                "phase2Lifetime": "3600`id`",
+            }
+            for field, payload in negative_payloads.items():
+                bad_tunnel = copy.deepcopy(base_tunnel)
+                bad_tunnel[field] = payload
+                bad_settings = copy.deepcopy(baseline)
+                bad_settings["tunnels"]["list"] = [bad_tunnel]
+                with pytest.raises(Exception):
+                    self._app.setSettings(bad_settings)
+                current = self._app.getSettings()
+                stored = current["tunnels"]["list"][0]
+                assert stored.get(field) != payload, (
+                    f"IpsecVpnTunnel.{field} stored rejected payload: "
+                    f"{stored.get(field)!r}"
                 )
         finally:
             ipsec_settings["tunnels"]["list"] = orig_tunnel_list

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnManager.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnManager.java
@@ -291,10 +291,10 @@ public class IpsecVpnManager
                 // this section is required and contains general protocol
                 // config directives and items that are common to all tunnels
                 ipsec_conf.write("config setup" + RET);
-                ipsec_conf.write(TAB + "uniqueids=" + settings.getUniqueIds() + RET);
+                ipsec_conf.write(TAB + "uniqueids=" + stripLineBreaks(settings.getUniqueIds()) + RET);
 
                 if (settings.getCharonDebug().length() > 0) {
-                    ipsec_conf.write(TAB + "charondebug=" + settings.getCharonDebug() + RET);
+                    ipsec_conf.write(TAB + "charondebug=" + stripLineBreaks(settings.getCharonDebug()) + RET);
                 }
 
                 ipsec_conf.write(RET);
@@ -316,7 +316,7 @@ public class IpsecVpnManager
 
                     ipsec_conf.write("conn UT" + Integer.toString(data.getId()) + "_" + workname + RET);
                     ipsec_conf.write(TAB + "keyexchange=ikev" + Integer.toString(data.getIkeVersion()) + RET);
-                    ipsec_conf.write(TAB + "type=" + data.getConntype() + RET);
+                    ipsec_conf.write(TAB + "type=" + stripLineBreaks(data.getConntype()) + RET);
                     ipsec_conf.write(TAB + "authby=psk" + RET);
 
                     ipsec_conf.write(TAB + "rekey=yes" + RET);
@@ -327,69 +327,69 @@ public class IpsecVpnManager
                     }
 
                     if (data.getPhase1Manual() == true) {
-                        ipsec_conf.write(TAB + "ike=" + data.getPhase1Cipher() + "-" + data.getPhase1Hash() + "-" + data.getPhase1Group() + "!" + RET);
-                        ipsec_conf.write(TAB + "ikelifetime=" + data.getPhase1Lifetime() + "s" + RET);
+                        ipsec_conf.write(TAB + "ike=" + stripLineBreaks(data.getPhase1Cipher()) + "-" + stripLineBreaks(data.getPhase1Hash()) + "-" + stripLineBreaks(data.getPhase1Group()) + "!" + RET);
+                        ipsec_conf.write(TAB + "ikelifetime=" + stripLineBreaks(data.getPhase1Lifetime()) + "s" + RET);
                     } else {
                         ipsec_conf.write(TAB + "ike=" + ike_default + RET);
-                        ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
+                        ipsec_conf.write(TAB + "ikelifetime=" + stripLineBreaks(settings.getPhase1DefaultLifetime()) + RET);
                     }
 
                     if (data.getPhase2Manual() == true) {
                         if (data.getPhase2Group().equals("disabled") == true) {
-                            ipsec_conf.write(TAB + "esp=" + data.getPhase2Cipher() + "-" + data.getPhase2Hash() + "!" + RET);
+                            ipsec_conf.write(TAB + "esp=" + stripLineBreaks(data.getPhase2Cipher()) + "-" + stripLineBreaks(data.getPhase2Hash()) + "!" + RET);
                         } else {
-                            ipsec_conf.write(TAB + "esp=" + data.getPhase2Cipher() + "-" + data.getPhase2Hash() + "-" + data.getPhase2Group() + "!" + RET);
+                            ipsec_conf.write(TAB + "esp=" + stripLineBreaks(data.getPhase2Cipher()) + "-" + stripLineBreaks(data.getPhase2Hash()) + "-" + stripLineBreaks(data.getPhase2Group()) + "!" + RET);
                         }
-                        ipsec_conf.write(TAB + "lifetime=" + data.getPhase2Lifetime() + "s" + RET);
+                        ipsec_conf.write(TAB + "lifetime=" + stripLineBreaks(data.getPhase2Lifetime()) + "s" + RET);
                     } else {
                         ipsec_conf.write(TAB + "esp=" + esp_default + RET);
-                        ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
+                        ipsec_conf.write(TAB + "lifetime=" + stripLineBreaks(settings.getPhase2DefaultLifetime()) + RET);
                     }
 
                     if ((data.getDpddelay().equals("0") == false) && (data.getDpdtimeout().equals("0") == false)) {
-                        ipsec_conf.write(TAB + "dpddelay=" + data.getDpddelay() + RET);
-                        ipsec_conf.write(TAB + "dpdtimeout=" + data.getDpdtimeout() + RET);
+                        ipsec_conf.write(TAB + "dpddelay=" + stripLineBreaks(data.getDpddelay()) + RET);
+                        ipsec_conf.write(TAB + "dpdtimeout=" + stripLineBreaks(data.getDpdtimeout()) + RET);
                         ipsec_conf.write(TAB + "dpdaction=restart" + RET);
                     }
 
-                    ipsec_conf.write(TAB + "left=" + this.resolveLeftAddress(data.getLeft()) + RET);
+                    ipsec_conf.write(TAB + "left=" + stripLineBreaks(this.resolveLeftAddress(data.getLeft())) + RET);
 
                     if(data.getAllSubnetNegotation()){
                         ipsec_conf.write(TAB + "leftsubnet=0.0.0.0/0" + RET);
                     }else{
-                        ipsec_conf.write(TAB + "leftsubnet=" + data.getLeftSubnet() + RET);
+                        ipsec_conf.write(TAB + "leftsubnet=" + stripLineBreaks(data.getLeftSubnet()) + RET);
                     }
                     // use the configured leftid if available otherwise use left
                     if ((data.getLeftId() != null) && (data.getLeftId().length() > 0)) {
-                        ipsec_conf.write(TAB + "leftid=" + data.getLeftId() + RET);
+                        ipsec_conf.write(TAB + "leftid=" + stripLineBreaks(data.getLeftId()) + RET);
                     } else {
                         if(data.getAllSubnetNegotation() == false){
-                            ipsec_conf.write(TAB + "leftid=" + this.resolveLeftAddress(data.getLeft()) + RET);
+                            ipsec_conf.write(TAB + "leftid=" + stripLineBreaks(this.resolveLeftAddress(data.getLeft())) + RET);
                         }
                     }
                     if ((data.getLeftSourceIp() != null) && (data.getLeftSourceIp().length() > 0)) {
-                        ipsec_conf.write(TAB + "leftsourceip=" + data.getLeftSourceIp() + RET);
+                        ipsec_conf.write(TAB + "leftsourceip=" + stripLineBreaks(data.getLeftSourceIp()) + RET);
                     }
 
-                    ipsec_conf.write(TAB + "right=" + data.getRight() + RET);
+                    ipsec_conf.write(TAB + "right=" + stripLineBreaks(data.getRight()) + RET);
                     if(data.getAllSubnetNegotation()){
                         ipsec_conf.write(TAB + "rightsubnet=0.0.0.0/0" + RET);
                     }else{
-                        ipsec_conf.write(TAB + "rightsubnet=" + data.getRightSubnet() + RET);
+                        ipsec_conf.write(TAB + "rightsubnet=" + stripLineBreaks(data.getRightSubnet()) + RET);
                     }
                     // use the configured rightid if available otherwise use right
                     if ((data.getRightId() != null) && (data.getRightId().length() > 0)) {
-                        ipsec_conf.write(TAB + "rightid=" + data.getRightId() + RET);
+                        ipsec_conf.write(TAB + "rightid=" + stripLineBreaks(data.getRightId()) + RET);
                     } else {
                         if(data.getAllSubnetNegotation() == false){
-                            ipsec_conf.write(TAB + "rightid=" + data.getRight() + RET);
+                            ipsec_conf.write(TAB + "rightid=" + stripLineBreaks(data.getRight()) + RET);
                         }
                     }
                     if ((data.getRightSourceIp() != null) && (data.getRightSourceIp().length() > 0)) {
-                        ipsec_conf.write(TAB + "rightsourceip=" + data.getRightSourceIp() + RET);
+                        ipsec_conf.write(TAB + "rightsourceip=" + stripLineBreaks(data.getRightSourceIp()) + RET);
                     }
 
-                    ipsec_conf.write(TAB + "auto=" + data.getRunmode() + RET);
+                    ipsec_conf.write(TAB + "auto=" + stripLineBreaks(data.getRunmode()) + RET);
                     if(data.getAllSubnetNegotation()){
                         int interfaceId = UvmContextFactory.context().networkManager().getNextFreeInterfaceId(UvmContextFactory.context().networkManager().getNetworkSettings());
                         ipsec_conf.write(TAB + "mark=" + Integer.toString(interfaceId) + RET);
@@ -414,18 +414,18 @@ public class IpsecVpnManager
 
                     // add the tunnel PSK to the ipsec.secrets file
                     ipsec_secrets.write("# " + workname + RET);
-                    ipsec_secrets.write(data.getLeft() + " " + data.getRight().replaceAll("\\s*,\\s*", " ") + " : PSK 0x" + StringHexify(data.getSecret()) + RET);
+                    ipsec_secrets.write(stripLineBreaks(data.getLeft()) + " " + stripLineBreaks(data.getRight()).replaceAll("\\s*,\\s*", " ") + " : PSK 0x" + StringHexify(data.getSecret()) + RET);
 
                     // start with left but prefer leftid if not null and not empty
-                    String lid = data.getLeft();
-                    if ((data.getLeftId() != null) && (data.getLeftId().length() > 0)) lid = data.getLeftId();
+                    String lid = stripLineBreaks(data.getLeft());
+                    if ((data.getLeftId() != null) && (data.getLeftId().length() > 0)) lid = stripLineBreaks(data.getLeftId());
 
                     // start with right but prefer rightid if not null and not empty
-                    String rid = data.getRight();
-                    if ((data.getRightId() != null) && (data.getRightId().length() > 0)) rid = data.getRightId();
+                    String rid = stripLineBreaks(data.getRight());
+                    if ((data.getRightId() != null) && (data.getRightId().length() > 0)) rid = stripLineBreaks(data.getRightId());
 
                     // if lid != left or rid != right add another secret using those values
-                    if ((!data.getLeft().equals(lid)) || (!data.getRight().equals(rid))) {
+                    if ((!stripLineBreaks(data.getLeft()).equals(lid)) || (!stripLineBreaks(data.getRight()).equals(rid))) {
                         ipsec_secrets.write(lid + " " + rid + " : PSK 0x" + StringHexify(data.getSecret()) + RET);
                     }
                 }
@@ -455,29 +455,29 @@ public class IpsecVpnManager
                         ipsec_conf.write(TAB + "dpdtimeout=90" + RET);
                         ipsec_conf.write(TAB + "dpdaction=clear" + RET);
                         ipsec_conf.write(TAB + "type=transport" + RET);
-                        ipsec_conf.write(TAB + "left=" + listen.getAddress() + RET);
+                        ipsec_conf.write(TAB + "left=" + stripLineBreaks(listen.getAddress()) + RET);
                         ipsec_conf.write(TAB + "leftprotoport=17/1701" + RET);
                         ipsec_conf.write(TAB + "right=%any" + RET);
                         ipsec_conf.write(TAB + "rightprotoport=17/%any" + RET);
 
                         if (settings.getPhase1Manual() == true) {
-                            ipsec_conf.write(TAB + "ike=" + settings.getPhase1Cipher() + "-" + settings.getPhase1Hash() + "-" + settings.getPhase1Group() + "!" + RET);
-                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1Lifetime() + "s" + RET);
+                            ipsec_conf.write(TAB + "ike=" + stripLineBreaks(settings.getPhase1Cipher()) + "-" + stripLineBreaks(settings.getPhase1Hash()) + "-" + stripLineBreaks(settings.getPhase1Group()) + "!" + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + stripLineBreaks(settings.getPhase1Lifetime()) + "s" + RET);
                         } else {
                             ipsec_conf.write(TAB + "ike=" + ike_default + RET);
-                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + stripLineBreaks(settings.getPhase1DefaultLifetime()) + RET);
                         }
 
                         if (settings.getPhase2Manual() == true) {
                             if (settings.getPhase2Group().equals("disabled") == true) {
-                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "!" + RET);
+                                ipsec_conf.write(TAB + "esp=" + stripLineBreaks(settings.getPhase2Cipher()) + "-" + stripLineBreaks(settings.getPhase2Hash()) + "!" + RET);
                             } else {
-                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "-" + settings.getPhase2Group() + "!" + RET);
+                                ipsec_conf.write(TAB + "esp=" + stripLineBreaks(settings.getPhase2Cipher()) + "-" + stripLineBreaks(settings.getPhase2Hash()) + "-" + stripLineBreaks(settings.getPhase2Group()) + "!" + RET);
                             }
-                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2Lifetime() + "s" + RET);
+                            ipsec_conf.write(TAB + "lifetime=" + stripLineBreaks(settings.getPhase2Lifetime()) + "s" + RET);
                         } else {
                             ipsec_conf.write(TAB + "esp=" + esp_default + RET);
-                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
+                            ipsec_conf.write(TAB + "lifetime=" + stripLineBreaks(settings.getPhase2DefaultLifetime()) + RET);
                         }
 
                         ipsec_conf.write(RET);
@@ -509,11 +509,11 @@ public class IpsecVpnManager
                             ipsec_conf.write(TAB + "replay_window=0" + RET);
                         }
 
-                        ipsec_conf.write(TAB + "left=" + listen.getAddress() + RET);
+                        ipsec_conf.write(TAB + "left=" + stripLineBreaks(listen.getAddress()) + RET);
                         ipsec_conf.write(TAB + "leftsubnet=0.0.0.0/0" + RET);
                         ipsec_conf.write(TAB + "leftupdown=" + XAUTH_UPDOWN_SCRIPT + RET);
                         ipsec_conf.write(TAB + "right=%any" + RET);
-                        ipsec_conf.write(TAB + "rightsourceip=" + settings.getVirtualXauthPool() + RET);
+                        ipsec_conf.write(TAB + "rightsourceip=" + stripLineBreaks(settings.getVirtualXauthPool()) + RET);
 
                         // if no DNS servers are configured we use the server address of the L2TP interface
                         if ((settings.getVirtualDnsOne().length() == 0) && (settings.getVirtualDnsTwo().length() == 0)) {
@@ -522,37 +522,37 @@ public class IpsecVpnManager
 
                         // handle only the first custom server
                         if ((settings.getVirtualDnsOne().length() > 0) && (settings.getVirtualDnsTwo().length() == 0)) {
-                            ipsec_conf.write(TAB + "rightdns=" + settings.getVirtualDnsOne() + RET);
+                            ipsec_conf.write(TAB + "rightdns=" + stripLineBreaks(settings.getVirtualDnsOne()) + RET);
                         }
 
                         // handle only the second custom server
                         if ((settings.getVirtualDnsOne().length() == 0) && (settings.getVirtualDnsTwo().length() > 0)) {
-                            ipsec_conf.write(TAB + "rightdns=" + settings.getVirtualDnsTwo() + RET);
+                            ipsec_conf.write(TAB + "rightdns=" + stripLineBreaks(settings.getVirtualDnsTwo()) + RET);
                         }
 
                         // handle both the first and second custom server
                         if ((settings.getVirtualDnsOne().length() > 0) && (settings.getVirtualDnsTwo().length() > 0)) {
-                            ipsec_conf.write(TAB + "rightdns=" + settings.getVirtualDnsOne() + "," + settings.getVirtualDnsTwo() + RET);
+                            ipsec_conf.write(TAB + "rightdns=" + stripLineBreaks(settings.getVirtualDnsOne()) + "," + stripLineBreaks(settings.getVirtualDnsTwo()) + RET);
                         }
 
                         if (settings.getPhase1Manual() == true) {
-                            ipsec_conf.write(TAB + "ike=" + settings.getPhase1Cipher() + "-" + settings.getPhase1Hash() + "-" + settings.getPhase1Group() + "!" + RET);
-                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1Lifetime() + "s" + RET);
+                            ipsec_conf.write(TAB + "ike=" + stripLineBreaks(settings.getPhase1Cipher()) + "-" + stripLineBreaks(settings.getPhase1Hash()) + "-" + stripLineBreaks(settings.getPhase1Group()) + "!" + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + stripLineBreaks(settings.getPhase1Lifetime()) + "s" + RET);
                         } else {
                             ipsec_conf.write(TAB + "ike=" + ike_default + RET);
-                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + stripLineBreaks(settings.getPhase1DefaultLifetime()) + RET);
                         }
 
                         if (settings.getPhase2Manual() == true) {
                             if (settings.getPhase2Group().equals("disabled") == true) {
-                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "!" + RET);
+                                ipsec_conf.write(TAB + "esp=" + stripLineBreaks(settings.getPhase2Cipher()) + "-" + stripLineBreaks(settings.getPhase2Hash()) + "!" + RET);
                             } else {
-                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "-" + settings.getPhase2Group() + "!" + RET);
+                                ipsec_conf.write(TAB + "esp=" + stripLineBreaks(settings.getPhase2Cipher()) + "-" + stripLineBreaks(settings.getPhase2Hash()) + "-" + stripLineBreaks(settings.getPhase2Group()) + "!" + RET);
                             }
-                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2Lifetime() + "s" + RET);
+                            ipsec_conf.write(TAB + "lifetime=" + stripLineBreaks(settings.getPhase2Lifetime()) + "s" + RET);
                         } else {
                             ipsec_conf.write(TAB + "esp=" + esp_default + RET);
-                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
+                            ipsec_conf.write(TAB + "lifetime=" + stripLineBreaks(settings.getPhase2DefaultLifetime()) + RET);
                         }
 
                         ipsec_conf.write(RET);
@@ -570,14 +570,14 @@ public class IpsecVpnManager
                             ipsec_conf.write(TAB + "replay_window=0" + RET);
                         }
 
-                        ipsec_conf.write(TAB + "left=" + listen.getAddress() + RET);
+                        ipsec_conf.write(TAB + "left=" + stripLineBreaks(listen.getAddress()) + RET);
 
                         if ((domainName == null) || (hostName == null)) {
-                            ipsec_conf.write(TAB + "leftid=" + listen.getAddress() + RET);
+                            ipsec_conf.write(TAB + "leftid=" + stripLineBreaks(listen.getAddress()) + RET);
                         }
 
                         else {
-                            ipsec_conf.write(TAB + "leftid=" + hostName + "." + domainName + RET);
+                            ipsec_conf.write(TAB + "leftid=" + stripLineBreaks(hostName) + "." + stripLineBreaks(domainName) + RET);
                         }
 
                         ipsec_conf.write(TAB + "leftauth=pubkey" + RET);
@@ -596,7 +596,7 @@ public class IpsecVpnManager
                             ipsec_conf.write(TAB + "rightauth=eap-radius" + RET);
                         }
 
-                        ipsec_conf.write(TAB + "rightsourceip=" + settings.getVirtualXauthPool() + RET);
+                        ipsec_conf.write(TAB + "rightsourceip=" + stripLineBreaks(settings.getVirtualXauthPool()) + RET);
 
                         // if no DNS servers are configured we use the server address of the L2TP interface
                         if ((settings.getVirtualDnsOne().length() == 0) && (settings.getVirtualDnsTwo().length() == 0)) {
@@ -605,17 +605,17 @@ public class IpsecVpnManager
 
                         // handle only the first custom server
                         if ((settings.getVirtualDnsOne().length() > 0) && (settings.getVirtualDnsTwo().length() == 0)) {
-                            ipsec_conf.write(TAB + "rightdns=" + settings.getVirtualDnsOne() + RET);
+                            ipsec_conf.write(TAB + "rightdns=" + stripLineBreaks(settings.getVirtualDnsOne()) + RET);
                         }
 
                         // handle only the second custom server
                         if ((settings.getVirtualDnsOne().length() == 0) && (settings.getVirtualDnsTwo().length() > 0)) {
-                            ipsec_conf.write(TAB + "rightdns=" + settings.getVirtualDnsTwo() + RET);
+                            ipsec_conf.write(TAB + "rightdns=" + stripLineBreaks(settings.getVirtualDnsTwo()) + RET);
                         }
 
                         // handle both the first and second custom server
                         if ((settings.getVirtualDnsOne().length() > 0) && (settings.getVirtualDnsTwo().length() > 0)) {
-                            ipsec_conf.write(TAB + "rightdns=" + settings.getVirtualDnsOne() + "," + settings.getVirtualDnsTwo() + RET);
+                            ipsec_conf.write(TAB + "rightdns=" + stripLineBreaks(settings.getVirtualDnsOne()) + "," + stripLineBreaks(settings.getVirtualDnsTwo()) + RET);
                         }
 
                         ipsec_conf.write(TAB + "rightsendcert=never" + RET);
@@ -623,26 +623,26 @@ public class IpsecVpnManager
 
                         // add the L2TP PSK to the shared secrets file
                         ipsec_secrets.write("# VPN-L2TP-" + Integer.toString(x) + RET);
-                        ipsec_secrets.write(listen.getAddress() + " %any : PSK 0x" + StringHexify(settings.getVirtualSecret()) + RET);
+                        ipsec_secrets.write(stripLineBreaks(listen.getAddress()) + " %any : PSK 0x" + StringHexify(settings.getVirtualSecret()) + RET);
 
                         if (settings.getPhase1Manual() == true) {
-                            ipsec_conf.write(TAB + "ike=" + settings.getPhase1Cipher() + "-" + settings.getPhase1Hash() + "-" + settings.getPhase1Group() + "!" + RET);
-                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1Lifetime() + "s" + RET);
+                            ipsec_conf.write(TAB + "ike=" + stripLineBreaks(settings.getPhase1Cipher()) + "-" + stripLineBreaks(settings.getPhase1Hash()) + "-" + stripLineBreaks(settings.getPhase1Group()) + "!" + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + stripLineBreaks(settings.getPhase1Lifetime()) + "s" + RET);
                         } else {
                             ipsec_conf.write(TAB + "ike=" + ike_default + RET);
-                            ipsec_conf.write(TAB + "ikelifetime=" + settings.getPhase1DefaultLifetime() + RET);
+                            ipsec_conf.write(TAB + "ikelifetime=" + stripLineBreaks(settings.getPhase1DefaultLifetime()) + RET);
                         }
 
                         if (settings.getPhase2Manual() == true) {
                             if (settings.getPhase2Group().equals("disabled") == true) {
-                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "!" + RET);
+                                ipsec_conf.write(TAB + "esp=" + stripLineBreaks(settings.getPhase2Cipher()) + "-" + stripLineBreaks(settings.getPhase2Hash()) + "!" + RET);
                             } else {
-                                ipsec_conf.write(TAB + "esp=" + settings.getPhase2Cipher() + "-" + settings.getPhase2Hash() + "-" + settings.getPhase2Group() + "!" + RET);
+                                ipsec_conf.write(TAB + "esp=" + stripLineBreaks(settings.getPhase2Cipher()) + "-" + stripLineBreaks(settings.getPhase2Hash()) + "-" + stripLineBreaks(settings.getPhase2Group()) + "!" + RET);
                             }
-                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2Lifetime() + "s" + RET);
+                            ipsec_conf.write(TAB + "lifetime=" + stripLineBreaks(settings.getPhase2Lifetime()) + "s" + RET);
                         } else {
                             ipsec_conf.write(TAB + "esp=" + esp_default + RET);
-                            ipsec_conf.write(TAB + "lifetime=" + settings.getPhase2DefaultLifetime() + RET);
+                            ipsec_conf.write(TAB + "lifetime=" + stripLineBreaks(settings.getPhase2DefaultLifetime()) + RET);
                         }
                     }
                 }
@@ -661,12 +661,12 @@ public class IpsecVpnManager
                 }
 
                 if (settings.getVirtualDnsOne().length() > 0) {
-                    options_xl2tpd.write("ms-dns " + settings.getVirtualDnsOne() + RET);
+                    options_xl2tpd.write("ms-dns " + stripLineBreaks(settings.getVirtualDnsOne()) + RET);
                     dnsWritten = true;
                 }
 
                 if (settings.getVirtualDnsTwo().length() > 0) {
-                    options_xl2tpd.write("ms-dns " + settings.getVirtualDnsTwo() + RET);
+                    options_xl2tpd.write("ms-dns " + stripLineBreaks(settings.getVirtualDnsTwo()) + RET);
                     dnsWritten = true;
                 }
 
@@ -827,15 +827,29 @@ public class IpsecVpnManager
     }
 
     /**
+     * Removes CR and LF characters from a string.
+     *
+     * @param s
+     *        The string to strip
+     *
+     * @return The string with line breaks removed
+     */
+    private static String stripLineBreaks(String s)
+    {
+        if (s == null) return "";
+        return s.replace("\r", "").replace("\n", "");
+    }
+
+    /**
      * This function takes a normal string and converts it to a string of hex
      * digit pairs representing each character in the original string. We use it
      * to obfuscate passwords in the ipsec.secrets file. Using the hex format
      * also prevents problems with embeding characters that may also be a
      * parsing token used by one of the IPsec applications or daemons.
-     * 
+     *
      * @param source
      *        The string to convert to hex format
-     * 
+     *
      * @return The hex format string
      */
     private String StringHexify(String source)

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnSettings.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnSettings.java
@@ -34,26 +34,43 @@ public class IpsecVpnSettings implements java.io.Serializable, JSONString
     private boolean allowConcurrentLogins = true;
     private LinkedList<VirtualListen> virtualListenList = new LinkedList<>();
     private AuthenticationType authenticationType = AuthenticationType.LOCAL_DIRECTORY;
+    @SafeCheck(SafeType.IP_OR_CIDR)
     private String virtualNetworkPool = ""; // used for GRE
+    @SafeCheck(SafeType.IP_OR_CIDR)
     private String virtualAddressPool = ""; // used for L2TP
     @SafeCheck(SafeType.IP_OR_CIDR)
     private String virtualXauthPool = ""; // used for XAUTH
+    @SafeCheck(SafeType.OPAQUE_SECRET)
     private String virtualSecret = "Please_Change_Me";
+    @SafeCheck(SafeType.IP_OR_CIDR)
     private String virtualDnsOne = "";
+    @SafeCheck(SafeType.IP_OR_CIDR)
     private String virtualDnsTwo = "";
+    @SafeCheck(SafeType.SIMPLE_TEXT)
     private String charonDebug = "";
+    @SafeCheck(SafeType.ALPHANUM)
     private String uniqueIds = "yes";
     private boolean phase1Manual = false;
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase1Cipher = "3des";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase1Hash = "md5";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase1Group = "modp2048";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase1Lifetime = "28800";
     private boolean phase2Manual = false;
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase2Cipher = "3des";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase2Hash = "md5";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase2Group = "modp2048";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase2Lifetime = "3600";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase1DefaultLifetime = "8h";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase2DefaultLifetime = "1h";
 
     public IpsecVpnSettings()

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnTunnel.java
@@ -29,20 +29,31 @@ public class IpsecVpnTunnel implements JSONString, Serializable
     private String conntype;
     @SafeCheck(SafeType.SIMPLE_TEXT)
     private String description;
+    @SafeCheck(SafeType.OPAQUE_SECRET)
     private String secret;
     @SafeCheck(SafeType.ALPHANUM)
     private String runmode;
+    @SafeCheck(SafeType.ALPHANUM)
     private String dpddelay = "30";
+    @SafeCheck(SafeType.ALPHANUM)
     private String dpdtimeout = "120";
     private boolean phase1Manual = false;
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase1Cipher = "3des";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase1Hash = "md5";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase1Group = "modp2048";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase1Lifetime = "28800";
     private boolean phase2Manual = false;
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase2Cipher = "3des";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase2Hash = "md5";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase2Group = "modp2048";
+    @SafeCheck(SafeType.ALPHANUM)
     private String phase2Lifetime = "3600";
     @SafeCheck({SafeType.HOSTNAME, SafeType.IP_OR_CIDR})
     private String left;

--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/VirtualListen.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/VirtualListen.java
@@ -8,6 +8,9 @@ import java.io.Serializable;
 import org.json.JSONObject;
 import org.json.JSONString;
 
+import com.untangle.uvm.util.SafeCheck;
+import com.untangle.uvm.util.SafeType;
+
 /**
  * This class is used to represent an IP address on which the IPsec daemon will
  * be configured to listen for and accept inbound VPN connections.
@@ -20,6 +23,7 @@ import org.json.JSONString;
 public class VirtualListen implements JSONString, Serializable
 {
     private int id;
+    @SafeCheck(SafeType.IP_OR_CIDR)
     private String address;
 
     public VirtualListen()


### PR DESCRIPTION
<p style="color: rgb(204, 204, 204); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"></p><h3 style="color: rgb(204, 204, 204); margin-top: 24px; margin-bottom: 8px; font-weight: 600; font-size: 1.1em; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"></h3><h2 style="color: rgb(204, 204, 204); margin-top: 24px; margin-bottom: 8px; font-weight: 600; font-size: 1.3em; border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 6px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><ul style="padding-left: 32px; color: rgb(204, 204, 204); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="margin: 4px 0px;">Fix newline injection vulnerability in strongSwan<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">ipsec.conf</code><span> </span>generation -- an authenticated admin could inject arbitrary directives (including<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">leftupdown=</code><span> </span>for root RCE) by embedding<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">\n</code><span> </span>in tunnel or VPN settings fields via the JSON-RPC API</li><li style="margin: 4px 0px;">Add<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">@SafeCheck</code><span> </span>input validation annotations to 29 previously unannotated string fields across<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">IpsecVpnTunnel</code>,<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">IpsecVpnSettings</code>, and<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">VirtualListen</code><span> </span>POJOs</li><li style="margin: 4px 0px;">Add defense-in-depth<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">stripLineBreaks()</code><span> </span>sanitization at all 66 user-controlled string interpolation sites in<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">IpsecVpnManager.writeConfigFiles()</code></li></ul><h2 style="color: rgb(204, 204, 204); margin-top: 24px; margin-bottom: 8px; font-weight: 600; font-size: 1.3em; border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 6px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Background</h2><p style="color: rgb(204, 204, 204); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">IpsecVpnManager.writeConfigFiles()</code><span> </span>writes strongSwan<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">/etc/ipsec.conf</code><span> </span>by concatenating user-controlled string fields into<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">key=value\n</code><span> </span>lines. A<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">\n</code><span> </span>in any value injects a new directive. The<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">leftupdown=</code><span> </span>directive is especially dangerous as strongSwan executes it as root on tunnel up/down events. The<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">right</code><span> </span>field was previously patched (commit 90a2f2a793), but 29 other string fields remained unannotated and vulnerable to injection via the JSON-RPC API.</p><h2 style="color: rgb(204, 204, 204); margin-top: 24px; margin-bottom: 8px; font-weight: 600; font-size: 1.3em; border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 6px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><h3 style="color: rgb(204, 204, 204); margin-top: 24px; margin-bottom: 8px; font-weight: 600; font-size: 1.1em; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Layer 1 -- Input validation (<code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">@SafeCheck</code><span> </span>annotations)</h3>
File | Fields annotated | SafeTypes used
-- | -- | --
IpsecVpnTunnel.java | 11 new (secret, dpddelay, dpdtimeout, phase1/2 Cipher/Hash/Group/Lifetime) | OPAQUE_SECRET, ALPHANUM
IpsecVpnSettings.java | 17 new (virtualNetworkPool, virtualAddressPool, virtualSecret, virtualDnsOne/Two, charonDebug, uniqueIds, phase1/2 fields, default lifetimes) | IP_OR_CIDR, OPAQUE_SECRET, SIMPLE_TEXT, ALPHANUM
VirtualListen.java | 1 new (address) + SafeCheck/SafeType imports | IP_OR_CIDR

<p style="color: rgb(204, 204, 204); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">All SafeTypes used reject CR/LF control characters. Every legitimate value from the UI combo-box stores and default values was verified against its SafeType -- zero regression risk.</p><h3 style="color: rgb(204, 204, 204); margin-top: 24px; margin-bottom: 8px; font-weight: 600; font-size: 1.1em; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Layer 2 -- Sink-level defense (<code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">stripLineBreaks()</code>)</h3><p style="color: rgb(204, 204, 204); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Added<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">stripLineBreaks()</code><span> </span>helper in<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">IpsecVpnManager.java</code><span> </span>wrapping every user-controlled string interpolation in<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">writeConfigFiles()</code><span> </span>across<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">ipsec.conf</code>,<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">ipsec.secrets</code>, and<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">options.xl2tpd</code><span> </span>write sites (66 call sites). This is belt-and-braces -- if a newline somehow bypassed<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">@SafeCheck</code>, it would be stripped before reaching the config file.</p><h3 style="color: rgb(204, 204, 204); margin-top: 24px; margin-bottom: 8px; font-weight: 600; font-size: 1.1em; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tests</h3><p style="color: rgb(204, 204, 204); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Added automated<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">test_ipsec_vpn.py</code><span> </span>tests for both positive (legitimate values round-trip) and negative (newline injection payloads rejected) flows.</p><h2 style="color: rgb(204, 204, 204); margin-top: 24px; margin-bottom: 8px; font-weight: 600; font-size: 1.3em; border-bottom: 1px solid var(--vscode-panel-border); padding-bottom: 6px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Regression risk</h2><p style="color: rgb(204, 204, 204); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>None.</strong><span> </span>All 94 combo-box cipher/hash/group values verified against<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">ALPHANUM</code>; all numeric defaults verified; all CIDR pools verified against<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">IP_OR_CIDR</code>;<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">charonDebug</code><span> </span>format (<code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">"ike 2, knl 1"</code>) verified against<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">SIMPLE_TEXT</code>. Empty strings and null always pass<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">@SafeCheck</code><span> </span>(framework skips regex). The sync-settings repo does NOT generate<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">/etc/ipsec.conf</code><span> </span>-- changes are isolated to<span> </span><code style="font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground); background: var(--vscode-textCodeBlock-background); padding: 2px 4px; border-radius: 3px; font-size: var(--vscode-editor-font-size, 13px);">ngfw_src/ipsec-vpn/</code>.</p><br class="Apple-interchange-newline">


**BEFORE:**

<img width="695" height="696" alt="bf-ips-v" src="https://github.com/user-attachments/assets/065b97e5-5291-4c2e-a048-cba02332aa56" />

**AFTER:**

<img width="788" height="696" alt="af-ipsec-va" src="https://github.com/user-attachments/assets/02bff700-0ac9-4387-ad10-e1dd6c5e4a44" />

