### PR TITLE
ngfw-15858 Added hostname verification in ssl-inspector

### DIFF
--- a/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
+++ b/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
@@ -23,6 +23,7 @@ testedServerName="news.ycombinator.com"
 testedServerURLParts = testedServerName.split(".")
 testedServerDomainWildcard = "*" + testedServerURLParts[-2] + "." + testedServerURLParts[-1]
 dropboxIssuer="C = US, ST = California, L = San Francisco, O = \\\"Dropbox, Inc\\\""
+hostnameVerifyBypassDetail = "Hostname Verification Bypassed"
 
 
 def createSSLInspectRule(url=testedServerDomainWildcard):
@@ -89,6 +90,16 @@ def search_term_rules_clear():
     webSettings = appWeb.getSettings()
     webSettings["searchTerms"]["list"] = []
     appWeb.setSettings(webSettings)
+
+
+def createHostnameBypassRule(hostname, enabled=True, description="test bypass"):
+    return {
+        "javaClass": "com.untangle.uvm.app.GenericRule",
+        "string": hostname,
+        "enabled": enabled,
+        "isGlobal": False,
+        "description": description
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -288,6 +299,101 @@ class SslInspectorTests(NGFWTestCase):
                                                 "host", t["host"],
                                                 "term", t["term"])
             assert( found )
+
+    def test_100_hostnameVerificationEnabled(self):
+        """Verify hostname verification enabled by default, normal HTTPS works without bypass pipe"""
+        appData = self._app.getSettings()
+        assert appData.get('verifyServerCertHostname') == True
+        result = remote_control.run_command(global_functions.build_curl_command(uri="https://" + testedServerName + "/"))
+        assert (result == 0)
+        events = global_functions.get_events('SSL Inspector', 'All Sessions', None, 5)
+        event = global_functions.find_event(events.get('list'), 5,
+            "ssl_inspector_status", "INSPECTED",
+            "ssl_inspector_detail", testedServerName)
+        assert event is not None
+        assert hostnameVerifyBypassDetail not in event.get("ssl_inspector_detail", "")
+
+    def test_101_hostnameVerificationBypassList(self):
+        """Verify bypass list entry adds bypass pipe to detail"""
+        appData = self._app.getSettings()
+        appData['hostnameVerificationBypassList']['list'].append(createHostnameBypassRule(testedServerName))
+        self._app.setSettings(appData)
+        try:
+            result = remote_control.run_command(global_functions.build_curl_command(uri="https://" + testedServerName + "/"))
+            assert (result == 0)
+            events = global_functions.get_events('SSL Inspector', 'All Sessions', None, 5)
+            event = global_functions.find_event(events.get('list'), 5, "ssl_inspector_status", "INSPECTED")
+            assert event is not None
+            assert hostnameVerifyBypassDetail in event.get("ssl_inspector_detail", "")
+        finally:
+            appData['hostnameVerificationBypassList']['list'] = []
+            self._app.setSettings(appData)
+
+    def test_102_hostnameVerificationGlobalDisable(self):
+        """Verify global disable adds bypass pipe to detail"""
+        appData = self._app.getSettings()
+        appData['verifyServerCertHostname'] = False
+        self._app.setSettings(appData)
+        try:
+            result = remote_control.run_command(global_functions.build_curl_command(uri="https://" + testedServerName + "/"))
+            assert (result == 0)
+            events = global_functions.get_events('SSL Inspector', 'All Sessions', None, 5)
+            event = global_functions.find_event(events.get('list'), 5, "ssl_inspector_status", "INSPECTED")
+            assert event is not None
+            assert hostnameVerifyBypassDetail in event.get("ssl_inspector_detail", "")
+        finally:
+            appData['verifyServerCertHostname'] = True
+            self._app.setSettings(appData)
+
+    def test_103_hostnameVerificationBlindTrust(self):
+        """Verify blind trust skips hostname verification without bypass pipe"""
+        appData = self._app.getSettings()
+        appData['serverBlindTrust'] = True
+        self._app.setSettings(appData)
+        try:
+            result = remote_control.run_command(global_functions.build_curl_command(uri="https://" + testedServerName + "/"))
+            assert (result == 0)
+            events = global_functions.get_events('SSL Inspector', 'All Sessions', None, 5)
+            event = global_functions.find_event(events.get('list'), 5, "ssl_inspector_status", "INSPECTED")
+            assert event is not None
+            assert hostnameVerifyBypassDetail not in event.get("ssl_inspector_detail", "")
+        finally:
+            appData['serverBlindTrust'] = False
+            self._app.setSettings(appData)
+
+    def test_104_hostnameVerificationWildcardBypass(self):
+        """Verify wildcard bypass entry matches and adds bypass pipe"""
+        appData = self._app.getSettings()
+        appData['hostnameVerificationBypassList']['list'].append(createHostnameBypassRule(testedServerDomainWildcard, description="wildcard test"))
+        self._app.setSettings(appData)
+        try:
+            result = remote_control.run_command(global_functions.build_curl_command(uri="https://" + testedServerName + "/"))
+            assert (result == 0)
+            events = global_functions.get_events('SSL Inspector', 'All Sessions', None, 5)
+            event = global_functions.find_event(events.get('list'), 5, "ssl_inspector_status", "INSPECTED")
+            assert event is not None
+            assert hostnameVerifyBypassDetail in event.get("ssl_inspector_detail", "")
+        finally:
+            appData['hostnameVerificationBypassList']['list'] = []
+            self._app.setSettings(appData)
+
+    def test_105_hostnameVerificationDisabledBypassEntry(self):
+        """Verify disabled bypass entry does not add bypass pipe"""
+        appData = self._app.getSettings()
+        appData['hostnameVerificationBypassList']['list'].append(createHostnameBypassRule(testedServerName, enabled=False, description="disabled entry"))
+        self._app.setSettings(appData)
+        try:
+            result = remote_control.run_command(global_functions.build_curl_command(uri="https://" + testedServerName + "/"))
+            assert (result == 0)
+            events = global_functions.get_events('SSL Inspector', 'All Sessions', None, 5)
+            event = global_functions.find_event(events.get('list'), 5,
+                "ssl_inspector_status", "INSPECTED",
+                "ssl_inspector_detail", testedServerName)
+            assert event is not None
+            assert hostnameVerifyBypassDetail not in event.get("ssl_inspector_detail", "")
+        finally:
+            appData['hostnameVerificationBypassList']['list'] = []
+            self._app.setSettings(appData)
 
     def test_551_https_with_sni_packet_split(self):
         """ Verify no exceptions with split Hello TLS packets"""

--- a/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
+++ b/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
@@ -18,6 +18,9 @@ import tests.global_functions as global_functions
 default_policy_id = 1
 app = None
 appWeb = None
+ssl_app_2 = None
+policy_app = None
+secondRackId = None
 pornServerName="www.pornhub.com"
 testedServerName="news.ycombinator.com"
 testedServerURLParts = testedServerName.split(".")
@@ -100,6 +103,24 @@ def createHostnameBypassRule(hostname, enabled=True, description="test bypass"):
         "isGlobal": False,
         "description": description
     }
+
+
+def addHostnameBypassEntry(app, hostname, enabled=True, isGlobal=False, description="test"):
+    appData = app.getSettings()
+    rule = createHostnameBypassRule(hostname, enabled=enabled, description=description)
+    rule['isGlobal'] = isGlobal
+    appData['hostnameVerificationBypassList']['list'].append(rule)
+    app.setSettings(appData)
+
+
+def clearHostnameBypassList(app):
+    appData = app.getSettings()
+    appData['hostnameVerificationBypassList']['list'] = []
+    app.setSettings(appData)
+
+
+def getHostnameBypassList(app):
+    return app.getSettings()['hostnameVerificationBypassList']['list']
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +218,7 @@ class SslInspectorTests(NGFWTestCase):
 
     @classmethod
     def initial_extra_setup(cls):
-        global appData, appWeb, appWebData
+        global appData, appWeb, appWebData, ssl_app_2, policy_app, secondRackId
 
         global_functions.get_latest_client_test_pkg("web")
 
@@ -209,6 +230,12 @@ class SslInspectorTests(NGFWTestCase):
 
         appData['ignoreRules']['list'].insert(0,createSSLInspectRule(testedServerDomainWildcard))
         cls._app.setSettings(appData)
+
+        if (global_functions.uvmContext.appManager().isInstantiated("policy-manager")):
+            raise Exception('app policy-manager already instantiated')
+        policy_app = global_functions.uvmContext.appManager().instantiate("policy-manager")
+        secondRackId = global_functions.addRack(policy_app, name="Second Rack")
+        ssl_app_2 = global_functions.uvmContext.appManager().instantiate("ssl-inspector", secondRackId)
         
     def test_010_clientIsOnline(self):
         result = remote_control.is_online()
@@ -664,10 +691,50 @@ class SslInspectorTests(NGFWTestCase):
             f"Expected safeForLog truncation marker ('...') in WARN; "
             f"got: {warns}")
 
+    def test_106_hostnameVerificationGlobalBypassPropagation(self):
+        """Verify global bypass entries propagate across SSL Inspector instances"""
+        # verify both start with empty bypass lists
+        list1 = getHostnameBypassList(self._app)
+        list2 = getHostnameBypassList(ssl_app_2)
+        assert len(list1) == 0, "Instance 1 bypass list should be empty initially"
+        assert len(list2) == 0, "Instance 2 bypass list should be empty initially"
+
+        try:
+            # add a global entry and a non-global entry on instance 1
+            addHostnameBypassEntry(self._app, "global.example.com", isGlobal=True, description="global entry")
+            addHostnameBypassEntry(self._app, "local.example.com", isGlobal=False, description="local entry")
+
+            # verify instance 1 has both entries
+            list1 = getHostnameBypassList(self._app)
+            assert len(list1) == 2, "Instance 1 should have 2 entries, got %d" % len(list1)
+
+            # verify instance 2 has only the global entry
+            list2 = getHostnameBypassList(ssl_app_2)
+            assert len(list2) == 1, "Instance 2 should have 1 global entry, got %d" % len(list2)
+            assert list2[0]['string'] == "global.example.com"
+
+            # clear all entries on instance 1 (this removes the global entry too)
+            clearHostnameBypassList(self._app)
+
+            # verify instance 2 no longer has the global entry
+            list2 = getHostnameBypassList(ssl_app_2)
+            assert len(list2) == 0, "Instance 2 should have 0 entries after clearing, got %d" % len(list2)
+
+        finally:
+            clearHostnameBypassList(self._app)
+
     @classmethod
     def final_extra_tear_down(cls):
-        global appWeb
+        global appWeb, ssl_app_2, policy_app, secondRackId
 
+        if ssl_app_2 != None:
+            global_functions.uvmContext.appManager().destroy(ssl_app_2.getAppSettings()["id"])
+            ssl_app_2 = None
+        if policy_app != None:
+            global_functions.nukeRules(policy_app)
+            global_functions.removeRack(policy_app, secondRackId)
+            global_functions.uvmContext.appManager().destroy(policy_app.getAppSettings()["id"])
+            policy_app = None
         if appWeb != None:
             global_functions.uvmContext.appManager().destroy( appWeb.getAppSettings()["id"])
             appWeb = None

--- a/ssl-inspector/js/Main.js
+++ b/ssl-inspector/js/Main.js
@@ -7,12 +7,14 @@ Ext.define('Ung.apps.sslinspector.Main', {
 
         data: {
             autoRefresh: false,
-            trustedCertData: []
+            trustedCertData: [],
+            isAddAction: false
         },
 
         stores: {
             ignoreRules: { data: '{settings.ignoreRules.list}' },
-            trustedCertList: { data: '{trustedCertData}' }
+            trustedCertList: { data: '{trustedCertData}' },
+            hostnameBypassList: { data: '{settings.hostnameVerificationBypassList.list}' }
         }
     },
 

--- a/ssl-inspector/js/MainController.js
+++ b/ssl-inspector/js/MainController.js
@@ -203,6 +203,22 @@ Ext.define('Ung.apps.sslinspector.MainController', {
 
 });
 
+Ext.define('Ung.apps.sslinspector.HostnameBypassGridController', {
+    extend: 'Ung.cmp.GridController',
+    alias: 'controller.app-sslinspector-hostname-bypass',
+
+    addRecord: function () {
+        var vm = this.getViewModel();
+        if (vm) vm.set('isAddAction', true);
+        this.callParent(arguments);
+    },
+    editRecord: function () {
+        var vm = this.getViewModel();
+        if (vm) vm.set('isAddAction', false);
+        this.callParent(arguments);
+    }
+});
+
 Ext.define('Ung.apps.sslinspector.SpecialGridController', {
     extend: 'Ung.cmp.GridController',
     alias: 'controller.app-sslinspector-special',

--- a/ssl-inspector/js/view/Configuration.js
+++ b/ssl-inspector/js/view/Configuration.js
@@ -181,6 +181,33 @@ Ext.define('Ung.apps.sslinspector.view.Configuration', {
             xtype: 'app-ssl-inspector-trusted-certs-grid',
             padding: '10 20 0 20'
         }]
+    }, {
+        xtype: 'fieldset',
+        padding: '10 0 10 0',
+        title: 'Server Certificate Hostname Verification'.t(),
+        labelWidth: 230,
+        bind: {
+            disabled: '{settings.serverBlindTrust}'
+        },
+        items: [{
+            xtype: 'checkbox',
+            fieldLabel: 'Enforce Hostname Match'.t(),
+            labelWidth: 250,
+            name: 'verifyServerCertHostname',
+            bind: '{settings.verifyServerCertHostname}'
+        },{
+            xtype: 'displayfield',
+            padding: '0 100 0 20',
+            value: 'When enabled, the SSL Inspector verifies that the upstream server certificate hostname matches the requested SNI hostname. Entries in the bypass list below will skip this verification while still performing certificate chain validation.'.t()
+        },{
+            xtype: 'app-ssl-inspector-hostname-bypass-grid',
+            padding: '10 20 0 20',
+            height: 200,
+            bind: {
+                store: '{hostnameBypassList}',
+                disabled: '{!settings.verifyServerCertHostname}'
+            }
+        }]
     }]
 
 });
@@ -226,5 +253,113 @@ Ext.define('Ung.apps.sslinspector.view.TrustedCertsGrid', {
         align: 'center',
         iconCls: 'fa fa-trash',
         handler: 'deleteTrustedCertificate'
+    }]
+});
+
+Ext.define('Ung.apps.sslinspector.view.HostnameBypassGrid', {
+    extend: 'Ung.cmp.Grid',
+    alias: 'widget.app-ssl-inspector-hostname-bypass-grid',
+    itemId: 'hostname-bypass-grid',
+    title: 'Hostname Verification Bypass List'.t(),
+    withValidation: false,
+    controller: 'app-sslinspector-hostname-bypass',
+
+    dockedItems: [{
+        xtype: 'toolbar',
+        dock: 'top',
+        items: ['@add', '->', '@import', '@export']
+    }],
+
+    recordActions: ['edit', 'copy', 'delete'],
+    copyAppendField: 'description',
+
+    emptyText: 'No Hostname Entries'.t(),
+
+    importValidationJavaClass: true,
+
+    viewConfig: {
+        deferEmptyText: false,
+        getRowClass: Ung.util.Util.getGlobalRowClass
+    },
+
+    listProperty: 'settings.hostnameVerificationBypassList.list',
+    emptyRow: {
+        string: '',
+        enabled: true,
+        isGlobal: false,
+        description: '',
+        javaClass: 'com.untangle.uvm.app.GenericRule'
+    },
+
+    columns: [{
+        header: 'Hostname'.t(),
+        width: Renderer.uriWidth,
+        flex: 1,
+        dataIndex: 'string',
+        editor: {
+            xtype: 'textfield',
+            emptyText: '[enter hostname, IP, or *.domain.com]'.t(),
+            allowBlank: false,
+            validator: function(val) {
+                if (Ext.form.field.VTypes.ipAddress(val)) return true;
+                if (/^(\*\.)?[a-zA-Z0-9]([a-zA-Z0-9\-_.]*[a-zA-Z0-9])?$/.test(val)) return true;
+                return 'Must be a valid hostname, IP address, or wildcard (*.domain.com)'.t();
+            }
+        }
+    }, {
+        xtype: 'checkcolumn',
+        width: Renderer.booleanWidth,
+        header: 'Bypass'.t(),
+        dataIndex: 'enabled',
+        resizable: false
+    }, {
+        xtype: 'checkcolumn',
+        width: Renderer.booleanWidth,
+        header: 'Global'.t(),
+        dataIndex: 'isGlobal',
+        resizable: false,
+        listeners: {
+            beforecheckchange: Ung.util.Util.canToggleGlobalCheckbox
+        }
+    }, {
+        header: 'Description'.t(),
+        width: Renderer.messageWidth,
+        flex: 2,
+        dataIndex: 'description',
+        editor: {
+            xtype: 'textfield',
+            emptyText: '[no description]'.t()
+        }
+    }],
+    editorFields: [{
+        xtype: 'textfield',
+        bind: '{record.string}',
+        fieldLabel: 'Hostname'.t(),
+        emptyText: '[enter hostname, IP, or *.domain.com]'.t(),
+        allowBlank: false,
+        width: 400,
+        validator: function(val) {
+            if (Ext.form.field.VTypes.ipAddress(val)) return true;
+            if (/^(\*\.)?[a-zA-Z0-9]([a-zA-Z0-9\-_.]*[a-zA-Z0-9])?$/.test(val)) return true;
+            return 'Must be a valid hostname, IP address, or wildcard (*.domain.com)'.t();
+        }
+    }, {
+        xtype: 'checkbox',
+        bind: '{record.enabled}',
+        fieldLabel: 'Bypass'.t()
+    }, {
+        xtype: 'checkbox',
+        bind: {
+            value: '{record.isGlobal}',
+            hidden: '{!isAddAction}'
+        },
+        fieldLabel: 'Global'.t()
+    }, {
+        xtype: 'textarea',
+        bind: '{record.description}',
+        fieldLabel: 'Description'.t(),
+        emptyText: '[no description]'.t(),
+        width: 400,
+        height: 60
     }]
 });

--- a/ssl-inspector/js/view/Configuration.js
+++ b/ssl-inspector/js/view/Configuration.js
@@ -256,6 +256,12 @@ Ext.define('Ung.apps.sslinspector.view.TrustedCertsGrid', {
     }]
 });
 
+var hostnameOrIpValidator = function(val) {
+    if (Ext.form.field.VTypes.ipAddress(val)) return true;
+    if (/^(\*\.)?[a-zA-Z0-9]([a-zA-Z0-9\-_.]*[a-zA-Z0-9])?$/.test(val)) return true;
+    return 'Must be a valid hostname, IP address, or wildcard (*.domain.com)'.t();
+};
+
 Ext.define('Ung.apps.sslinspector.view.HostnameBypassGrid', {
     extend: 'Ung.cmp.Grid',
     alias: 'widget.app-ssl-inspector-hostname-bypass-grid',
@@ -300,11 +306,7 @@ Ext.define('Ung.apps.sslinspector.view.HostnameBypassGrid', {
             xtype: 'textfield',
             emptyText: '[enter hostname, IP, or *.domain.com]'.t(),
             allowBlank: false,
-            validator: function(val) {
-                if (Ext.form.field.VTypes.ipAddress(val)) return true;
-                if (/^(\*\.)?[a-zA-Z0-9]([a-zA-Z0-9\-_.]*[a-zA-Z0-9])?$/.test(val)) return true;
-                return 'Must be a valid hostname, IP address, or wildcard (*.domain.com)'.t();
-            }
+            validator: hostnameOrIpValidator
         }
     }, {
         xtype: 'checkcolumn',
@@ -338,11 +340,7 @@ Ext.define('Ung.apps.sslinspector.view.HostnameBypassGrid', {
         emptyText: '[enter hostname, IP, or *.domain.com]'.t(),
         allowBlank: false,
         width: 400,
-        validator: function(val) {
-            if (Ext.form.field.VTypes.ipAddress(val)) return true;
-            if (/^(\*\.)?[a-zA-Z0-9]([a-zA-Z0-9\-_.]*[a-zA-Z0-9])?$/.test(val)) return true;
-            return 'Must be a valid hostname, IP address, or wildcard (*.domain.com)'.t();
-        }
+        validator: hostnameOrIpValidator
     }, {
         xtype: 'checkbox',
         bind: '{record.enabled}',

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorApp.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorApp.java
@@ -16,9 +16,12 @@ package com.untangle.app.ssl_inspector;
 import javax.net.ssl.TrustManagerFactory;
 
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -29,8 +32,12 @@ import java.io.IOException;
 import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.HookCallback;
 import com.untangle.uvm.OAuthDomain;
+import com.untangle.uvm.SettingsManager;
 import com.untangle.uvm.UvmContextFactory;
+import com.untangle.uvm.app.App;
 import com.untangle.uvm.app.AppMetric;
+import com.untangle.uvm.app.GenericRule;
+import com.untangle.uvm.app.GlobMatcher;
 import com.untangle.uvm.vnet.PipelineConnector;
 import com.untangle.uvm.vnet.Affinity;
 import com.untangle.uvm.app.AppBase;
@@ -79,6 +86,7 @@ public class SslInspectorApp extends AppBase
 
     private static final File CRON_FILE = new File("/etc/cron.daily/ssl-inspector-cleanup");
     private static String keyStorePath = "/var/cache/untangle-ssl";
+    private static final String GLOBAL_SETTINGS_FILE = System.getProperty("uvm.settings.dir") + "/ssl-inspector/globalSettings.js";
 
     private AuthenticationOautDomainChangeHookCallback authenticationOautDomainChangeHookCallback = new AuthenticationOautDomainChangeHookCallback();
 
@@ -144,7 +152,7 @@ public class SslInspectorApp extends AppBase
                 logger.warn("No settings found... initializing with defaults");
                 SslInspectorSettings makeSettings = new SslInspectorSettings();
                 makeSettings.setIgnoreRules(generateDefaultRules());
-                makeSettings.setVersion(3);
+                makeSettings.setVersion(4);
                 setSettings(makeSettings);
             }
 
@@ -177,6 +185,15 @@ public class SslInspectorApp extends AppBase
                     renumberRules = true;
                 }
 
+                // v3 to v4: add hostname verification settings
+                if (readSettings.getVersion().intValue() < 4) {
+                    logger.info("Migrating settings from v{} to v4: adding hostname verification", readSettings.getVersion());
+                    readSettings.setVerifyServerCertHostname(true);
+                    readSettings.setHostnameVerificationBypassList(new LinkedList<>());
+                    readSettings.setVersion(4);
+                    setSettings(readSettings);
+                }
+
                 if(renumberRules) {
                     int idx = 1;
                     for (SslInspectorRule rule : readSettings.getIgnoreRules()) {
@@ -185,6 +202,7 @@ public class SslInspectorApp extends AppBase
                 }
 
                 this.settings = readSettings;
+                loadAllGlobalSettings();
 
                 // appy the settings to the app
                 reconfigure();
@@ -249,6 +267,8 @@ public class SslInspectorApp extends AppBase
         String appID = this.getAppSettings().getId().toString();
         String settingsFile = System.getProperty("uvm.settings.dir") + "/ssl-inspector/settings_" + appID + ".js";
 
+        setGlobalSettings(newSettings);
+
         try {
             UvmContextFactory.context().settingsManager().save(settingsFile, newSettings);
         } catch (Exception exn) {
@@ -258,6 +278,7 @@ public class SslInspectorApp extends AppBase
 
         this.settings = newSettings;
         reconfigure();
+        syncAllInstances();
     }
 
     /**
@@ -303,6 +324,152 @@ public class SslInspectorApp extends AppBase
     public TrustManagerFactory getTrustFactory()
     {
         return (trustFactory);
+    }
+
+    /**
+     * Loads global settings from the shared global settings file.
+     *
+     * @return The global settings, or a new empty settings object if none exist
+     */
+    private SslInspectorSettings getGlobalSettings()
+    {
+        SslInspectorSettings globalSettings = new SslInspectorSettings();
+        try {
+            SslInspectorSettings loaded = UvmContextFactory.context().settingsManager().load(SslInspectorSettings.class, GLOBAL_SETTINGS_FILE);
+            if (loaded != null) globalSettings = loaded;
+        } catch (SettingsManager.SettingsException e) {
+            logger.warn("Failed to load global settings:", e);
+        }
+        return globalSettings;
+    }
+
+    /**
+     * Extracts isGlobal entries from the bypass list in newSettings,
+     * saves them to the global settings file, and removes them from
+     * the instance settings so they are not duplicated.
+     *
+     * @param newSettings The settings being saved
+     */
+    private void setGlobalSettings(SslInspectorSettings newSettings)
+    {
+        SslInspectorSettings globalSettings = getGlobalSettings();
+        List<GenericRule> globalBypassList = globalSettings.getHostnameVerificationBypassList();
+        if (globalBypassList == null) globalBypassList = new LinkedList<>();
+
+        List<GenericRule> newBypassList = newSettings.getHostnameVerificationBypassList();
+        if (newBypassList == null) {
+            logger.warn("Hostname verification bypass list is null in incoming settings, skipping global settings update");
+            return;
+        }
+
+        Set<String> newGlobalHostnames = new HashSet<>();
+        Iterator<GenericRule> iterator = newBypassList.iterator();
+
+        while (iterator.hasNext()) {
+            GenericRule rule = iterator.next();
+            if (rule.getIsGlobal()) {
+                String hostname = rule.getString();
+                newGlobalHostnames.add(hostname);
+
+                Optional<GenericRule> existing = globalBypassList.stream()
+                    .filter(g -> g.getString().equals(hostname))
+                    .findFirst();
+
+                if (existing.isPresent()) {
+                    GenericRule globalRule = existing.get();
+                    boolean changed = globalRule.getEnabled() != rule.getEnabled()
+                        || !String.valueOf(globalRule.getDescription()).equals(String.valueOf(rule.getDescription()));
+                    if (changed) {
+                        globalRule.setEnabled(rule.getEnabled());
+                        globalRule.setDescription(rule.getDescription());
+                    }
+                } else {
+                    globalBypassList.add(rule);
+                }
+
+                iterator.remove();
+            }
+        }
+
+        globalBypassList.removeIf(g -> !newGlobalHostnames.contains(g.getString()));
+        globalSettings.setHostnameVerificationBypassList(new LinkedList<>(globalBypassList));
+
+        try {
+            UvmContextFactory.context().settingsManager().save(GLOBAL_SETTINGS_FILE, globalSettings);
+            logger.info("Saved global hostname bypass settings ({} entries)", globalBypassList.size());
+        } catch (SettingsManager.SettingsException e) {
+            logger.error("Failed to save global settings.", e);
+        }
+    }
+
+    /**
+     * Reloads instance settings from disk and merges in the global
+     * hostname verification bypass entries.
+     */
+    public void loadAllGlobalSettings()
+    {
+        String appID = this.getAppSettings().getId().toString();
+        String settingsFile = System.getProperty("uvm.settings.dir") + "/ssl-inspector/settings_" + appID + ".js";
+
+        try {
+            SslInspectorSettings readSettings = UvmContextFactory.context().settingsManager().load(SslInspectorSettings.class, settingsFile);
+            if (readSettings == null) {
+                logger.warn("Failed to reload settings from {}", settingsFile);
+                return;
+            }
+
+            if (readSettings.getHostnameVerificationBypassList() == null) {
+                readSettings.setHostnameVerificationBypassList(new LinkedList<>());
+            }
+
+            SslInspectorSettings globalSettings = getGlobalSettings();
+            List<GenericRule> globalBypassList = globalSettings.getHostnameVerificationBypassList();
+            if (globalBypassList != null && !globalBypassList.isEmpty()) {
+                readSettings.getHostnameVerificationBypassList().addAll(0, globalBypassList);
+                logger.info("Merged {} global hostname bypass entries into instance {}", globalBypassList.size(), appID);
+            }
+
+            this.settings = readSettings;
+        } catch (Exception e) {
+            logger.error("Failed to load settings for instance " + appID, e);
+        }
+    }
+
+    /**
+     * Syncs global settings across all SSL Inspector instances.
+     */
+    private void syncAllInstances()
+    {
+        List<App> appList = UvmContextFactory.context().appManager().appInstances("ssl-inspector");
+        for (App app : appList) {
+            SslInspectorApp sslApp = (SslInspectorApp) app;
+            sslApp.loadAllGlobalSettings();
+        }
+    }
+
+    /**
+     * Checks whether hostname verification should be bypassed for the given SNI hostname.
+     * Returns true if verification is globally disabled, if sniHostname is null,
+     * or if the hostname matches an enabled entry in the bypass list.
+     *
+     * @param sniHostname The SNI hostname to check
+     * @return True if hostname verification should be skipped
+     */
+    public boolean isHostnameVerificationBypassed(String sniHostname)
+    {
+        if (!settings.getVerifyServerCertHostname()) return true;
+        if (sniHostname == null) return true;
+
+        for (GenericRule rule : settings.getHostnameVerificationBypassList()) {
+            if (rule.getEnabled()) {
+                GlobMatcher matcher = GlobMatcher.getMatcher(rule.getString());
+                if (matcher.isMatch(sniHostname)) {
+                    logger.debug("Hostname verification bypassed for {} (matched bypass entry: {})", sniHostname, rule.getString());
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorApp.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorApp.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.io.BufferedReader;
@@ -352,46 +353,18 @@ public class SslInspectorApp extends AppBase
      */
     private void setGlobalSettings(SslInspectorSettings newSettings)
     {
-        SslInspectorSettings globalSettings = getGlobalSettings();
-        List<GenericRule> globalBypassList = globalSettings.getHostnameVerificationBypassList();
-        if (globalBypassList == null) globalBypassList = new LinkedList<>();
-
         List<GenericRule> newBypassList = newSettings.getHostnameVerificationBypassList();
         if (newBypassList == null) {
             logger.warn("Hostname verification bypass list is null in incoming settings, skipping global settings update");
             return;
         }
 
-        Set<String> newGlobalHostnames = new HashSet<>();
-        Iterator<GenericRule> iterator = newBypassList.iterator();
+        SslInspectorSettings globalSettings = getGlobalSettings();
+        List<GenericRule> globalBypassList = globalSettings.getHostnameVerificationBypassList();
+        if (globalBypassList == null) globalBypassList = new LinkedList<>();
 
-        while (iterator.hasNext()) {
-            GenericRule rule = iterator.next();
-            if (rule.getIsGlobal()) {
-                String hostname = rule.getString();
-                newGlobalHostnames.add(hostname);
+        updateGlobalList(newBypassList, globalBypassList);
 
-                Optional<GenericRule> existing = globalBypassList.stream()
-                    .filter(g -> g.getString().equals(hostname))
-                    .findFirst();
-
-                if (existing.isPresent()) {
-                    GenericRule globalRule = existing.get();
-                    boolean changed = globalRule.getEnabled() != rule.getEnabled()
-                        || !String.valueOf(globalRule.getDescription()).equals(String.valueOf(rule.getDescription()));
-                    if (changed) {
-                        globalRule.setEnabled(rule.getEnabled());
-                        globalRule.setDescription(rule.getDescription());
-                    }
-                } else {
-                    globalBypassList.add(rule);
-                }
-
-                iterator.remove();
-            }
-        }
-
-        globalBypassList.removeIf(g -> !newGlobalHostnames.contains(g.getString()));
         globalSettings.setHostnameVerificationBypassList(new LinkedList<>(globalBypassList));
 
         try {
@@ -400,6 +373,47 @@ public class SslInspectorApp extends AppBase
         } catch (SettingsManager.SettingsException e) {
             logger.error("Failed to save global settings.", e);
         }
+    }
+
+    /**
+     * Splits global entries from instance entries. Global entries (isGlobal=true) are
+     * moved to globalList and removed from newList. Existing global entries are updated
+     * if changed. Global entries no longer present are removed.
+     *
+     * @param newList    The incoming list (modified in-place: global entries removed)
+     * @param globalList The global list (modified in-place: entries added/updated/removed)
+     */
+    private void updateGlobalList(List<GenericRule> newList, List<GenericRule> globalList)
+    {
+        Set<String> newGlobalKeys = new HashSet<>();
+        Iterator<GenericRule> iterator = newList.iterator();
+
+        while (iterator.hasNext()) {
+            GenericRule rule = iterator.next();
+            if (!rule.getIsGlobal()) continue;
+
+            String key = rule.getString();
+            newGlobalKeys.add(key);
+
+            Optional<GenericRule> existing = globalList.stream()
+                .filter(g -> g.getString().equals(key))
+                .findFirst();
+
+            if (existing.isPresent()) {
+                GenericRule globalRule = existing.get();
+                if (!Objects.equals(globalRule.getEnabled(), rule.getEnabled())
+                        || !Objects.equals(globalRule.getDescription(), rule.getDescription())) {
+                    globalRule.setEnabled(rule.getEnabled());
+                    globalRule.setDescription(rule.getDescription());
+                }
+            } else {
+                globalList.add(rule);
+            }
+
+            iterator.remove();
+        }
+
+        globalList.removeIf(g -> !newGlobalKeys.contains(g.getString()));
     }
 
     /**

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
@@ -299,7 +299,7 @@ class SslInspectorManager
         // No idea if this is even possible, but if so it would allow us
         // to support client to server authentication via certificate.
 
-        // if blind trust is enabled or we are doing SMTP then we simply trust everything
+        // if blind trust is enabled we simply trust everything
         if (useBlindTrust) {
             logger.debug("Using blind trust for upstream connection to {}", sniHostname);
             sslContext.init(null, new TrustManager[] { trust_all_certificates }, null);

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorManager.java
@@ -18,6 +18,7 @@ import javax.net.ssl.X509TrustManager;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 
@@ -289,6 +290,8 @@ class SslInspectorManager
     {
         sslContext = SSLContext.getInstance("TLS");
 
+        boolean useBlindTrust = (app.getSettings().getServerBlindTrust() == true);
+
         // TODO - Today we pass null as the key manager but some day we may
         // want to investigate the possibility of grabbing the cert and key
         // presented for authentication on the client side and put them
@@ -297,11 +300,12 @@ class SslInspectorManager
         // to support client to server authentication via certificate.
 
         // if blind trust is enabled or we are doing SMTP then we simply trust everything
-        if ((app.getSettings().getServerBlindTrust() == true) || (session.getServerPort() == 25)) {
+        if (useBlindTrust) {
+            logger.debug("Using blind trust for upstream connection to {}", sniHostname);
             sslContext.init(null, new TrustManager[] { trust_all_certificates }, null);
         }
 
-        // blind trust not enabled and not SMTP so use the shared list of trusted certs
+        // blind trust not enabled so use the shared list of trusted certs
         else {
             sslContext.init(null, app.getTrustFactory().getTrustManagers(), null);
         }
@@ -319,6 +323,15 @@ class SslInspectorManager
         }
 
         sslEngine.setEnabledProtocols(generateProtocolList(ProtocolList.SERVER));
+
+        if (!useBlindTrust && sniHostname != null
+                && !app.checkBrokenServer(target)
+                && !app.isHostnameVerificationBypassed(sniHostname)) {
+            logger.debug("Enabling hostname verification for {}", sniHostname);
+            SSLParameters sslParams = sslEngine.getSSLParameters();
+            sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+            sslEngine.setSSLParameters(sslParams);
+        }
 
         // on the server side we act like an SSL client
         sslEngine.setUseClientMode(true);

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
@@ -472,7 +472,7 @@ public class SslInspectorParserEventHandler extends AbstractEventHandler
                 app.logEvent(logevt);
                 app.incrementMetric(SslInspectorApp.STAT_UNTRUSTED);
 
-                logger.debug("UNTRUSTED SERVER = " + logDetail);
+                logger.debug("UNTRUSTED SERVER = {}", logDetail);
 
                 // kill the session on both sides
                 shutdownOtherSide(session, true);
@@ -806,6 +806,13 @@ public class SslInspectorParserEventHandler extends AbstractEventHandler
             logDetail = (String) session.globalAttachment(AppTCPSession.KEY_SSL_INSPECTOR_SNI_HOSTNAME);
             if (logDetail == null) logDetail = session.getServerAddr().getHostAddress();
             logevt = new SslInspectorLogEvent(session.sessionEvent(), 0, SslInspectorApp.STAT_INSPECTED, logDetail);
+        }
+
+        // append hostname verification bypass status to the detail
+        // only for bypass list / global disable - not for blind trust, broken server, or null SNI
+        String sniHost = (String) session.globalAttachment(AppTCPSession.KEY_SSL_INSPECTOR_SNI_HOSTNAME);
+        if (sniHost != null && app.isHostnameVerificationBypassed(sniHost)) {
+            logevt.setDetail(logevt.getDetail() + " | Hostname Verification Bypassed");
         }
 
         // either no rule match or we matched an inspect rule so log an event

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorParserEventHandler.java
@@ -809,7 +809,7 @@ public class SslInspectorParserEventHandler extends AbstractEventHandler
         }
 
         // append hostname verification bypass status to the detail
-        // only for bypass list / global disable - not for blind trust, broken server, or null SNI
+        // only for bypass list / global disable - not for blind trust, broken server
         String sniHost = (String) session.globalAttachment(AppTCPSession.KEY_SSL_INSPECTOR_SNI_HOSTNAME);
         if (sniHost != null && app.isHostnameVerificationBypassed(sniHost)) {
             logevt.setDetail(logevt.getDetail() + " | Hostname Verification Bypassed");

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorSettings.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorSettings.java
@@ -11,6 +11,8 @@ import java.util.LinkedList;
 import org.json.JSONString;
 import org.json.JSONObject;
 
+import com.untangle.uvm.app.GenericRule;
+
 /**
  * This is the implementation of the ssl inspector settings.
  * 
@@ -27,6 +29,8 @@ public class SslInspectorSettings implements Serializable, JSONString
     private boolean processEncryptedWebTraffic;
     private boolean blockInvalidTraffic;
     private boolean serverBlindTrust;
+    private boolean verifyServerCertHostname;
+    private LinkedList<GenericRule> hostnameVerificationBypassList;
     private boolean javaxDebug;
     private boolean enabled;
 
@@ -51,6 +55,8 @@ public class SslInspectorSettings implements Serializable, JSONString
         processEncryptedWebTraffic = true;
         blockInvalidTraffic = false;
         serverBlindTrust = false;
+        verifyServerCertHostname = true;
+        hostnameVerificationBypassList = new LinkedList<>();
         javaxDebug = false;
         enabled = true;
 
@@ -103,6 +109,12 @@ public class SslInspectorSettings implements Serializable, JSONString
 
     public boolean getServerBlindTrust() { return (serverBlindTrust); }
     public void setServerBlindTrust(boolean flag) { this.serverBlindTrust = flag; }
+
+    public boolean getVerifyServerCertHostname() { return (verifyServerCertHostname); }
+    public void setVerifyServerCertHostname(boolean flag) { this.verifyServerCertHostname = flag; }
+
+    public LinkedList<GenericRule> getHostnameVerificationBypassList() { return (hostnameVerificationBypassList); }
+    public void setHostnameVerificationBypassList(LinkedList<GenericRule> list) { this.hostnameVerificationBypassList = list; }
 
     public boolean getJavaxDebug() { return (javaxDebug); }
     public void setJavaxDebug(boolean flag) { this.javaxDebug = flag; }


### PR DESCRIPTION
## Summary

Add server certificate hostname verification to the SSL Inspector's upstream TLS connections (UNT-33). Previously, the SSL Inspector validated only the certificate chain (trusted CA) but never checked whether the certificate's CN/SAN matched the requested hostname — allowing an on-path attacker with any valid CA-signed certificate to silently intercept all inspected HTTPS traffic. Also removes the hardcoded port 25 SMTP `trust_all_certificates` bypass.

## Motivation

**Mythos Finding UNT-33:** The SSL Inspector's `initializeServerEngine()` never called `setEndpointIdentificationAlgorithm("HTTPS")`, so Java's TLS engine accepted any upstream certificate signed by a trusted CA regardless of hostname. An on-path attacker could present a valid cert for `evil.com` while intercepting `bank.com` and the NGFW would accept it, generating a trusted MitM cert for the browser. Additionally, port 25 SMTP was hardcoded to use `trust_all_certificates`, bypassing all certificate validation.

## Changes

### Core Fix — `SslInspectorManager.java`
- Enable hostname verification via `setEndpointIdentificationAlgorithm("HTTPS")` in `initializeServerEngine()`, gated on: blind trust off, SNI available, not a broken server, and not in the bypass list
- Remove hardcoded `|| (session.getServerPort() == 25)` from the blind trust condition — SMTP now uses real CA trust store

### Settings Model — `SslInspectorSettings.java`
- Add `verifyServerCertHostname` (boolean, default `true`) and `hostnameVerificationBypassList` (`LinkedList<GenericRule>`) fields
- Settings version bump from 3 → 4 with migration in `preInit()`

### Global Settings & Bypass Logic — `SslInspectorApp.java`
- Add `isHostnameVerificationBypassed()` method using `GlobMatcher` for wildcard hostname matching
- Add global settings support following the Web Filter pattern: `getGlobalSettings()`, `setGlobalSettings()`, `loadAllGlobalSettings()`, `syncAllInstances()`, `updateGlobalList()`
- Global bypass entries (`isGlobal=true`) are stored in a shared `globalSettings.js` file and merged into all SSL Inspector instances across policy racks

### Reporting — `SslInspectorParserEventHandler.java`
- Append `" | Hostname Verification Bypassed"` to the `ssl_inspector_detail` column for INSPECTED sessions where verification was skipped via the bypass list or global disable
- No new DB columns — bypass status is encoded in the existing detail field

### UI — Configuration Page
- **`Configuration.js`**: Add "Server Certificate Hostname Verification" fieldset with "Enforce Hostname Match" checkbox and a Hostname Verification Bypass List grid (hostname, bypass toggle, global flag, description columns)
- Fieldset disabled when "Trust All Server Certificates" is checked; grid disabled when "Enforce Hostname Match" is unchecked
- Input validation via `hostnameOrIpValidator` — accepts hostnames, IPv4/IPv6, and wildcard patterns (`*.domain.com`)
- **`Main.js`**: Add `hostnameBypassList` ViewModel store and `isAddAction` flag
- **`MainController.js`**: Add `HostnameBypassGridController` for Global checkbox toggle behavior

### Tests — `test_ssl_inspector.py`
- Add 7 new tests (`test_100` through `test_106`):
  - `test_100`: Default settings — verification enabled, no bypass pipe in detail
  - `test_101`: Bypass list entry — detail shows `| Hostname Verification Bypassed`
  - `test_102`: Global disable — detail shows bypass pipe
  - `test_103`: Blind trust — no bypass pipe (separate concern)
  - `test_104`: Wildcard bypass — glob matching works
  - `test_105`: Disabled bypass entry — no bypass pipe
  - `test_106`: Global bypass propagation — `isGlobal=true` entries propagate to second SSL Inspector instance in a separate policy rack
- Add helper functions: `createHostnameBypassRule()`, `addHostnameBypassEntry()`, `clearHostnameBypassList()`, `getHostnameBypassList()`
- Add class-level setup for `policy-manager` + second rack + second SSL Inspector instance

## Testing

1. **Normal HTTPS browsing** — verify no regression, sites with valid certs work normally
2. **Hostname mismatch attack** — simulate with mitmproxy presenting a wrong-domain cert; verify session becomes UNTRUSTED
3. **Bypass list** — add hostname to bypass list, verify INSPECTED with `| Hostname Verification Bypassed` in detail
4. **Global disable** — uncheck "Enforce Hostname Match", verify all sessions show bypass pipe
5. **Blind trust** — enable "Trust All Server Certificates", verify hostname verification section is disabled in UI
6. **Global bypass propagation** — add `isGlobal=true` entry in one policy, verify it appears in SSL Inspector on another policy rack
7. **SMTP (port 25)** — verify SMTP to servers with self-signed certs is now rejected (previously silently accepted)
8. **Automated tests** — run `pytest -xvs test_ssl_inspector.py -k "test_10"` for hostname verification tests


## Breaking Changes

**Will be addressed in Release Notes**
- **Port 25 SMTP**: Connections to mail servers with self-signed or expired certificates will now be rejected (previously silently accepted). Admins must add IGNORE rules for mail servers with invalid certificates.
- **Hostname mismatch**: Upstream servers presenting certificates for the wrong hostname will now be rejected as UNTRUSTED. Admins can add specific hostnames to the bypass list if needed.

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
