### PR TITLE
ngfw-15912 vue boolean rule conditions mtcher issue fix

### DIFF
--- a/uvm/api/com/untangle/uvm/app/RuleCondition.java
+++ b/uvm/api/com/untangle/uvm/app/RuleCondition.java
@@ -24,6 +24,7 @@ import com.untangle.uvm.app.IPMatcher;
 import com.untangle.uvm.app.IntMatcher;
 import com.untangle.uvm.app.IntfMatcher;
 import com.untangle.uvm.app.UserMatcher;
+import com.untangle.uvm.util.Constants;
 import com.untangle.uvm.app.GroupMatcher;
 import com.untangle.uvm.app.DomainMatcher;
 import com.untangle.uvm.app.ProtocolMatcher;
@@ -230,6 +231,9 @@ public class RuleCondition implements JSONString, Serializable
     
     /**
      * Returns true if this matcher matches the specified session
+     * TODO: After full Vue migration, boolean conditions (quota, entitled, flagged)
+     * use value="false" for negation instead of invert. The invert path for these
+     * condition types can be removed once ExtJS is fully retired.
      */
     public boolean matches( AppSession sess )
     {
@@ -251,6 +255,9 @@ public class RuleCondition implements JSONString, Serializable
      * This provides limited matching
      * This is useful for sessions that do not yet exists
      * Many matches will never match in this case because the session does not exist
+     * TODO: After full Vue migration, boolean conditions (quota, entitled, flagged)
+     * use value="false" for negation instead of invert. The invert path for these
+     * condition types can be removed once ExtJS is fully retired.
      */
     public boolean matches( short protocol,
                             int srcIntf, int dstIntf,
@@ -276,6 +283,9 @@ public class RuleCondition implements JSONString, Serializable
      * This provides limited matching
      * This is useful for sessions that do not yet exists
      * Many matches will never match in this case because the session does not exist
+     * TODO: After full Vue migration, boolean conditions (quota, entitled, flagged)
+     * use value="false" for negation instead of invert. The invert path for these
+     * condition types can be removed once ExtJS is fully retired.
      */
     public boolean matches( short protocol,
                             int srcIntf, int dstIntf,
@@ -539,42 +549,42 @@ public class RuleCondition implements JSONString, Serializable
         case HOST_HAS_NO_QUOTA:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( sess.sessionEvent().getLocalAddr() );
             if (hostEntry == null)
-                return true;
-            return ( hostEntry.getQuotaSize() == 0 );
+                return matchBooleanValue(true);
+            return matchBooleanValue( hostEntry.getQuotaSize() == 0 );
 
         case CLIENT_HAS_NO_QUOTA:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( sess.getClientAddr() );
             if (hostEntry == null)
-                return true;
-            return ( hostEntry.getQuotaSize() == 0 );
+                return matchBooleanValue(true);
+            return matchBooleanValue( hostEntry.getQuotaSize() == 0 );
 
         case SERVER_HAS_NO_QUOTA:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( sess.getServerAddr() );
             if (hostEntry == null)
-                return true;
-            return ( hostEntry.getQuotaSize() == 0 );
+                return matchBooleanValue(true);
+            return matchBooleanValue( hostEntry.getQuotaSize() == 0 );
 
         case USER_HAS_NO_QUOTA:
             if ( sess.user() == null )
                 return false; //no user
             userEntry = UvmContextFactory.context().userTable().getUserTableEntry( sess.user() );
             if (userEntry == null)
-                return true;
-            return ( userEntry.getQuotaSize() == 0 );
-            
+                return matchBooleanValue(true);
+            return matchBooleanValue( userEntry.getQuotaSize() == 0 );
+
         case HOST_QUOTA_EXCEEDED:
-            return UvmContextFactory.context().hostTable().hostQuotaExceeded( sess.sessionEvent().getLocalAddr() );
+            return matchBooleanValue(UvmContextFactory.context().hostTable().hostQuotaExceeded( sess.sessionEvent().getLocalAddr() ));
 
         case CLIENT_QUOTA_EXCEEDED:
-            return UvmContextFactory.context().hostTable().hostQuotaExceeded( sess.getClientAddr() );
+            return matchBooleanValue(UvmContextFactory.context().hostTable().hostQuotaExceeded( sess.getClientAddr() ));
 
         case SERVER_QUOTA_EXCEEDED:
-            return UvmContextFactory.context().hostTable().hostQuotaExceeded( sess.getServerAddr() );
+            return matchBooleanValue(UvmContextFactory.context().hostTable().hostQuotaExceeded( sess.getServerAddr() ));
 
         case USER_QUOTA_EXCEEDED:
             if ( sess.user() == null )
                 return false; //no user
-            return UvmContextFactory.context().userTable().userQuotaExceeded( sess.user() );
+            return matchBooleanValue(UvmContextFactory.context().userTable().userQuotaExceeded( sess.user() ));
             
         case HOST_QUOTA_ATTAINMENT:
             if ( this.intMatcher == null ) {
@@ -796,7 +806,7 @@ public class RuleCondition implements JSONString, Serializable
             Boolean flagged = (Boolean) sess.globalAttachment(SessionAttachments.KEY_WEB_FILTER_FLAGGED);
             if (flagged == null)
                 return false;
-            return flagged.booleanValue();
+            return matchBooleanValue(flagged.booleanValue());
 
         case TAGGED:
             for( Tag t : sess.getTags() ) {
@@ -838,9 +848,9 @@ public class RuleCondition implements JSONString, Serializable
         case HOST_ENTITLED:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( sess.getClientAddr() );
             if (hostEntry == null)
-                return true;
-            return hostEntry.getEntitled();
-            
+                return matchBooleanValue(true);
+            return matchBooleanValue(hostEntry.getEntitled());
+
         case USERNAME:
             tmpStr = sess.user();
             if (this.userMatcher.isMatch(tmpStr))
@@ -1150,8 +1160,8 @@ public class RuleCondition implements JSONString, Serializable
         case HOST_ENTITLED:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( srcAddress );
             if (hostEntry == null)
-                return true;
-            return hostEntry.getEntitled();
+                return matchBooleanValue(true);
+            return matchBooleanValue(hostEntry.getEntitled());
 
         case USERNAME:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( srcAddress );
@@ -1239,20 +1249,20 @@ public class RuleCondition implements JSONString, Serializable
                 return false;
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( tmpAddress );
             if (hostEntry == null)
-                return true;
-            return ( hostEntry.getQuotaSize() == 0 );
+                return matchBooleanValue(true);
+            return matchBooleanValue( hostEntry.getQuotaSize() == 0 );
 
         case CLIENT_HAS_NO_QUOTA:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( srcAddress );
             if (hostEntry == null)
-                return true;
-            return ( hostEntry.getQuotaSize() == 0 );
+                return matchBooleanValue(true);
+            return matchBooleanValue( hostEntry.getQuotaSize() == 0 );
 
         case SERVER_HAS_NO_QUOTA:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( dstAddress );
             if (hostEntry == null)
-                return true;
-            return ( hostEntry.getQuotaSize() == 0 );
+                return matchBooleanValue(true);
+            return matchBooleanValue( hostEntry.getQuotaSize() == 0 );
 
         case USER_HAS_NO_QUOTA:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( srcAddress );
@@ -1263,21 +1273,21 @@ public class RuleCondition implements JSONString, Serializable
                 return false; //no user
             userEntry = UvmContextFactory.context().userTable().getUserTableEntry( tmpStr );
             if (userEntry == null)
-                return true;
-            return ( userEntry.getQuotaSize() == 0 );
-            
+                return matchBooleanValue(true);
+            return matchBooleanValue( userEntry.getQuotaSize() == 0 );
+
         case HOST_QUOTA_EXCEEDED:
             tmpAddress = getLocalAddress( srcAddress, srcIntf, dstAddress, dstIntf );
             if ( tmpAddress == null )
                 return false;
             else
-                return UvmContextFactory.context().hostTable().hostQuotaExceeded( tmpAddress );
+                return matchBooleanValue(UvmContextFactory.context().hostTable().hostQuotaExceeded( tmpAddress ));
 
         case CLIENT_QUOTA_EXCEEDED:
-            return UvmContextFactory.context().hostTable().hostQuotaExceeded( srcAddress );
+            return matchBooleanValue(UvmContextFactory.context().hostTable().hostQuotaExceeded( srcAddress ));
 
         case SERVER_QUOTA_EXCEEDED:
-            return UvmContextFactory.context().hostTable().hostQuotaExceeded( dstAddress );
+            return matchBooleanValue(UvmContextFactory.context().hostTable().hostQuotaExceeded( dstAddress ));
 
         case USER_QUOTA_EXCEEDED:
             hostEntry = UvmContextFactory.context().hostTable().getHostTableEntry( srcAddress );
@@ -1286,7 +1296,7 @@ public class RuleCondition implements JSONString, Serializable
             tmpStr = hostEntry.getUsername();
             if ( tmpStr == null )
                 return false; //no user
-            return UvmContextFactory.context().userTable().userQuotaExceeded( tmpStr );
+            return matchBooleanValue(UvmContextFactory.context().userTable().userQuotaExceeded( tmpStr ));
             
         case HOST_QUOTA_ATTAINMENT:
             if ( this.intMatcher == null ) {
@@ -1514,6 +1524,21 @@ public class RuleCondition implements JSONString, Serializable
         return false;
     }
         
+    /**
+     * Matches the boolean value of a condition against the result of a check.
+     * TODO: Once all UIs are Vue-migrated, invert will always be false for boolean conditions.
+     * At that point, this method fully handles negation via value and the invert logic
+     * in the outer matches() methods can be removed for these condition types.
+     * @param result The result of the check to match against the condition's value.
+     * @return True if the result matches the condition's value, false otherwise.
+     */
+    private boolean matchBooleanValue(boolean result)
+    {
+        if (Constants.FALSE.toLowerCase().equals(this.value))
+            return !result;
+        return result;
+    }
+
     /**
      * Returns the country code for address
      * If intf is a non-WAN - returns "XL" (local)


### PR DESCRIPTION
## Summary

Fix boolean rule conditions (quota, entitled, flagged) to respect the `value` field sent by the Vue UI. Previously, selecting "No" for these conditions behaved identically to "Yes" because the Java matcher ignored `this.value` entirely.

## Motivation

The Vue UI uses Yes/No radio buttons for boolean conditions — selecting "Yes" sends `value="true"` and "No" sends `value="false"`, with `invert` always `false`. The backend `_matches()` methods returned raw boolean results without consulting `this.value`, so the "No" selection had no effect. This broke Firewall, Web Filter, Captive Portal, Bandwidth Control, and Policy Manager rules using any of the 10 affected boolean condition types.

Ticket: NGFW-15912

## Changes

### RuleCondition boolean matching
- Added `matchBooleanValue(boolean result)` private helper that negates the result when `this.value` equals `"false"`, otherwise returns it unchanged
- Wrapped all 19 boolean return statements across both `_matches()` overloads:
  - **Full-session** `_matches(AppSession)`: HOST/CLIENT/SERVER_HAS_NO_QUOTA, USER_HAS_NO_QUOTA, HOST/CLIENT/SERVER_QUOTA_EXCEEDED, USER_QUOTA_EXCEEDED, WEB_FILTER_FLAGGED, HOST_ENTITLED
  - **Pre-session** `_matches(protocol, ...)`: same conditions minus WEB_FILTER_FLAGGED (not applicable pre-session)

### Future migration notes
- Added TODO comments to the three `matches()` overloads and `matchBooleanValue()` noting that the `invert` path for boolean conditions can be removed once ExtJS is fully retired

### Backward compatibility
- `value=null` or `value="true"` (ExtJS default): `matchBooleanValue()` returns result unchanged — no behavior change
- `invert` flag continues to work via the outer `matches()` wrapper
- Only `value="false"` (Vue "No" selection) changes behavior — negates the raw result

## Testing

All 10 boolean conditions should be verified with both "Yes" and "No" values:

1. **HOST_QUOTA_EXCEEDED / CLIENT_QUOTA_EXCEEDED / SERVER_QUOTA_EXCEEDED** — Assign a small quota via Bandwidth Control, exhaust it, then create Firewall rules with Yes/No and verify block/pass behavior
2. **HOST_HAS_NO_QUOTA / CLIENT_HAS_NO_QUOTA / SERVER_HAS_NO_QUOTA** — Create Firewall rules targeting hosts with and without quotas assigned, verify Yes/No correctly matches the quota state
3. **USER_HAS_NO_QUOTA / USER_QUOTA_EXCEEDED** — Set up Captive Portal with Local Directory authentication, assign user quotas via Bandwidth Control, then verify Firewall rules with Yes/No
4. **HOST_ENTITLED** — Create Firewall rule with Host Entitled = Yes/No, toggle the entitled flag on a host via the JSON-RPC API (`rpc.hostTable.getHosts` / `setHosts`), and verify matching behavior changes accordingly
5. **WEB_FILTER_FLAGGED** — Enable flagging on a Web Filter category, then create Web Filter filter rules with Web Filter Flagged = Yes/No and verify flagged sites are correctly matched or excluded
6. **Backward compatibility** — Verify existing ExtJS-created rules with `value="true"` and `invert=false/true` (is/is Not operator) continue to work unchanged

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
