### PR TITLE
ngfw-15303 / ngfw-15904 : UNT-05,UNT-28 Harden Reports SQL injection defenses and add ATS regression tests

### DIFF
--- a/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
+++ b/reports/hier/usr/lib/python3/dist-packages/tests/test_reports.py
@@ -1635,6 +1635,143 @@ class ReportsTests(NGFWTestCase):
         assert "ReportsContextImpl" not in java_class, \
             f"Admin should receive unrestricted base singleton, not proxy: {java_class}"
 
+    def test_200_regression_shipped_reports_all_types(self):
+        """
+        UNT-05 regression: verify that shipped (server-side) reports of every type
+        can still be queried after the SQL-injection hardening changes.
+        Iterates TEXT, PIE_GRAPH, TIME_GRAPH, TIME_GRAPH_DYNAMIC, EVENT_LIST.
+        """
+        reports_manager = global_functions.uvmContext.appManager().app("reports").getReportsManager()
+        all_entries = reports_manager.getReportEntries()
+        entries = all_entries.get("list", []) if isinstance(all_entries, dict) else all_entries
+
+        by_type = {}
+        for e in entries:
+            if isinstance(e, dict):
+                t = e.get("type", "UNKNOWN")
+                by_type.setdefault(t, []).append(e)
+
+        tested = []
+        for typ in ["TEXT", "PIE_GRAPH", "TIME_GRAPH", "TIME_GRAPH_DYNAMIC", "EVENT_LIST"]:
+            assert typ in by_type, f"No shipped report of type {typ} found"
+            entry = by_type[typ][0]
+            if typ == "EVENT_LIST":
+                result = reports_manager.getEventsResultSet(entry, [], 5)
+            else:
+                result = reports_manager.getDataForReportEntry(entry, None, None, None, [], None, 5)
+            assert result is not None, f"Query returned None for shipped {typ} report: {entry.get('title', '?')}"
+            tested.append(typ)
+        assert len(tested) == 5, f"Expected 5 report types tested, got {len(tested)}"
+
+    def test_201_regression_conditions_filter_types(self):
+        """
+        UNT-05 regression: verify common condition operators (=, IS NULL, IN, BETWEEN, LIKE)
+        work correctly after the new validateConditions() checks.
+        """
+        reports_manager = global_functions.uvmContext.appManager().app("reports").getReportsManager()
+        all_entries = reports_manager.getReportEntries()
+        entries = all_entries.get("list", []) if isinstance(all_entries, dict) else all_entries
+        text_entry = None
+        for e in entries:
+            if isinstance(e, dict) and e.get("type") == "TEXT" and e.get("uniqueId"):
+                text_entry = e
+                break
+        assert text_entry is not None, "No TEXT report found for condition tests"
+
+        condition_sets = {
+            "equality": [{"javaClass": "com.untangle.app.reports.SqlCondition",
+                          "column": "hostname", "operator": "=", "value": "test.example.com"}],
+            "is_null":  [{"javaClass": "com.untangle.app.reports.SqlCondition",
+                          "column": "hostname", "operator": "is", "value": "null"}],
+            "in_list":  [{"javaClass": "com.untangle.app.reports.SqlCondition",
+                          "column": "hostname", "operator": "in", "value": "('host1','host2')"}],
+            "between":  [{"javaClass": "com.untangle.app.reports.SqlCondition",
+                          "column": "c2p_bytes", "operator": "between", "value": "100 and 5000"}],
+            "like":     [{"javaClass": "com.untangle.app.reports.SqlCondition",
+                          "column": "hostname", "operator": "like", "value": "%example%"}],
+        }
+        for label, conds in condition_sets.items():
+            result = reports_manager.getDataForReportEntry(text_entry, None, None, None, conds, None, 1)
+            assert result is not None, f"Condition filter '{label}' returned None"
+
+    def test_210_unt05_sqli_pg_read_file_blocked(self):
+        """
+        UNT-05 security: pg_read_file() injection via textColumns must be blocked
+        by the denylist (Layer 1) for both admin and reports-only paths.
+        """
+        reports_manager = global_functions.uvmContext.appManager().app("reports").getReportsManager()
+        malicious_entry = {
+            "javaClass": "com.untangle.app.reports.ReportEntry",
+            "type": "TEXT", "table": "sessions",
+            "textColumns": ["pg_read_file('/etc/passwd') as a"],
+        }
+        exception_caught = False
+        try:
+            reports_manager.getDataForReportEntry(malicious_entry, None, None, None, [], None, 1)
+        except Exception:
+            exception_caught = True
+        assert exception_caught, "pg_read_file() in textColumns was NOT blocked"
+
+    def test_211_unt05_sqli_reports_realm_resolveEntry(self):
+        """
+        UNT-05 security: reports-only realm must resolve entries server-side,
+        rejecting fabricated uniqueIds with malicious textColumns.
+        """
+        original_settings = self._app.getSettings()
+        settings = copy.deepcopy(original_settings)
+        settings["reportsUsers"]["list"] = settings["reportsUsers"]["list"][:1]
+        test_email = global_functions.random_email()
+        settings["reportsUsers"]["list"].append(create_reports_user(profile_email=test_email, access=True))
+        self._app.setSettings(settings)
+
+        s, rpc_url, nonce, oid, java_class = reports_realm_rpc_login(test_email, "passwd")
+
+        malicious_params = [
+            {
+                "javaClass": "com.untangle.app.reports.ReportEntry",
+                "uniqueId": "fabricated-nonexistent-id",
+                "type": "TEXT", "table": "sessions",
+                "textColumns": ["pg_read_file('/etc/passwd') as a"],
+            },
+            None, None, None, [], None, 1,
+        ]
+        r = s.post(rpc_url, json={
+            "id": 99, "nonce": nonce,
+            "method": f".obj#{oid}.getDataForReportEntry",
+            "params": malicious_params,
+        }, verify=False)
+        resp = json.loads(r.text)
+        self._app.setSettings(original_settings)
+
+        has_error = "error" in resp and resp["error"]
+        result = resp.get("result")
+        is_exception = isinstance(result, dict) and "Exception" in result.get("javaClass", "")
+        assert has_error or is_exception, \
+            f"Fabricated uniqueId with pg_read_file() was NOT blocked: {str(resp)[:300]}"
+
+    def test_212_unt28_dollar_quoting_blocked(self):
+        """
+        UNT-28 security: PostgreSQL dollar-quoting ($$ and $tag$) bypass must be
+        blocked by the denylist patterns added to ReportEntry.Injections.
+        """
+        reports_manager = global_functions.uvmContext.appManager().app("reports").getReportsManager()
+        payloads = [
+            ["pg_read_file($$/etc/passwd$$) as a"],
+            ["pg_read_file($tag$/etc/passwd$tag$) as a"],
+        ]
+        for payload in payloads:
+            entry = {
+                "javaClass": "com.untangle.app.reports.ReportEntry",
+                "type": "TEXT", "table": "sessions",
+                "textColumns": payload,
+            }
+            exception_caught = False
+            try:
+                reports_manager.getDataForReportEntry(entry, None, None, None, [], None, 1)
+            except Exception:
+                exception_caught = True
+            assert exception_caught, f"Dollar-quoting bypass was NOT blocked for: {payload[0]}"
+
     # tests for each report type:
     #    case EVENT_LIST:
 

--- a/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/ReportsContextImpl.java
+++ b/reports/servlets/reports/src/com/untangle/uvm/reports/jabsorb/ReportsContextImpl.java
@@ -5,7 +5,9 @@ package com.untangle.uvm.reports.jabsorb;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.TimeZone;
 import java.util.List;
 import java.util.Map;
@@ -13,10 +15,14 @@ import java.util.Map;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.json.JSONObject;
 
 import com.untangle.app.reports.ReportEntry;
 import com.untangle.app.reports.ReportsApp;
 import com.untangle.app.reports.ReportsManager;
+import com.untangle.app.reports.ResultSetReader;
+import com.untangle.app.reports.SqlCondition;
+import com.untangle.app.reports.SqlFrom;
 import com.untangle.uvm.LanguageManager;
 import com.untangle.uvm.LanguageSettings;
 import com.untangle.uvm.LocaleInfo;
@@ -236,17 +242,142 @@ public class ReportsContextImpl implements UtJsonRpcServlet.ReportsContext
 
     /**
      * This class is used extend ReportsManagerImpl and overwrite some methods that changes settings so reports servlet does not have access to them.
+     * Query methods resolve client-provided entries against server-side definitions to prevent
+     * injection of malicious entry fields (pieGroupColumn, conditions, etc.)
      */
     public class ReportsManagerImpl extends com.untangle.app.reports.ReportsManagerImpl
     {
         /**
-         * Set report entries.
+         * Resolve a client-provided report entry against server-side definitions.
          *
-         * @param newEntries
-         *  New report entries.
+         * @param clientEntry the entry provided by the client.
+         * @return the server-side entry if found, otherwise the original client entry.
+         */
+        private ReportEntry resolveEntry(ReportEntry clientEntry)
+        {
+            if (clientEntry == null) return null;
+            String uniqueId = clientEntry.getUniqueId();
+            if (uniqueId != null && !uniqueId.isEmpty()) {
+                ReportEntry serverEntry = super.getReportEntry(uniqueId);
+                if (serverEntry != null) return serverEntry;
+            }
+            throw new RuntimeException("No server-side report entry found for uniqueId: " + uniqueId);
+        }
+
+        /**
+         * Get report data for the given entry and date range with extra options.
+         *
+         * @param entry the report entry.
+         * @param startDate the start date.
+         * @param endDate the end date.
+         * @param extraSelects additional select columns.
+         * @param extraConditions additional SQL conditions.
+         * @param fromType the SQL from type.
+         * @param limit maximum number of results.
+         * @return list of JSON result objects.
+         */
+        @Override
+        public List<JSONObject> getDataForReportEntry( ReportEntry entry, final Date startDate, final Date endDate, String[] extraSelects, SqlCondition[] extraConditions, SqlFrom fromType, final int limit )
+        {
+            return super.getDataForReportEntry(resolveEntry(entry), startDate, endDate, null, extraConditions, fromType, limit);
+        }
+
+        /**
+         * Get report data for the given entry and date range.
+         *
+         * @param entry the report entry.
+         * @param startDate the start date.
+         * @param endDate the end date.
+         * @param limit maximum number of results.
+         * @return list of JSON result objects.
+         */
+        @Override
+        public List<JSONObject> getDataForReportEntry( ReportEntry entry, final Date startDate, final Date endDate, final int limit )
+        {
+            return super.getDataForReportEntry(resolveEntry(entry), startDate, endDate, limit);
+        }
+
+        /**
+         * Get report data for the given entry and timeframe.
+         *
+         * @param entry the report entry.
+         * @param timeframeSec the timeframe in seconds.
+         * @param limit maximum number of results.
+         * @return list of JSON result objects.
+         */
+        @Override
+        public List<JSONObject> getDataForReportEntry( ReportEntry entry, final int timeframeSec, final int limit )
+        {
+            return super.getDataForReportEntry(resolveEntry(entry), timeframeSec, limit);
+        }
+
+        /**
+         * Get events for the given report entry.
+         *
+         * @param entry the report entry.
+         * @param extraConditions additional SQL conditions.
+         * @param limit maximum number of results.
+         * @return list of JSON event objects.
+         */
+        @Override
+        public ArrayList<JSONObject> getEvents( final ReportEntry entry, final SqlCondition[] extraConditions, final int limit )
+        {
+            return super.getEvents(resolveEntry(entry), extraConditions, limit);
+        }
+
+        /**
+         * Get an events result set for the given report entry.
+         *
+         * @param entry the report entry.
+         * @param extraConditions additional SQL conditions.
+         * @param limit maximum number of results.
+         * @return the result set reader.
+         */
+        @Override
+        public ResultSetReader getEventsResultSet( final ReportEntry entry, final SqlCondition[] extraConditions, final int limit )
+        {
+            return super.getEventsResultSet(resolveEntry(entry), extraConditions, limit);
+        }
+
+        /**
+         * Get an events result set for the given report entry and timeframe.
+         *
+         * @param entry the report entry.
+         * @param extraConditions additional SQL conditions.
+         * @param timeframeSec the timeframe in seconds.
+         * @param limit maximum number of results.
+         * @return the result set reader.
+         */
+        @Override
+        public ResultSetReader getEventsForTimeframeResultSet( final ReportEntry entry, final SqlCondition[] extraConditions, final int timeframeSec, final int limit )
+        {
+            return super.getEventsForTimeframeResultSet(resolveEntry(entry), extraConditions, timeframeSec, limit);
+        }
+
+        /**
+         * Get an events result set for the given report entry and date range.
+         *
+         * @param entry the report entry.
+         * @param extraConditions additional SQL conditions.
+         * @param limit maximum number of results.
+         * @param startDate the start date.
+         * @param endDate the end date.
+         * @return the result set reader.
+         */
+        @Override
+        public ResultSetReader getEventsForDateRangeResultSet( final ReportEntry entry, final SqlCondition[] extraConditions, final int limit, final Date startDate, final Date endDate )
+        {
+            return super.getEventsForDateRangeResultSet(resolveEntry(entry), extraConditions, limit, startDate, endDate);
+        }
+
+        /**
+         * Set report entries. Not supported in this context.
+         *
+         * @param newEntries the report entries to set.
          */
         @Override
         public void setReportEntries( List<ReportEntry> newEntries ) { throw new RuntimeException("Unable to set the report entries."); }
+
         /**
          * Save report entry.
          *

--- a/reports/src/com/untangle/app/reports/ReportEntry.java
+++ b/reports/src/com/untangle/app/reports/ReportEntry.java
@@ -38,36 +38,49 @@ public class ReportEntry implements Serializable, JSONString
     static {
         Injections = new ArrayList<Pattern>();
         // Semi-colon
-        Injections.add(Pattern.compile(".*;.*"));
+        Injections.add(Pattern.compile(".*;.*", Pattern.DOTALL));
         // Comment (dash)
-        Injections.add(Pattern.compile(".*--.*"));
+        Injections.add(Pattern.compile(".*--.*", Pattern.DOTALL));
         // Comment (slash)
-        Injections.add(Pattern.compile(".*\\/\\*.*"));
+        Injections.add(Pattern.compile(".*\\/\\*.*", Pattern.DOTALL));
         // Unmatched quotes
-        Injections.add(Pattern.compile("^([^\']*?)(\')([^\']*?)$"));
+        Injections.add(Pattern.compile("^([^\']*?)(\')([^\']*?)$", Pattern.DOTALL));
         // UNION
-        Injections.add(Pattern.compile("(?i).*UNION.*"));
-        // Character casting
-        Injections.add(Pattern.compile("(?i).*chr(\\(|%28).*"));
+        Injections.add(Pattern.compile(".*UNION.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        // Character casting (word-boundary to block double-quoted bypass like "chr"(...))
+        Injections.add(Pattern.compile(".*\\bchr\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
         // System catalog access
-        Injections.add(Pattern.compile("(?i).*from\\s+pg_.*"));
+        Injections.add(Pattern.compile(".*from\\s+pg_.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
         // Always true
-        Injections.add(Pattern.compile("(?i).*OR\\s+(['\\w]+)=\\1.*"));
-        // patterns for classical SQL injection 1=1 , 2=2 with ON, OR, AND 
-        Injections.add(Pattern.compile(".*\\bOR\\b.*\\b\\d+=\\d+\\b.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*'\\s*OR\\s*'\\d+'=\\d+\\s*--.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*\\bON\\b\\s*\\d+\\s*=\\s*\\d+.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*\\bAND\\b.*\\b\\d+=\\d+\\b.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*UNION.*SELECT.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*EXEC\\s+.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*INSERT\\s+INTO.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*DROP\\s+TABLE.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*\\bUPDATE\\b.*\\bSET\\b.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*\\bDELETE\\b.*\\bFROM\\b.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*\\bCREATE\\b.*\\bTABLE\\b.*", Pattern.CASE_INSENSITIVE));
-        Injections.add(Pattern.compile(".*\\bALTER\\b.*\\bTABLE\\b.*", Pattern.CASE_INSENSITIVE));
+        Injections.add(Pattern.compile(".*OR\\s+(['\\w]+)=\\1.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        // patterns for classical SQL injection 1=1 , 2=2 with ON, OR, AND
+        Injections.add(Pattern.compile(".*\\bOR\\b.*\\b\\d+=\\d+\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*'\\s*OR\\s*'\\d+'=\\d+\\s*--.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*\\bON\\b\\s*\\d+\\s*=\\s*\\d+.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*\\bAND\\b.*\\b\\d+=\\d+\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*UNION.*SELECT.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*EXEC\\s+.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*INSERT\\s+INTO.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*DROP\\s+TABLE.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*\\bUPDATE\\b.*\\bSET\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*\\bDELETE\\b.*\\bFROM\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*\\bCREATE\\b.*\\bTABLE\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*\\bALTER\\b.*\\bTABLE\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
         // pattern for lo_prefix function tables
-        Injections.add(Pattern.compile(".*\\blo_\\w+\\b.*", Pattern.CASE_INSENSITIVE)); 
+        Injections.add(Pattern.compile(".*\\blo_\\w+\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        // Block pg_* functions (word-boundary to block double-quoted bypass like "pg_read_file"(...))
+        Injections.add(Pattern.compile(".*\\bpg_\\w+\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        // Block subqueries
+        Injections.add(Pattern.compile(".*\\(\\s*SELECT\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        // Block dblink remote connection functions (word-boundary to block double-quoted bypass)
+        Injections.add(Pattern.compile(".*\\bdblink\\w*\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        // Block current_setting config reads (word-boundary to block double-quoted bypass)
+        Injections.add(Pattern.compile(".*\\bcurrent_setting\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        // Block set_config config writes (word-boundary to block double-quoted bypass)
+        Injections.add(Pattern.compile(".*\\bset_config\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL));
+        // Block dollar-quoting (PostgreSQL alternative string quoting that bypasses single-quote checks)
+        Injections.add(Pattern.compile(".*\\$\\$.*", Pattern.DOTALL));
+        Injections.add(Pattern.compile(".*\\$[a-zA-Z_]\\w*\\$.*", Pattern.DOTALL));
     };
 
 

--- a/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
+++ b/reports/src/com/untangle/app/reports/ReportsManagerImpl.java
@@ -16,8 +16,10 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.Iterator;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -25,6 +27,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import com.untangle.uvm.AdminUserSettings;
+import com.untangle.uvm.logging.LogEvent;
 import com.untangle.uvm.ExecManagerResult;
 import com.untangle.uvm.OperationsEvent;
 import com.untangle.uvm.UvmContextFactory;
@@ -66,7 +69,33 @@ public class ReportsManagerImpl implements ReportsManager
      */
     private List<AppProperties> appPropertiesList = null;
 
-    /** 
+    private static final Set<String> VALID_AGG_FUNCTIONS = new HashSet<>(
+        java.util.Arrays.asList("avg", "count", "sum", "min", "max")
+    );
+    private static final Set<String> IS_KEYWORDS = new HashSet<>(
+        java.util.Arrays.asList("null", "not null", "true", "false", "unknown")
+    );
+    private static final Pattern SAFE_IN_LIST = Pattern.compile(
+        "^\\(\\s*" +
+        "(?:" +
+            "(?:'(?:[^']|'')*'|-?\\d+(?:\\.\\d+)?|(?:null|true|false))" +
+            "(?:\\s*,\\s*(?:'(?:[^']|'')*'|-?\\d+(?:\\.\\d+)?|(?:null|true|false)))*" +
+        ")?" +
+        "\\s*\\)$",
+        Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern SAFE_BETWEEN_VALUE = Pattern.compile(
+        "^\\s*(-?\\d+(\\.\\d+)?|'(?:[^']|'')*')\\s+[Aa][Nn][Dd]\\s+(-?\\d+(\\.\\d+)?|'(?:[^']|'')*')\\s*$"
+    );
+    private static final Pattern IDENTIFIER = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
+    private static final Pattern NUMERIC_LITERAL = Pattern.compile("-?\\d+(\\.\\d+)?");
+    private static final Pattern QUOTED_STRING = Pattern.compile("'(?:[^']|'')*'(?:::[a-zA-Z_][a-zA-Z0-9_]*)?");
+    private static final Pattern DOTTED_VALUE = Pattern.compile("[a-zA-Z0-9_]+(\\.[a-zA-Z0-9_]+)+");
+    private static final Set<String> BLOCKED_IDENTIFIERS = new HashSet<>(
+        java.util.Arrays.asList("dblink", "current_setting", "set_config", "chr")
+    );
+
+    /**
      * Initialize reports manager
      */
     protected ReportsManagerImpl()
@@ -453,6 +482,11 @@ public class ReportsManagerImpl implements ReportsManager
      */
     public List<JSONObject> getDataForReportEntry( ReportEntry entry, final Date startDate, final Date endDate, String[] extraSelects, SqlCondition[] extraConditions, SqlFrom fromType, final int limit )
     {
+        validateReportEntry(entry);
+        extraConditions = validateConditions(extraConditions, entry.getTable());
+        if (!ReportEntry.isValidStringArrayField(extraSelects, true)) {
+            throw new RuntimeException("invalid extraSelects: " + (extraSelects != null ? String.join(",", extraSelects) : ""));
+        }
         Connection conn = app.getDbConnection();
         if(conn == null){
             return null;
@@ -663,6 +697,8 @@ public class ReportsManagerImpl implements ReportsManager
         }
         if ( entry.getType() != ReportEntry.ReportEntryType.EVENT_LIST )
             throw new RuntimeException("Can only retrieve events for an EVENT_LIST type report entry");
+        validateReportEntry(entry);
+        SqlCondition[] validatedConditions = validateConditions(extraConditions, entry.getTable());
         if ( app == null ) {
             return results;
         }
@@ -677,7 +713,7 @@ public class ReportsManagerImpl implements ReportsManager
         if(conn == null){
             return null;
         }
-        PreparedStatement statement = entry.toSql( conn, null, null, null, extraConditions, null, limit );
+        PreparedStatement statement = entry.toSql( conn, null, null, null, validatedConditions, null, limit );
 
         logger.info("Getting Events for : (" + entry.getCategory() + ") " + entry.getTitle());
         logger.info("Statement          : " + statement);
@@ -766,6 +802,8 @@ public class ReportsManagerImpl implements ReportsManager
         }
         if ( entry.getType() != ReportEntry.ReportEntryType.EVENT_LIST )
             throw new RuntimeException("Can only retrieve events for an EVENT_LIST type report entry");
+        validateReportEntry(entry);
+        SqlCondition[] validatedConditions = validateConditions(extraConditions, entry.getTable());
         if ( app == null ) {
             return result;
         }
@@ -786,7 +824,7 @@ public class ReportsManagerImpl implements ReportsManager
         if(conn == null){
             return null;
         }
-        PreparedStatement statement = entry.toSql( conn, startDate, endDate, null, extraConditions, null, limit );
+        PreparedStatement statement = entry.toSql( conn, startDate, endDate, null, validatedConditions, null, limit );
 
         logger.info("Getting Events for : (" + entry.getCategory() + ") " + entry.getTitle());
         logger.info("Statement          : " + statement);
@@ -1154,6 +1192,287 @@ public class ReportsManagerImpl implements ReportsManager
     }
 
     /**
+     * Remove cached column metadata for the given table.
+     *
+     * @param tableName the database table whose column cache should be cleared.
+     */
+    protected void invalidateColumnCache(String tableName)
+    {
+        cacheColumnsResults.remove(tableName);
+    }
+
+    /**
+     * Build a lowercase column-name set for the given table, retrying once
+     * after a cache invalidation if the initial set is empty.
+     *
+     * @param table the bare table name.
+     * @return set of lowercase column names.
+     */
+    private Set<String> getColumnSetOrRefresh(String table)
+    {
+        Set<String> columnSet = new HashSet<>();
+        String[] cols = getColumnsForTable(table);
+        if (cols != null) {
+            for (String c : cols) columnSet.add(c.toLowerCase());
+        }
+        if (columnSet.isEmpty()) {
+            invalidateColumnCache(table);
+            cols = getColumnsForTable(table);
+            if (cols != null) {
+                for (String c : cols) columnSet.add(c.toLowerCase());
+            }
+        }
+        return columnSet;
+    }
+
+    /**
+     * Check whether a column exists for the given table, refreshing the
+     * column cache once on a miss before giving up.
+     *
+     * @param column the column name to look for (case-insensitive).
+     * @param table  the bare table name.
+     * @return true if the column exists in the table schema.
+     */
+    private boolean columnExistsOrRefresh(String column, String table)
+    {
+        if (column == null) return false;
+        String[] cols = getColumnsForTable(table);
+        if (cols != null) {
+            for (String c : cols) {
+                if (c.equalsIgnoreCase(column)) return true;
+            }
+        }
+        invalidateColumnCache(table);
+        cols = getColumnsForTable(table);
+        if (cols != null) {
+            for (String c : cols) {
+                if (c.equalsIgnoreCase(column)) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Verify that the given table name exists in the database schema.
+     *
+     * @param table the table name to validate.
+     */
+    private void validateTable(String table)
+    {
+        if (table == null || table.isEmpty()) {
+            throw new RuntimeException("table is required");
+        }
+        String[] validTables = getTables();
+        if (validTables != null) {
+            boolean found = false;
+            for (String t : validTables) {
+                if (t.equalsIgnoreCase(table)) { found = true; break; }
+            }
+            if (!found) {
+                cacheTablesResults = null;
+                validTables = getTables();
+                if (validTables != null) {
+                    for (String t : validTables) {
+                        if (t.equalsIgnoreCase(table)) { found = true; break; }
+                    }
+                }
+                if (!found) {
+                    throw new RuntimeException("invalid table: " + table);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validate the aggregation function for dynamic time-graph entries.
+     *
+     * @param entry the report entry to check.
+     */
+    private void validateAggFunction(ReportEntry entry)
+    {
+        if (entry.getType() == ReportEntry.ReportEntryType.TIME_GRAPH_DYNAMIC) {
+            String fn = entry.getTimeDataDynamicAggregationFunction();
+            if (fn != null && !VALID_AGG_FUNCTIONS.contains(fn.toLowerCase())) {
+                throw new RuntimeException("invalid aggregation function: " + fn);
+            }
+        }
+    }
+
+    /**
+     * Validate the dynamic column for dynamic time-graph entries.
+     *
+     * @param entry the report entry to check.
+     */
+    private void validateDynamicColumn(ReportEntry entry)
+    {
+        if (entry.getType() == ReportEntry.ReportEntryType.TIME_GRAPH_DYNAMIC) {
+            String col = entry.getTimeDataDynamicColumn();
+            if (col != null && !col.isEmpty() && !columnExistsOrRefresh(col, entry.getTable())) {
+                throw new RuntimeException("invalid dynamic column: " + col);
+            }
+        }
+    }
+
+    /**
+     * Validate column-based fields for pie-graph report entries.
+     *
+     * @param entry the report entry to check.
+     */
+    private void validateEntryFields(ReportEntry entry)
+    {
+        if (entry.getType() == ReportEntry.ReportEntryType.PIE_GRAPH) {
+            String bareTable = entry.getTable();
+            String pieGroup = entry.getPieGroupColumn();
+            if (pieGroup != null && !pieGroup.trim().isEmpty() && !columnExistsOrRefresh(pieGroup.trim(), bareTable)) {
+                throw new RuntimeException("invalid pieGroupColumn: " + pieGroup);
+            }
+            String orderBy = entry.getOrderByColumn();
+            if (orderBy != null && !"value".equalsIgnoreCase(orderBy.trim())
+                    && !columnExistsOrRefresh(orderBy.trim(), bareTable)) {
+                throw new RuntimeException("invalid orderByColumn: " + orderBy);
+            }
+        }
+    }
+
+    /**
+     * Validate all user-controlled fields of a report entry.
+     *
+     * @param entry the report entry to validate.
+     */
+    private void validateReportEntry(ReportEntry entry)
+    {
+        validateTable(entry.getTable());
+        validateAggFunction(entry);
+        validateDynamicColumn(entry);
+        validateEntryFields(entry);
+        validateEntryStringFields(entry);
+        if (entry.getConditions() != null) {
+            validateConditions(entry.getConditions(), entry.getTable());
+        }
+    }
+
+    /**
+     * Validate entry string fields against the injection denylist.
+     * These checks run before SQL execution so exceptions propagate
+     * to the caller as clear error responses.
+     *
+     * @param entry the report entry to validate.
+     */
+    private void validateEntryStringFields(ReportEntry entry)
+    {
+        if (!ReportEntry.isValidStringArrayField(entry.getTextColumns(), true)) {
+            throw new RuntimeException("invalid textColumns");
+        }
+        String pieSumCol = entry.getPieSumColumn();
+        if (pieSumCol != null && !pieSumCol.trim().isEmpty()) {
+            if (!ReportEntry.isValidStringField(pieSumCol, true)) {
+                throw new RuntimeException("invalid pieSumColumn: " + pieSumCol);
+            }
+        }
+        if (!ReportEntry.isValidStringArrayField(entry.getTimeDataColumns(), true)) {
+            throw new RuntimeException("invalid timeDataColumns");
+        }
+        String dynVal = entry.getTimeDataDynamicValue();
+        if (dynVal != null && !dynVal.trim().isEmpty()) {
+            if (!ReportEntry.isValidStringField(dynVal, true)) {
+                throw new RuntimeException("invalid timeDataDynamicValue: " + dynVal);
+            }
+        }
+    }
+
+    /**
+     * Validate SQL conditions ensuring columns exist and values are safe.
+     *
+     * @param conditions the conditions to validate.
+     * @param table the table name used to resolve valid columns.
+     * @return the validated conditions array.
+     */
+    protected SqlCondition[] validateConditions(SqlCondition[] conditions, String table)
+    {
+        if (conditions == null) return null;
+        Set<String> columnSet = getColumnSetOrRefresh(table);
+        for (SqlCondition c : conditions) {
+            if (c.getColumn() == null || !columnSet.contains(c.getColumn().toLowerCase())) {
+                throw new RuntimeException("invalid condition column: " + c.getColumn());
+            }
+            String op = c.getOperator() != null ? c.getOperator().toLowerCase() : "";
+            if ("is".equals(op) || "is not".equals(op)) {
+                String val = c.getValue() != null ? c.getValue().trim().toLowerCase() : "";
+                if (!IS_KEYWORDS.contains(val)) {
+                    throw new RuntimeException("invalid value for IS operator: " + c.getValue());
+                }
+            } else if ("in".equals(op) || "not in".equals(op)) {
+                if (!isValidInList(c.getValue())) {
+                    throw new RuntimeException("invalid value for IN operator: " + c.getValue());
+                }
+            } else if ("between".equals(op)) {
+                if (!isValidBetweenValue(c.getValue())) {
+                    throw new RuntimeException("invalid value for BETWEEN operator: " + c.getValue());
+                }
+            } else if (!c.isAutoFormatValueRaw()) {
+                if (!isAllowedExpression(c.getValue())) {
+                    throw new RuntimeException("invalid expression in condition value: " + c.getValue());
+                }
+            }
+        }
+        return conditions;
+    }
+
+    /**
+     * Check whether a value is a safe comma-separated list for IN clauses.
+     *
+     * @param value the value string to check.
+     * @return true if the value matches the safe IN-list pattern.
+     */
+    private boolean isValidInList(String value)
+    {
+        if (value == null || value.trim().isEmpty()) return false;
+        return SAFE_IN_LIST.matcher(value.trim()).matches();
+    }
+
+    /**
+     * Check whether a BETWEEN value is safe (literal AND literal).
+     *
+     * @param value the value string to check.
+     * @return true if the value matches the safe BETWEEN pattern.
+     */
+    private boolean isValidBetweenValue(String value)
+    {
+        if (value == null || value.trim().isEmpty()) return false;
+        return SAFE_BETWEEN_VALUE.matcher(value.trim()).matches();
+    }
+
+    /**
+     * Check whether a condition value is an allowed literal expression.
+     *
+     * @param value the expression to check.
+     * @return true if the value is a safe numeric, string, boolean, or identifier literal.
+     */
+    private static boolean isAllowedExpression(String value)
+    {
+        if (value == null || value.trim().isEmpty()) return false;
+        String trimmed = value.trim();
+        if (NUMERIC_LITERAL.matcher(trimmed).matches()) return true;
+        if (QUOTED_STRING.matcher(trimmed).matches()) return true;
+        if ("true".equalsIgnoreCase(trimmed) || "false".equalsIgnoreCase(trimmed)) return true;
+        if ("null".equalsIgnoreCase(trimmed)) return true;
+        if (IDENTIFIER.matcher(trimmed).matches()) {
+            String lower = trimmed.toLowerCase();
+            if (lower.startsWith("pg_") || lower.startsWith("lo_")) return false;
+            if (BLOCKED_IDENTIFIERS.contains(lower)) return false;
+            return true;
+        }
+        if (DOTTED_VALUE.matcher(trimmed).matches()) {
+            for (String part : trimmed.toLowerCase().split("\\.")) {
+                if (part.startsWith("pg_") || part.startsWith("lo_")) return false;
+                if (BLOCKED_IDENTIFIERS.contains(part)) return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Report Entry order display.
      */
     private class ReportEntryDisplayOrderComparator implements Comparator<ReportEntry>
@@ -1234,6 +1553,8 @@ public class ReportsManagerImpl implements ReportsManager
             logger.info("Postgress Status Response {}", pgStatus);
             if (pgStatus == 0) {
                 UvmContextFactory.context().execManager().execOutput(generateReportTablesCmd);
+                cacheColumnsResults.clear();
+                cacheTablesResults = null;
                 String username = null;
                 String hostname = null;
                 String userHostNameInfo = UvmContextFactory.context().settingsManager().getUserAndHostNameInfo("reports");

--- a/reports/src/com/untangle/app/reports/SqlCondition.java
+++ b/reports/src/com/untangle/app/reports/SqlCondition.java
@@ -102,6 +102,27 @@ public class SqlCondition implements Serializable, JSONString
         if ("not in".equalsIgnoreCase( getOperator() )) {
             return false;
         }
+        if ("between".equalsIgnoreCase( getOperator() )) {
+            return false;
+        }
+        if (!this.autoFormatValue) {
+            String val = getValue() != null ? getValue().trim() : "";
+            if (val.matches("[a-zA-Z_][a-zA-Z0-9_]*")) {
+                String lower = val.toLowerCase();
+                if (lower.startsWith("pg_") || lower.startsWith("lo_")) {
+                    return true;
+                }
+                return false;
+            }
+            if ("true".equalsIgnoreCase(val) || "false".equalsIgnoreCase(val)) {
+                return false;
+            }
+            if ("null".equalsIgnoreCase(val)) {
+                return false;
+            }
+            logger.warn("Forcing autoFormatValue=true for non-safe expression: " + val);
+            return true;
+        }
 
         return this.autoFormatValue;
     }
@@ -109,6 +130,11 @@ public class SqlCondition implements Serializable, JSONString
     public void setAutoFormatValue( boolean newValue )
     {
         this.autoFormatValue = newValue;
+    }
+
+    public boolean isAutoFormatValueRaw()
+    {
+        return this.autoFormatValue;
     }
 
     public String getTable() { return this.table; }


### PR DESCRIPTION

**Summary**

**UNT-05:** Add multi-layer SQL injection protection to the Reports subsystem — denylist patterns in ReportEntry (pg_read_file, dblink, current_setting, set_config, subqueries, dollar-quoting), server-side input validation in ReportsManagerImpl (table, columns, aggregation functions, conditions), and a resolveEntry() proxy in the reports-only servlet that forces client entries to match server-side definitions
**UNT-28:** Block PostgreSQL $$ and $tag$ dollar-quoting bypass patterns that could circumvent single-quote injection checks
SqlCondition: Harden getAutoFormatValue() to force quoting on non-safe raw expressions and add isAutoFormatValueRaw() accessor

**BEFORE :**  
<img width="1859" height="1088" alt="ATS-before-fix" src="https://github.com/user-attachments/assets/268a2b01-c735-42a7-971d-e63fed6d22b9" />


**AFTER:** 
<img width="1859" height="1088" alt="ATS-after-fix" src="https://github.com/user-attachments/assets/d6172ce8-fdfe-4f71-9394-187541cd18d1" />
