### PR TITLE
NGFW-15913: detect trixie upgrade from apt Release metadata

### DIFF
--- a/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
+++ b/uvm/hier/usr/share/untangle/bin/ut-upgrade.py
@@ -380,39 +380,56 @@ def post_upgrade_fixups():
 
 def is_trixie_upgrade():
     """
-    Detect if apt sources point to trixie while the system is still on
-    bookworm kernel (6.1.x) — or just rebooted into trixie kernel (6.12.x)
-    with post-upgrade fixups not yet completed.
+    Detect if the apt repository serves trixie packages while the system
+    is still on a pre-trixie kernel — or just rebooted into trixie kernel
+    (6.12.x) with post-upgrade fixups not yet completed.
+    Detection checks both apt Release metadata (supports server-side Apache
+    rewrites) and apt sources content (supports direct source changes).
     Returns True only when the upgrade target is trixie and fixups are needed.
     """
-    sources_have_trixie = False
-    sources_dirs = ["/etc/apt/sources.list.d/"]
-    sources_files = ["/etc/apt/sources.list"]
-    for d in sources_dirs:
-        if os.path.isdir(d):
-            for f in os.listdir(d):
-                fp = os.path.join(d, f)
-                if os.path.isfile(fp):
-                    sources_files.append(fp)
-    for sf in sources_files:
+    import glob
+    repo_has_trixie = False
+
+    for release_file in glob.glob("/var/lib/apt/lists/*Release"):
         try:
-            with open(sf) as fh:
+            with open(release_file) as fh:
                 for line in fh:
-                    if 'trixie' in line and not line.strip().startswith('#'):
-                        sources_have_trixie = True
+                    if line.strip().startswith("Codename:") and "trixie" in line:
+                        repo_has_trixie = True
                         break
         except:
             pass
-        if sources_have_trixie:
+        if repo_has_trixie:
             break
 
-    if not sources_have_trixie:
+    if not repo_has_trixie:
+        sources_dirs = ["/etc/apt/sources.list.d/"]
+        sources_files = ["/etc/apt/sources.list"]
+        for d in sources_dirs:
+            if os.path.isdir(d):
+                for f in os.listdir(d):
+                    fp = os.path.join(d, f)
+                    if os.path.isfile(fp):
+                        sources_files.append(fp)
+        for sf in sources_files:
+            try:
+                with open(sf) as fh:
+                    for line in fh:
+                        if 'trixie' in line and not line.strip().startswith('#'):
+                            repo_has_trixie = True
+                            break
+            except:
+                pass
+            if repo_has_trixie:
+                break
+
+    if not repo_has_trixie:
         return False
 
-    # Pre-reboot: bookworm 6.1.x kernel still running, dist-upgrade needed
+    # Pre-reboot: pre-trixie kernel still running, dist-upgrade needed
     running_kernel = platform.release()
     if running_kernel.startswith("6.1.") or running_kernel.startswith("5.") or running_kernel.startswith("4."):
-        log("Trixie upgrade detected: sources point to trixie, running kernel %s" % running_kernel)
+        log("Trixie upgrade detected: repo serves trixie, running kernel %s" % running_kernel)
         return True
 
     # Post-reboot: trixie 6.12.x kernel active, check whether fixups already ran


### PR DESCRIPTION
is_trixie_upgrade() previously scanned sources.list files for the string 'trixie'. This broke the production upgrade flow where server-side Apache rewrites serve trixie packages while the appliance sources still reference bullseye.

Check apt Release files in /var/lib/apt/lists/ for Codename: trixie first (populated by apt-get update which runs before detection), falling back to sources file scan for direct source changes.

Zero behavioral change for normal bullseye-to-bullseye point upgrades — detection returns False when no trixie codename is present in either Release files or sources.