### PR TITLE
ngfw-15917 custom event list report bug fix

### DIFF
--- a/reports/src/com/untangle/app/reports/ReportEntry.java
+++ b/reports/src/com/untangle/app/reports/ReportEntry.java
@@ -163,7 +163,7 @@ public class ReportEntry implements Serializable, JSONString
     private String orderByColumn = null; /* The column to order by */
     private Boolean orderDesc = null; /* The direction to order, True is DESC, False is regular, null is neither */
 
-    private String[] defaultColumns; /* The default columns for an event list report entry */
+    private String[] defaultColumns = new String[0]; /* The default columns for an event list report entry */
 
     /* http://api.highcharts.com/highstock/plotOptions.area.dataGrouping */
     private String approximation; /* The data-approximation technique: average, open, high, low, close, sum */

--- a/uvm/js/common/reports/model/Report.js
+++ b/uvm/js/common/reports/model/Report.js
@@ -5,7 +5,7 @@ Ext.define ('Ung.model.Report', {
         { name: 'category', type: 'string', defaultValue: '' },
         { name: 'colors', type: 'auto', defaultValue: null },
         { name: 'conditions', type: 'auto', defaultValue: null },
-        { name: 'defaultColumns' }, //???
+        { name: 'defaultColumns', type: 'auto', defaultValue: [] },
         { name: 'description', type: 'string', defaultValue: '' },
         { name: 'displayOrder', type: 'int' },
         { name: 'enabled', type: 'boolean', defaultValue: true },

--- a/uvm/js/common/reports/view/EventReport.js
+++ b/uvm/js/common/reports/view/EventReport.js
@@ -130,7 +130,7 @@ Ext.define('Ung.view.reports.EventReport', {
 
             if (!entry) { return; }
 
-            defaultColumns = entry.get('defaultColumns');
+            defaultColumns = entry.get('defaultColumns') || [];
 
             // keep this for backward compatibility
             if (me.getView().up('reportwidget')) {


### PR DESCRIPTION
## Summary

Fix crash when creating a custom Event List report without selecting any default columns. The Dashboard and Reports pages become completely unusable until the broken report entry is manually repaired.

## Motivation

Creating a new Event List report, selecting a table but skipping column selection, then saving causes `defaultColumns` to be persisted as `null`. Any subsequent navigation to Dashboard or Reports throws `TypeError: Array.prototype.indexOf called on null or undefined` in `Ext.Array.contains`, crashing the entire page.

Ticket: NGFW-15917

## Changes

- **Reports Java model (`ReportEntry.java`)**
  - Initialize `defaultColumns` field to `new String[0]` instead of leaving it as Java `null`, so new and deserialized entries always have a valid array

- **Reports JS model (`Report.js`)**
  - Add `type: 'auto', defaultValue: []` to the `defaultColumns` field definition, matching the pattern used by `colors`, `conditions`, `textColumns`, and `timeDataColumns`

- **Event List renderer (`EventReport.js`)**
  - Add `|| []` fallback in `setupGrid()` when reading `defaultColumns` from the entry, protecting against pre-existing corrupted settings files loaded before the backend fix takes effect

## Testing

1. Navigate to Reports → click "Create New" directly (do not select an existing report first)
2. Set type to "Event List", select a table (e.g., "sessions")
3. Do **not** select any default columns
4. Enter a title and click Save
5. Verify the report saves without error and renders with all columns hidden
6. Navigate to Dashboard → verify no crash
7. Navigate back to Reports → verify the saved report loads correctly
8. Edit the report, select some columns, save → verify columns display correctly
9. Create PIE_GRAPH, TIME_GRAPH, TEXT reports → verify no regressions

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
