### PR TITLE
ngfw-15900 v2 API's for Firewall App

### DIFF
--- a/firewall/src/com/untangle/app/firewall/FirewallApp.java
+++ b/firewall/src/com/untangle/app/firewall/FirewallApp.java
@@ -8,9 +8,11 @@ import java.util.List;
 import java.util.Map;
 import java.net.InetAddress;
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.untangle.app.firewall.generic.FirewallSettingsGeneric;
 import com.untangle.uvm.UvmContextFactory;
 import com.untangle.uvm.SettingsManager;
 import com.untangle.uvm.SessionMatcher;
@@ -163,6 +165,32 @@ public class FirewallApp extends AppBase
         try {logger.debug("New Settings: \n" + new org.json.JSONObject(this.settings).toString(2));} catch (Exception e) {}
 
         this.reconfigure();
+    }
+
+    /**
+     * Get the settings in V2 (generic) format for the Vue UI.
+     *
+     * @return FirewallSettingsGeneric
+     */
+    public FirewallSettingsGeneric getSettingsV2() {
+        if (this.getSettings() != null)
+            return this.getSettings().transformFirewallSettingsToGeneric();
+        return new FirewallSettingsGeneric();
+    }
+
+    /**
+     * Set the settings from a V2 (generic) format payload coming from the Vue UI.
+     * Deep-clones the current V1 settings so V1-only fields (version) are preserved.
+     *
+     * @param newSettings FirewallSettingsGeneric
+     */
+    public void setSettingsV2(FirewallSettingsGeneric newSettings)
+    {
+        if (this.getSettings() != null) {
+            FirewallSettings cloned = SerializationUtils.clone(this.getSettings());
+            newSettings.transformGenericToFirewallSettings(cloned);
+            this.setSettings(cloned);
+        }
     }
 
     /**

--- a/firewall/src/com/untangle/app/firewall/FirewallRule.java
+++ b/firewall/src/com/untangle/app/firewall/FirewallRule.java
@@ -3,7 +3,11 @@
  */
 package com.untangle.app.firewall;
 
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.io.Serializable;
 import java.net.InetAddress;
 
@@ -12,6 +16,11 @@ import org.json.JSONString;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.untangle.uvm.generic.RuleActionGeneric;
+import com.untangle.uvm.generic.RuleConditionGeneric;
+import com.untangle.uvm.generic.RuleGeneric;
+import com.untangle.uvm.util.Constants;
+import com.untangle.uvm.util.StringUtil;
 import com.untangle.uvm.vnet.SessionAttachments;
 
 /**
@@ -102,6 +111,110 @@ public class FirewallRule implements JSONString, Serializable
          */
         return true;
     }
-    
+
+    /**
+     * Transforms a list of FirewallRule into the generic RuleGeneric form for
+     * the V2 API. Used by getSettingsV2().
+     *
+     * @param v1Rules list of V1 FirewallRule objects
+     * @return LinkedList of RuleGeneric
+     */
+    public static LinkedList<RuleGeneric> transformFirewallRulesToGeneric(List<FirewallRule> v1Rules)
+    {
+        LinkedList<RuleGeneric> out = new LinkedList<>();
+        if (v1Rules == null) return out;
+        for (FirewallRule rule : v1Rules) {
+            out.add(toGeneric(rule));
+        }
+        return out;
+    }
+
+    /**
+     * Transforms a single FirewallRule into its RuleGeneric representation.
+     */
+    private static RuleGeneric toGeneric(FirewallRule v1)
+    {
+        String ruleId = String.valueOf(v1.getRuleId());
+
+        RuleActionGeneric action = new RuleActionGeneric();
+        action.setType(Boolean.TRUE.equals(v1.getBlock()) ? RuleActionGeneric.Type.REJECT : RuleActionGeneric.Type.ACCEPT);
+        action.setFlagged(v1.getFlag());
+
+        LinkedList<RuleConditionGeneric> conds = new LinkedList<>();
+        if (v1.getConditions() != null) {
+            for (FirewallRuleCondition c : v1.getConditions()) {
+                String op = Boolean.TRUE.equals(c.getInvert())
+                        ? Constants.IS_NOT_EQUALS_TO
+                        : Constants.IS_EQUALS_TO;
+                conds.add(new RuleConditionGeneric(op, c.getConditionType(), c.getValue()));
+            }
+        }
+
+        RuleGeneric g = new RuleGeneric(Boolean.TRUE.equals(v1.getEnabled()), v1.getDescription(), ruleId);
+        g.setAction(action);
+        g.setConditions(conds);
+        return g;
+    }
+
+    /**
+     * Transforms a list of generic RuleGeneric into V1 FirewallRule, preserving
+     * existing V1 rule objects (matched by ruleId) and removing orphaned rules.
+     * Used by setSettingsV2().
+     *
+     * @param genRules    list of V2 RuleGeneric objects from the UI
+     * @param legacyRules current V1 FirewallRule list (to preserve internal state
+     *                    on update and detect deletions)
+     * @return list of updated/preserved V1 FirewallRule objects
+     */
+    public static List<FirewallRule> transformGenericToFirewallRules(
+            LinkedList<RuleGeneric> genRules, List<FirewallRule> legacyRules)
+    {
+        if (legacyRules == null) legacyRules = new LinkedList<>();
+
+        RuleGeneric.deleteOrphanRules(
+                genRules, legacyRules,
+                RuleGeneric::getRuleId,
+                r -> String.valueOf(r.getRuleId()));
+
+        Map<Integer, FirewallRule> rulesMap = legacyRules.stream()
+                .collect(Collectors.toMap(FirewallRule::getRuleId, Function.identity()));
+
+        List<FirewallRule> out = new LinkedList<>();
+        for (RuleGeneric g : genRules) {
+            FirewallRule existing = rulesMap.get(StringUtil.getInstance().parseInt(g.getRuleId(), 0));
+            out.add(toLegacy(g, existing));
+        }
+        return out;
+    }
+
+    /**
+     * Transforms a single RuleGeneric back into a V1 FirewallRule, mutating the
+     * passed-in existing rule (or creating a new one if null).
+     */
+    private static FirewallRule toLegacy(RuleGeneric g, FirewallRule existing)
+    {
+        if (existing == null) existing = new FirewallRule();
+        existing.setEnabled(g.isEnabled());
+        existing.setDescription(g.getDescription());
+        existing.setRuleId(StringUtil.getInstance().parseInt(g.getRuleId(), -1));
+
+        if (g.getAction() != null) {
+            existing.setBlock(g.getAction().getType() == RuleActionGeneric.Type.REJECT);
+            existing.setFlag(Boolean.TRUE.equals(g.getAction().getFlagged()));
+        }
+
+        List<FirewallRuleCondition> conds = new LinkedList<>();
+        if (g.getConditions() != null) {
+            for (RuleConditionGeneric gc : g.getConditions()) {
+                FirewallRuleCondition c = new FirewallRuleCondition();
+                c.setInvert(Constants.IS_NOT_EQUALS_TO.equals(gc.getOp()));
+                c.setConditionType(gc.getType());
+                c.setValue(gc.getValue());
+                conds.add(c);
+            }
+        }
+        existing.setConditions(conds);
+        return existing;
+    }
 }
 

--- a/firewall/src/com/untangle/app/firewall/FirewallSettings.java
+++ b/firewall/src/com/untangle/app/firewall/FirewallSettings.java
@@ -10,6 +10,8 @@ import java.util.List;
 import org.json.JSONObject;
 import org.json.JSONString;
 
+import com.untangle.app.firewall.generic.FirewallSettingsGeneric;
+
 /**
  * Settings for the Firewall app.
  */
@@ -39,5 +41,18 @@ public class FirewallSettings implements Serializable, JSONString
     {
         JSONObject jO = new JSONObject(this);
         return jO.toString();
+    }
+
+    /**
+     * Transforms this V1 FirewallSettings into the generic V2 representation
+     * for the Vue UI. Used by getSettingsV2().
+     *
+     * @return FirewallSettingsGeneric populated from this V1 object
+     */
+    public FirewallSettingsGeneric transformFirewallSettingsToGeneric()
+    {
+        FirewallSettingsGeneric g = new FirewallSettingsGeneric();
+        g.setFirewall_rules(FirewallRule.transformFirewallRulesToGeneric(this.rules));
+        return g;
     }
 }

--- a/firewall/src/com/untangle/app/firewall/generic/FirewallSettingsGeneric.java
+++ b/firewall/src/com/untangle/app/firewall/generic/FirewallSettingsGeneric.java
@@ -1,0 +1,47 @@
+/**
+ * $Id$
+ */
+package com.untangle.app.firewall.generic;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+
+import org.json.JSONObject;
+import org.json.JSONString;
+
+import com.untangle.app.firewall.FirewallRule;
+import com.untangle.app.firewall.FirewallSettings;
+import com.untangle.uvm.generic.RuleGeneric;
+
+/**
+ * Generic (V2) settings for the Firewall app, consumed by the Vue UI.
+ * Transforms the rules list into the shared RuleGeneric shape.
+ */
+@SuppressWarnings("serial")
+public class FirewallSettingsGeneric implements Serializable, JSONString {
+
+    private LinkedList<RuleGeneric> firewall_rules = new LinkedList<>();
+
+    public String toJSONString() {
+        JSONObject jO = new JSONObject(this);
+        return jO.toString();
+    }
+
+    public LinkedList<RuleGeneric> getFirewall_rules() { return firewall_rules; }
+    public void setFirewall_rules(LinkedList<RuleGeneric> firewall_rules) { this.firewall_rules = firewall_rules; }
+
+    /**
+     * Transforms this V2 generic settings back into a V1 FirewallSettings object.
+     * Mutates the passed-in v1 object in place so that V1-only fields (e.g. version)
+     * are preserved. Used by setSettingsV2().
+     *
+     * @param v1 deep-cloned V1 settings (mutated in place)
+     * @return the same v1 reference, populated from this V2 object
+     */
+    public FirewallSettings transformGenericToFirewallSettings(FirewallSettings v1)
+    {
+        if (v1 == null) v1 = new FirewallSettings();
+        v1.setRules(FirewallRule.transformGenericToFirewallRules(this.firewall_rules, v1.getRules()));
+        return v1;
+    }
+}

--- a/web-filter-base/src/com/untangle/app/web_filter/generic/WebFilterSettingsGeneric.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/generic/WebFilterSettingsGeneric.java
@@ -5,7 +5,6 @@ package com.untangle.app.web_filter.generic;
 
 import java.io.Serializable;
 import java.util.LinkedList;
-import java.util.List;
 
 import com.untangle.app.web_filter.WebFilterRule;
 import com.untangle.app.web_filter.WebFilterSettings;


### PR DESCRIPTION
## Summary

Add V2 API endpoints (`getSettingsV2`, `setSettingsV2`) to the Firewall app, transforming legacy `FirewallSettings`/`FirewallRule` into the shared `RuleGeneric` format consumed by the Vue UI.

## Motivation

Part of the ExtJS → Vue UI migration (NGFW-15900). The Vue frontend expects settings in the normalized `RuleGeneric` shape (with `RuleActionGeneric` and `RuleConditionGeneric`) rather than the legacy per-app rule classes. This change provides the backend bridge so the Vue Firewall UI can read and write rules through the V2 API.

## Changes

### Firewall Rule Transformation (`FirewallRule.java`)
- Added `transformFirewallRulesToGeneric()` — converts V1 rule list to `LinkedList<RuleGeneric>`
- Added `transformGenericToFirewallRules()` — converts V2 rules back to V1 with orphan cleanup via `RuleGeneric.deleteOrphanRules()`

### Firewall Settings V1→V2 (`FirewallSettings.java`)
- Added `transformFirewallSettingsToGeneric()` — delegates rule list transformation and returns `FirewallSettingsGeneric`

### Firewall Settings V2→V1 (`FirewallSettingsGeneric.java`)
- Added `transformGenericToFirewallSettings()` — mutates a cloned V1 settings object in place, preserving V1-only fields like `version`

### V2 API Endpoints (`FirewallApp.java`)
- Replaced stub `getSettingsV2()` (which returned raw V1 settings) with proper implementation returning `FirewallSettingsGeneric`
- Added `setSettingsV2(FirewallSettingsGeneric)` — deep-clones current V1 settings via `SerializationUtils.clone()`, applies V2 data, and saves through the existing `setSettings()` path


## Testing

1. Deploy the updated Firewall app
2. Call `getSettingsV2()` via JSON-RPC and verify the response contains `firewall_rules` with `RuleGeneric` objects where:
   - `action.type` is `REJECT` for blocked rules, `ACCEPT` for passed rules
   - `action.flagged` matches the rule's flag value
   - `conditions` use `op: "=="` / `op: "!="` instead of boolean `invert`
   - `ruleId` is a string
3. Call `setSettingsV2()` with modified rules and verify:
   - Round-trip preserves all field values (`getSettings()` returns correct V1 data)
   - `version` field is preserved (not lost during V2 round-trip)
   - Deleting a rule in V2 payload removes it from V1 (orphan cleanup)
   - Adding a new rule with a UUID string `ruleId` succeeds (backend assigns integer ID on save)

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
