### PR TITLE
ngfw-15920 v2 API's added for threat prevention app

### DIFF
--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionApp.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionApp.java
@@ -12,6 +12,7 @@ import java.net.InetAddress;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
@@ -46,6 +47,7 @@ import com.untangle.uvm.vnet.PipelineConnector;
 import com.untangle.uvm.vnet.SessionAttachments;
 import com.untangle.uvm.vnet.Token;
 import com.untangle.app.http.HeaderToken;
+import com.untangle.app.threat_prevention.generic.ThreatPreventionSettingsGeneric;
 import com.untangle.uvm.app.IntMatcher;
 import com.untangle.uvm.app.License;
 
@@ -257,6 +259,28 @@ public class ThreatPreventionApp extends AppBase
         try {logger.debug("New Settings: \n" + new org.json.JSONObject(this.settings).toString(2));} catch (Exception e) {}
 
         this.reconfigure();
+    }
+
+    /**
+     * Get the current settings in V2 generic format
+     * @return ThreatPreventionSettingsGeneric
+     */
+    public ThreatPreventionSettingsGeneric getSettingsV2() {
+        if (this.getSettings() != null)
+            return this.getSettings().transformThreatPreventionSettingsToGeneric();
+        return new ThreatPreventionSettingsGeneric();
+    }
+
+    /**
+     * Set the settings from a V2 (generic) format payload coming from the Vue UI.
+     * @param newSettings - the new settings in V2 format
+     */
+    public void setSettingsV2(final ThreatPreventionSettingsGeneric newSettings) {
+        if (this.getSettings() != null) {
+            ThreatPreventionSettings cloned = SerializationUtils.clone(this.getSettings());
+            newSettings.transformGenericToThreatPreventionSettings(cloned);
+            this.setSettings(cloned);
+        }
     }
 
     /**

--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionRule.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionRule.java
@@ -3,16 +3,24 @@
  */
 package com.untangle.app.threat_prevention;
 
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.io.Serializable;
 import java.net.InetAddress;
-
 
 import org.json.JSONObject;
 import org.json.JSONString;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.untangle.uvm.generic.RuleActionGeneric;
+import com.untangle.uvm.generic.RuleConditionGeneric;
+import com.untangle.uvm.generic.RuleGeneric;
+import com.untangle.uvm.util.Constants;
+import com.untangle.uvm.util.StringUtil;
 import com.untangle.uvm.vnet.SessionAttachments;
 import com.untangle.uvm.vnet.AppSession;
 
@@ -139,6 +147,113 @@ public class ThreatPreventionRule implements JSONString, Serializable
         return true;
     }
 
-    
+    /**
+     * Transforms a list of ThreatPreventionRule into the generic RuleGeneric form for
+     * the V2 API. Used by getSettingsV2().
+     *
+     * @param v1Rules list of V1 ThreatPreventionRule objects
+     * @return LinkedList of RuleGeneric
+     */
+    public static LinkedList<RuleGeneric> transformThreatPreventionRulesToGeneric(List<ThreatPreventionRule> v1Rules)
+    {
+        LinkedList<RuleGeneric> out = new LinkedList<>();
+        if (v1Rules == null) return out;
+        for (ThreatPreventionRule rule : v1Rules) {
+            out.add(toGeneric(rule));
+        }
+        return out;
+    }
+
+    /**
+     * Transforms a single ThreatPreventionRule into its RuleGeneric representation.
+     */
+    private static RuleGeneric toGeneric(ThreatPreventionRule v1)
+    {
+        if (v1 == null) return null;
+        String ruleId = String.valueOf(v1.getRuleId());
+
+        RuleActionGeneric action = new RuleActionGeneric();
+        action.setType(ThreatPreventionApp.ACTION_BLOCK.equals(v1.getAction()) ? RuleActionGeneric.Type.REJECT : RuleActionGeneric.Type.ACCEPT);
+        action.setFlagged(v1.getFlag());
+
+        LinkedList<RuleConditionGeneric> conds = new LinkedList<>();
+        if (v1.getConditions() != null) {
+            for (ThreatPreventionRuleCondition c : v1.getConditions()) {
+                String op = Boolean.TRUE.equals(c.getInvert())
+                        ? Constants.IS_NOT_EQUALS_TO
+                        : Constants.IS_EQUALS_TO;
+                conds.add(new RuleConditionGeneric(op, c.getConditionType(), c.getValue()));
+            }
+        }
+
+        RuleGeneric g = new RuleGeneric(Boolean.TRUE.equals(v1.getEnabled()), v1.getDescription(), ruleId);
+        g.setAction(action);
+        g.setConditions(conds);
+        return g;
+    }
+
+    /**
+     * Transforms a list of generic RuleGeneric into V1 ThreatPreventionRule, preserving
+     * existing V1 rule objects (matched by ruleId) and removing orphaned rules.
+     * Used by setSettingsV2().
+     *
+     * @param genRules    list of V2 RuleGeneric objects from the UI
+     * @param legacyRules current V1 ThreatPreventionRule list (to preserve internal state
+     *                    on update and detect deletions)
+     * @return list of updated/preserved V1 ThreatPreventionRule objects
+     */
+    public static List<ThreatPreventionRule> transformGenericToThreatPreventionRules(
+            LinkedList<RuleGeneric> genRules, List<ThreatPreventionRule> legacyRules)
+    {
+        if (legacyRules == null) legacyRules = new LinkedList<>();
+
+        RuleGeneric.deleteOrphanRules(
+                genRules, legacyRules,
+                RuleGeneric::getRuleId,
+                r -> String.valueOf(r.getRuleId()));
+
+        Map<Integer, ThreatPreventionRule> rulesMap = legacyRules.stream()
+                .collect(Collectors.toMap(ThreatPreventionRule::getRuleId, Function.identity()));
+
+        List<ThreatPreventionRule> out = new LinkedList<>();
+        for (RuleGeneric g : genRules) {
+            ThreatPreventionRule existing = rulesMap.get(StringUtil.getInstance().parseInt(g.getRuleId(), 0));
+            out.add(toLegacy(g, existing));
+        }
+        return out;
+    }
+
+    /**
+     * Transforms a single RuleGeneric back into a V1 ThreatPreventionRule, mutating the
+     * passed-in existing rule (or creating a new one if null).
+     */
+    private static ThreatPreventionRule toLegacy(RuleGeneric g, ThreatPreventionRule existing)
+    {
+        if (g == null) return existing;
+        if (existing == null) existing = new ThreatPreventionRule();
+        existing.setEnabled(g.isEnabled());
+        existing.setDescription(g.getDescription());
+        existing.setRuleId(StringUtil.getInstance().parseInt(g.getRuleId(), -1));
+
+        if (g.getAction() != null) {
+            existing.setAction(g.getAction().getType() == RuleActionGeneric.Type.REJECT
+                    ? ThreatPreventionApp.ACTION_BLOCK
+                    : ThreatPreventionApp.ACTION_PASS);
+            existing.setFlag(Boolean.TRUE.equals(g.getAction().getFlagged()));
+        }
+
+        List<ThreatPreventionRuleCondition> conds = new LinkedList<>();
+        if (g.getConditions() != null) {
+            for (RuleConditionGeneric gc : g.getConditions()) {
+                ThreatPreventionRuleCondition c = new ThreatPreventionRuleCondition();
+                c.setInvert(Constants.IS_NOT_EQUALS_TO.equals(gc.getOp()));
+                c.setConditionType(gc.getType());
+                c.setValue(gc.getValue());
+                conds.add(c);
+            }
+        }
+        existing.setConditions(conds);
+        return existing;
+    }
 }
 

--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionSettings.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionSettings.java
@@ -6,6 +6,7 @@ package com.untangle.app.threat_prevention;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import com.untangle.app.threat_prevention.generic.ThreatPreventionSettingsGeneric;
 import com.untangle.uvm.app.GenericRule;
 
 import java.io.Serializable;
@@ -78,6 +79,23 @@ public class ThreatPreventionSettings implements Serializable, JSONString
     {
         JSONObject jO = new JSONObject(this);
         return jO.toString();
+    }
+
+    /**
+     * Transforms this V1 settings into a V2 generic settings object.
+     * Used by getSettingsV2().
+     *
+     * @return a new ThreatPreventionSettingsGeneric object populated from this V1 object
+     */
+    public ThreatPreventionSettingsGeneric transformThreatPreventionSettingsToGeneric() {
+        ThreatPreventionSettingsGeneric g = new ThreatPreventionSettingsGeneric();
+        g.setReputationThreshold(this.reputationThreshold);
+        g.setThreat_prevention_rules(ThreatPreventionRule.transformThreatPreventionRulesToGeneric(this.rules));
+        g.setPassSites(this.passSites != null ? new LinkedList<>(this.passSites) : new LinkedList<>());
+        g.setCustomBlockPageEnabled(this.customBlockPageEnabled);
+        g.setCustomBlockPageUrl(this.customBlockPageUrl);
+        g.setCloseHttpsBlockEnabled(this.closeHttpsBlockEnabled);
+        return g;
     }
 
 }

--- a/threat-prevention/src/com/untangle/app/threat-prevention/generic/ThreatPreventionSettingsGeneric.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/generic/ThreatPreventionSettingsGeneric.java
@@ -1,0 +1,73 @@
+/**
+ * $Id$
+ */
+package com.untangle.app.threat_prevention.generic;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+
+import org.json.JSONObject;
+import org.json.JSONString;
+
+import com.untangle.app.threat_prevention.ThreatPreventionRule;
+import com.untangle.app.threat_prevention.ThreatPreventionSettings;
+import com.untangle.uvm.app.GenericRule;
+import com.untangle.uvm.generic.RuleGeneric;
+
+/**
+ * Generic (V2) settings for the Threat Prevention app, consumed by the Vue UI.
+ */
+@SuppressWarnings("serial")
+public class ThreatPreventionSettingsGeneric implements Serializable, JSONString {
+    private Integer reputationThreshold = 20;
+    
+    private LinkedList<RuleGeneric> threat_prevention_rules = new LinkedList<>();
+    private LinkedList<GenericRule> passSites = new LinkedList<>();
+
+    private Boolean customBlockPageEnabled = false;
+    private String customBlockPageUrl = "";
+    private Boolean closeHttpsBlockEnabled = false;
+
+    public String toJSONString() {
+        JSONObject jO = new JSONObject(this);
+        return jO.toString();
+    }
+
+    public Integer getReputationThreshold() { return reputationThreshold; }
+    public void setReputationThreshold(Integer reputationThreshold) { this.reputationThreshold = reputationThreshold; }
+
+    public LinkedList<RuleGeneric> getThreat_prevention_rules() { return threat_prevention_rules;}
+    public void setThreat_prevention_rules(LinkedList<RuleGeneric> threat_prevention_rules) { this.threat_prevention_rules = threat_prevention_rules; }
+
+    public LinkedList<GenericRule> getPassSites() { return passSites; }
+    public void setPassSites(LinkedList<GenericRule> passSites) { this.passSites = passSites; }
+
+    public Boolean getCustomBlockPageEnabled() { return customBlockPageEnabled; }
+    public void setCustomBlockPageEnabled(Boolean customBlockPageEnabled) { this.customBlockPageEnabled = customBlockPageEnabled; }
+    
+    public String getCustomBlockPageUrl() { return customBlockPageUrl; }
+    public void setCustomBlockPageUrl(String customBlockPageUrl) { this.customBlockPageUrl = customBlockPageUrl; }
+
+    public Boolean getCloseHttpsBlockEnabled() { return closeHttpsBlockEnabled; }
+    public void setCloseHttpsBlockEnabled(Boolean closeHttpsBlockEnabled) { this.closeHttpsBlockEnabled = closeHttpsBlockEnabled; }
+
+    /**
+     * Transforms this V2 generic settings back into a V1 ThreatPreventionSettings object.
+     * Mutates the passed-in v1 object in place so that V1-only fields (e.g. version)
+     * are preserved. Used by setSettingsV2().
+     *
+     * @param v1 deep-cloned V1 settings (mutated in place)
+     * @return the same v1 reference, populated from this V2 object
+     */
+    public ThreatPreventionSettings transformGenericToThreatPreventionSettings(ThreatPreventionSettings v1) {
+        if (v1 == null) v1 = new ThreatPreventionSettings();
+        v1.setReputationThreshold(this.reputationThreshold);
+        v1.setRules(ThreatPreventionRule.transformGenericToThreatPreventionRules(this.threat_prevention_rules, v1.getRules()));
+        v1.setPassSites(this.passSites != null ? new LinkedList<>(this.passSites) : new LinkedList<>());
+        v1.setCustomBlockPageEnabled(this.customBlockPageEnabled);
+        v1.setCustomBlockPageUrl(this.customBlockPageUrl);
+        v1.setCloseHttpsBlockEnabled(this.closeHttpsBlockEnabled);
+        return v1;
+    }
+
+}

--- a/uvm/api/com/untangle/uvm/generic/RuleActionGeneric.java
+++ b/uvm/api/com/untangle/uvm/generic/RuleActionGeneric.java
@@ -20,7 +20,7 @@ public class RuleActionGeneric implements JSONString, Serializable {
      * DNAT - Required for Port Forward Rules
      * SNAT, MASQUERADE - Required for NAT Rules
      * BYPASS, PROCESS - Required for Bypass Rules
-     * ACCEPT, REJECT - Required for Filter, Access, UPnP and Web Filter Rules
+     * ACCEPT, REJECT - Required for Filter, Access, UPnP, Web Filter, Firewall and Threat Prevention Rules
      * PRIORITY - Required for QoS Rules
      * SCAN, PASS - Required for Shield Rules
      * TARGET_POLICY - Required for Policy Manager
@@ -34,7 +34,7 @@ public class RuleActionGeneric implements JSONString, Serializable {
     public Type getType() { return type; }
     public void setType(Type type) { this.type = type; }
 
-    // Required for Web Filter Rules indicates the rule should flag matching traffic
+    // Required for Web Filter, Firewall and Threat Prevention Rules indicates the rule should flag matching traffic
     private Boolean flagged;
 
     public Boolean getFlagged() { return flagged; }


### PR DESCRIPTION
## Summary

Add V2 settings APIs (`getSettingsV2`/`setSettingsV2`) to the Threat Prevention app, enabling the Vue UI to consume and save settings using the flat generic format without jabsorb `javaClass`/`list` wrapper nodes.


## Testing

1. Start the NGFW appliance with Threat Prevention installed and running
2. Call `getSettingsV2()` via JSON-RPC — verify the response is flat JSON (no `{javaClass, list}` wrappers), rules use `RuleGeneric` with `action.type` as `REJECT`/`ACCEPT`, conditions have `op` as `"=="`/`"!="`
3. Call `setSettingsV2(getSettingsV2())` — verify round-trip preserves all settings (rule count, `reputationThreshold`, pass sites, block page settings)
4. Add a new rule via V2 with a UUID `ruleId` — verify it gets reassigned a numeric ID by `setSettings()`
5. Delete a rule from the V2 payload — verify `deleteOrphanRules` removes it from V1
6. Verify V1-only fields (`version`, `action`, `flag`) survive the round-trip unchanged

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
