### PR TITLE
NGFW-15918: restore original root CA before test cleanup

### DIFF
--- a/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
+++ b/uvm/hier/usr/lib/python3/dist-packages/tests/test_administration.py
@@ -509,6 +509,7 @@ class AdministrationTests(NGFWTestCase):
         cert_mgr = global_functions.uvmContext.certificateManager()
         certificates_dir = '/usr/share/untangle/settings/untangle-certificates'
         initial_root_dirs = set(glob(join(certificates_dir, '[0-9]*/')))
+        original_active_ca = os.path.realpath(join(certificates_dir, 'untangle.crt'))
 
         try:
             resp = cert_mgr.uploadCertificate("ROOT", certData, keyData, "")
@@ -548,7 +549,13 @@ class AdministrationTests(NGFWTestCase):
                 f"serial content mismatch: crt={crt_serial} file={file_serial}"
 
         finally:
-            # Cleanup - removeCertificate("ROOT") takes absolute path to untangle.crt
+            # Restore the original active root CA before deleting the test cert.
+            # uploadCertificate("ROOT") re-points the active CA symlinks to the
+            # new directory; without restoring, removeCertificate("ROOT") deletes
+            # the active CA directory, breaking SSL Inspector MITM cert generation.
+            original_ca_dir = os.path.dirname(original_active_ca)
+            if original_ca_dir and os.path.isdir(original_ca_dir):
+                cert_mgr.setActiveRootCertificate(join(original_ca_dir, "untangle.crt"))
             for d in set(glob(join(certificates_dir, '[0-9]*/'))) - initial_root_dirs:
                 cert_mgr.removeCertificate("ROOT", join(d, "untangle.crt"))
 


### PR DESCRIPTION
test_026_upload_root_certificate uploads a new root CA which becomes the active CA (symlinks re-pointed). The finally: block then deletes that directory, breaking all active CA symlinks and silently disabling SSL Inspector MITM cert generation for subsequent test suites.

Save the original active CA path before the test and restore it via setActiveRootCertificate() before deleting the test cert directory.