### PR TITLE
NGFW-15830 WebFilter filter flag is now in conjunction with global blocked sites

### DIFF
--- a/web-filter-base/src/com/untangle/app/web_filter/WebFilterBase.java
+++ b/web-filter-base/src/com/untangle/app/web_filter/WebFilterBase.java
@@ -1207,13 +1207,11 @@ public abstract class WebFilterBase extends AppBase implements WebFilter
      */
     protected void _setSettings(WebFilterSettings newSettings)
     {
-        //Move and save all the global settings to globalSettings file
-        if(this.isWebFilterApp){
-            setGlobalSettings(newSettings);
-        }  
         /**
          * Prepare settings for saving This makes sure certain things are always
-         * true, such as flagged == true if blocked == true
+         * true, such as flagged == true if blocked == true.
+         * Must run before setGlobalSettings so global rules are normalized
+         * before they are split out into globalSettings.js.
          */
         if (newSettings.getCategories() != null) {
             for (GenericRule rule : newSettings.getCategories()) {
@@ -1231,6 +1229,11 @@ public abstract class WebFilterBase extends AppBase implements WebFilter
                 rule.setRuleId(++index);
                 if (rule.getBlocked()) rule.setFlagged(Boolean.TRUE);
             }
+        }
+
+        //Move and save all the global settings to globalSettings file
+        if(this.isWebFilterApp){
+            setGlobalSettings(newSettings);
         }
 
         /**


### PR DESCRIPTION
The three normalization loops in _setSettings (categories, blockedUrls, filterRules) now run BEFORE setGlobalSettings(newSettings) instead of after. Global rules get their flagged field corrected in place before updateUrls splits them out into globalSettings.js, so the persisted file — and the in-memory settings the UI reads back via loadAllGlobalSettings/syncAllInstances — both see the correct flagged=true. This is a pure reorder of an existing normalization block; no logic added or removed. As a nice side benefit, users can no longer accidentally UN-flag an already-flagged global blocked rule by submitting flagged=false — the same normalization runs first and preserves the invariant.