### PR TITLE
NGFW-15887 Migrated cross-cutting exec() calls and hardened ExecManager filterd

### DIFF
--- a/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
+++ b/ipsec-vpn/src/com/untangle/app/ipsec_vpn/IpsecVpnApp.java
@@ -447,9 +447,23 @@ public class IpsecVpnApp extends AppBase
     private void waitForCharonStart() {
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
         Runnable task = () -> {
-            String processes = IpsecVpnApp.execManager().execOutput("ps aux | grep charon");
-            logger.debug("ps aux | grep charon : {}", processes);
-            if (processes.contains(CHARON_DAEMON_PATH)) {
+            // NGFW-15855: argv form via pgrep -f avoids the shell pipe from
+            // "ps aux | grep charon". Semantically equivalent: pgrep -f matches
+            // any process whose full command line contains CHARON_DAEMON_PATH,
+            // which is exactly what the OLD contains(CHARON_DAEMON_PATH) test
+            // did on ps-aux output.
+            //
+            // NOTE: pgrep -f treats PATTERN as a POSIX extended regex, NOT a
+            // literal string. CHARON_DAEMON_PATH has no regex metacharacters
+            // today (. [ ] ( ) + ? * | ^ $ \), so regex-matching behaves
+            // identically to literal substring matching. If the constant is
+            // ever changed to include a regex metacharacter, revisit this call
+            // to preserve the OLD literal-substring semantics.
+            int rc = IpsecVpnApp.execManager()
+                .execCommand("/usr/bin/pgrep", List.of("-f", CHARON_DAEMON_PATH))
+                .getResult();
+            logger.debug("pgrep -f {} : exit={}", CHARON_DAEMON_PATH, rc);
+            if (rc == 0) {
                 scheduler.shutdown();
             }
         };

--- a/uvm/api/com/untangle/uvm/ExecManager.java
+++ b/uvm/api/com/untangle/uvm/ExecManager.java
@@ -95,7 +95,29 @@ public interface ExecManager
      * Called "execEvil" because it calls fork which can cause issues
      */
     Process execEvilProcess(String cmd[]);
-    
+
+    /**
+     * Fire-and-forget process launch with stdout/stderr redirected to /dev/null
+     * and SIGHUP ignored by the child, so the spawned process survives when
+     * the JVM exits. Behaviorally equivalent to shell
+     * "nohup CMD &gt;/dev/null 2&gt;&amp;1 &amp;" without invoking a shell.
+     *
+     * Differs from execEvilProcess() which uses Runtime.exec() and leaves the
+     * child's stdout/stderr connected as pipes into the JVM.
+     *
+     * Internally prepends /usr/bin/nohup to the argv so the child inherits
+     * SIG_IGN for SIGHUP. Required because the UVM JVM is started under
+     * start-stop-daemon --background, which makes it a session leader; when
+     * the JVM exits, the kernel sends SIGHUP to every process in its session.
+     * Without nohup the spawned child would die on JVM exit, matching the
+     * OLD shell "nohup ... &amp;" semantics.
+     *
+     * @param cmd
+     *        argv array (element 0 is the executable, rest are its arguments)
+     * @return the spawned Process, or null if launch failed
+     */
+    Process execEvilProcessDetached(String cmd[]);
+
     /**
      * Close this instance of exec manager
      * This shuts down the "launcher" process

--- a/uvm/api/com/untangle/uvm/WebBrowser.java
+++ b/uvm/api/com/untangle/uvm/WebBrowser.java
@@ -107,7 +107,15 @@ public class WebBrowser
 
         try{
             UvmContextFactory.context().execManager().exec("pkill -f \"" + this.xCommand+ "\"");
-            UvmContextFactory.context().execManager().execOutput("nohup " + this.xCommand + " >/dev/null 2>&1 &");
+            // NGFW-15855: replaced shell "nohup ... >/dev/null 2>&1 &" with
+            // execEvilProcessDetached. Redirect.DISCARD attaches /dev/null at
+            // the OS fd layer (equivalent to >/dev/null 2>&1), so Xvfb won't
+            // get SIGPIPE when the JVM exits. start() returns immediately
+            // (equivalent to trailing &). nohup is a no-op here because the
+            // JVM child has no controlling terminal.
+            // xCommand is built from fixed tokens (Xvfb, :N, -screen, S, WxHxD)
+            // with no embedded spaces, so split("\\s+") is safe.
+            UvmContextFactory.context().execManager().execEvilProcessDetached(this.xCommand.split("\\s+"));
 
             ChromeDriverService service = new ChromeDriverService.Builder()
                 .usingDriverExecutable(new File(chromeDriver))

--- a/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ConfigManagerImpl.java
@@ -307,7 +307,13 @@ public class ConfigManagerImpl implements ConfigManager
             @Override
             public void run()
             {
-                context.execManager().exec("nohup " + FACTORY_RESET_SCRIPT + " force-reboot >/dev/null 2>&1 &");
+                // NGFW-15855: replaced shell "nohup ... >/dev/null 2>&1 &" with
+                // execEvilProcessDetached. Redirect.DISCARD attaches /dev/null at
+                // the OS fd layer so the script's later echoes (running AFTER
+                // systemctl stop untangle-vm kills the JVM) do not hit a broken
+                // pipe. start() returns immediately (equivalent to trailing &);
+                // no controlling terminal on a Timer thread so nohup is a no-op.
+                context.execManager().execEvilProcessDetached(new String[]{FACTORY_RESET_SCRIPT, "force-reboot"});
             }
         }, 1000);
 

--- a/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/ExecManagerImpl.java
@@ -42,6 +42,23 @@ public class ExecManagerImpl implements ExecManager
 {
     private final Logger logger = LogManager.getLogger(getClass());
 
+    /**
+     * Shell metacharacters that make exec(String) unsafe. Any command containing
+     * one of these is refused by the filter (see exec(cmd, rateLimit, safe, ...)).
+     *
+     * NGFW-15855 / UNT-50: the filter is a defense-in-depth backstop; the real
+     * defense is migrating callers to execCommand(exe, argsList) argv form per
+     * ngfw-rce-architecture.md L3. Do NOT introduce new exec(String) callers
+     * whose command string embeds user-controlled input.
+     *
+     * "||" is functionally redundant with "|" for substring matching (any
+     * string containing "||" also contains "|"), kept in the list for source
+     * clarity and to match the T-18 canonical metachar set.
+     */
+    private static final String[] SUSPICIOUS_METAS = {
+        ";", "&&", "||", "|", ">", "<", "$(", "`"
+    };
+
     private JSONSerializer serializer = null;
 
     private Process proc = null;
@@ -159,8 +176,24 @@ public class ExecManagerImpl implements ExecManager
     }
 
     /**
+     * Returns true if cmd contains any shell metacharacter that would make
+     * exec(String) unsafe. See SUSPICIOUS_METAS for the current list.
+     *
+     * @param cmd
+     *        The command string to inspect
+     * @return true if any metacharacter in SUSPICIOUS_METAS is a substring of cmd
+     */
+    private static boolean containsSuspicious(String cmd)
+    {
+        for (String meta : SUSPICIOUS_METAS) {
+            if (cmd.contains(meta)) return true;
+        }
+        return false;
+    }
+
+    /**
      * Executes a command and returns the result object
-     * 
+     *
      * @param cmd
      *        The String command to execute and optionally the rate limit flag
      * @return The execution result object
@@ -219,13 +252,19 @@ public class ExecManagerImpl implements ExecManager
         cmd = cmd.replace("\n", "");
         cmd = cmd.replace("\r", "");
 
-        if (cmd.contains(";") || cmd.contains("&&") || cmd.contains("|") || cmd.contains(">") || cmd.contains("$(")) {
-            if(safe){
-                logger.log(this.level, "Suspicious command (" + cmd + "), blocked");
-                return new ExecManagerResult();
-            }else{
-                logger.log(this.level, "Suspicious command (" + cmd + "), allowing");
+        // NGFW-15855 / UNT-50: always block on suspicious metacharacters, regardless
+        // of the `safe` flag. Previously safe=false (the default for exec/execOutput/
+        // execResult) logged and continued, providing zero protection. The `safe`
+        // flag now only controls log severity so the two paths can be triaged
+        // separately during the ongoing migration to execCommand(exe, argsList).
+        // See ngfw-rce-architecture.md L3.
+        if (containsSuspicious(cmd)) {
+            if (safe) {
+                logger.warn("Refusing suspicious command: " + cmd);
+            } else {
+                logger.error("Refusing suspicious command (caller must migrate to execCommand(exe, args) or fix template): " + cmd);
             }
+            return new ExecManagerResult(-1, "");
         }
 
         try {
@@ -502,7 +541,7 @@ public class ExecManagerImpl implements ExecManager
 
     /**
      * Execute a command in a new process and return the process
-     * 
+     *
      * @param cmd
      *        The command to execute
      * @return The process
@@ -516,6 +555,56 @@ public class ExecManagerImpl implements ExecManager
         }
 
         return execEvilProcess(cmdArray);
+    }
+
+    /**
+     * Fire-and-forget process launch with stdout/stderr redirected to /dev/null
+     * at the OS file-descriptor layer, and SIGHUP ignored by the child.
+     * Behaviorally equivalent to shell "nohup CMD &gt;/dev/null 2&gt;&amp;1 &amp;"
+     * without invoking a shell.
+     *
+     * Differs from execEvilProcess() which uses Runtime.exec() and leaves the
+     * child's stdout/stderr connected as pipes into the JVM. Those pipes break
+     * when the JVM exits, delivering SIGPIPE to the child.
+     *
+     * SIGHUP handling: this method prepends /usr/bin/nohup to the argv so the
+     * child inherits SIG_IGN for SIGHUP via exec. Required because the UVM JVM
+     * is started under start-stop-daemon --background (see
+     * /etc/init.d/untangle-vm), which makes it a session leader. When a session
+     * leader exits, the kernel delivers SIGHUP to every process in its session,
+     * including any children spawned via ProcessBuilder. Without nohup, the
+     * spawned child would die on JVM exit (observed with ut-factory-defaults,
+     * which aborted before reaching `shutdown -r now`). The nohup wrapper
+     * matches the semantics of the OLD shell form "nohup CMD &amp;".
+     *
+     * @param cmd
+     *        The argv array to execute (element 0 is the executable, rest are
+     *        its arguments). No shell involvement.
+     * @return The spawned Process (representing the nohup wrapper, which exec's
+     *         the target), or null if launch failed. Caller typically discards
+     *         the Process reference; the child continues running and reparents
+     *         to init after the JVM exits.
+     */
+    public Process execEvilProcessDetached(String[] cmd)
+    {
+        // NGFW-15855: prepend nohup so the child ignores SIGHUP and survives JVM
+        // (session-leader) exit. See method Javadoc for the full rationale.
+        String[] withNohup = new String[cmd.length + 1];
+        withNohup[0] = "/usr/bin/nohup";
+        System.arraycopy(cmd, 0, withNohup, 1, cmd.length);
+
+        if (logger.isInfoEnabled()) {
+            logger.info("ExecManager.execEvilProcessDetached( " + String.join(" ", withNohup) + " )");
+        }
+        try {
+            return new ProcessBuilder(withNohup)
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start();
+        } catch (IOException e) {
+            logger.warn("Detached process launch failed:", e);
+            return null;
+        }
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/MailSenderImpl.java
+++ b/uvm/impl/com/untangle/uvm/MailSenderImpl.java
@@ -558,12 +558,20 @@ public class MailSenderImpl implements MailSender
              * Substitute the port in the exim template Set it back to 25 in
              * case it was previously configured to something else in smarthost
              */
+            // NGFW-15855: migrated to argv form via execCommand. Note the "\\n"
+            // in the replacement pattern below MUST remain a 2-char literal
+            // (backslash + n) in Java source, so sed receives the 2-char sequence
+            // "\n" in argv and interprets it as a newline in the replacement.
+            // Using Java "\n" (1-char real newline) would terminate sed's `s`
+            // command mid-parse.
             // remove all "  port = xx"
-            String cmd1 = "/bin/sed -e \"/..port.=.[0-9].*$/d\" -i " + EXIM_TEMPLATE_FILE;
-            UvmContextFactory.context().execManager().exec(cmd1);
+            UvmContextFactory.context().execManager().execCommand("/bin/sed", List.of(
+                "-e", "/..port.=.[0-9].*$/d",
+                "-i", EXIM_TEMPLATE_FILE));
             // insert new "  port = xx"
-            String cmd2 = "/bin/sed -e \"s|  driver = smtp|  driver = smtp\\n  port = " + 25 + "|g\" -i " + EXIM_TEMPLATE_FILE;
-            UvmContextFactory.context().execManager().exec(cmd2);
+            UvmContextFactory.context().execManager().execCommand("/bin/sed", List.of(
+                "-e", "s|  driver = smtp|  driver = smtp\\n  port = " + 25 + "|g",
+                "-i", EXIM_TEMPLATE_FILE));
         } else {
             /**
              * Send mail to smarthost
@@ -624,12 +632,15 @@ public class MailSenderImpl implements MailSender
             if (settings.getSendMethod() == MailSettings.SendMethod.CUSTOM) targetPort = settings.getSmtpPort();
             if (settings.getSendMethod() == MailSettings.SendMethod.RELAY) targetPort = STUNNEL_RELAY_PORT;
 
+            // NGFW-15855: same argv migration as the direct-send block above.
             // remove all "  port = xx"
-            String cmd1 = "/bin/sed -e \"/..port.=.[0-9].*$/d\" -i " + EXIM_TEMPLATE_FILE;
-            UvmContextFactory.context().execManager().exec(cmd1);
+            UvmContextFactory.context().execManager().execCommand("/bin/sed", List.of(
+                "-e", "/..port.=.[0-9].*$/d",
+                "-i", EXIM_TEMPLATE_FILE));
             // insert new "  port = xx"
-            String cmd2 = "/bin/sed -e \"s|  driver = smtp|  driver = smtp\\n  port = " + targetPort + "|g\" -i " + EXIM_TEMPLATE_FILE;
-            UvmContextFactory.context().execManager().exec(cmd2);
+            UvmContextFactory.context().execManager().execCommand("/bin/sed", List.of(
+                "-e", "s|  driver = smtp|  driver = smtp\\n  port = " + targetPort + "|g",
+                "-i", EXIM_TEMPLATE_FILE));
         }
 
         this.writeFile(sb, EXIM_CONF_FILE);


### PR DESCRIPTION
**What was wrong**

The ExecManager suspicious-character filter had two problems. First, with safe=false (the default for most callers) it logged the offending command but let it through anyway, providing no real protection. Second, the metacharacter list missed backtick, <, and ||. Separately, five call sites still passed shell-string commands into exec(String), leaving those flows dependent on that leaky filter as their only defense.

**How the fix works**

Two atomic changes shipped together on this branch:

- Filter tightening. Widened the metacharacter list to include backtick, <, and ||. Both the safe=true and safe=false paths now block on any metacharacter (safe=false previously logged-and-allowed). Return type also normalized to (-1, "") so callers that unwrap the result don't hit null fields.

- Migrated five call sites off shell-string exec():
Here is how it is migrated,

- IPsec charon startup check — replaced ps aux | grep charon with a pgrep -f argv call.
- WebBrowser Xvfb launch — replaced nohup Xvfb … & with a new execEvilProcessDetached argv API.
- Factory reset trigger — replaced nohup ut-factory-defaults … & with the same detached API.
- Two MailSender exim SMTP port edits — replaced shell-string sed calls with argv-form sed.

The new ExecManager.execEvilProcessDetached(String[]) method was added to support the WebBrowser and factory-reset flows. It launches a fire-and-forget process with stdout/stderr routed to /dev/null at the OS fd layer, and internally prepends /usr/bin/nohup so the child ignores SIGHUP — required because the UVM JVM is a session leader, and its exit would otherwise kill the child mid-flow. This was particularly critical for factory reset, which needs to keep running past the JVM's own shutdown to reach the reboot line.

What doesn't change

- Every migrated site produces the same observable outcome as before — same files written, same exit codes, same downstream side effects.
- execCommand, execEvilProcess, and other unrelated ExecManager methods are untouched.
- No changes to app UIs or user-facing settings.