### PR TITLE
ngfw-15946 Preserve old behviour on upgrade for UNT-33 fix

### DIFF
--- a/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
+++ b/ssl-inspector/hier/usr/lib/python3/dist-packages/tests/test_ssl_inspector.py
@@ -328,21 +328,28 @@ class SslInspectorTests(NGFWTestCase):
             assert( found )
 
     def test_100_hostnameVerificationEnabled(self):
-        """Verify hostname verification enabled by default, normal HTTPS works without bypass pipe"""
+        """Verify hostname verification disabled by default, enable and verify normal HTTPS works without bypass pipe"""
         appData = self._app.getSettings()
-        assert appData.get('verifyServerCertHostname') == True
-        result = remote_control.run_command(global_functions.build_curl_command(uri="https://" + testedServerName + "/"))
-        assert (result == 0)
-        events = global_functions.get_events('SSL Inspector', 'All Sessions', None, 5)
-        event = global_functions.find_event(events.get('list'), 5,
-            "ssl_inspector_status", "INSPECTED",
-            "ssl_inspector_detail", testedServerName)
-        assert event is not None
-        assert hostnameVerifyBypassDetail not in event.get("ssl_inspector_detail", "")
+        assert appData.get('verifyServerCertHostname') == False
+        appData['verifyServerCertHostname'] = True
+        self._app.setSettings(appData)
+        try:
+            result = remote_control.run_command(global_functions.build_curl_command(uri="https://" + testedServerName + "/"))
+            assert (result == 0)
+            events = global_functions.get_events('SSL Inspector', 'All Sessions', None, 5)
+            event = global_functions.find_event(events.get('list'), 5,
+                "ssl_inspector_status", "INSPECTED",
+                "ssl_inspector_detail", testedServerName)
+            assert event is not None
+            assert hostnameVerifyBypassDetail not in event.get("ssl_inspector_detail", "")
+        finally:
+            appData['verifyServerCertHostname'] = False
+            self._app.setSettings(appData)
 
     def test_101_hostnameVerificationBypassList(self):
         """Verify bypass list entry adds bypass pipe to detail"""
         appData = self._app.getSettings()
+        appData['verifyServerCertHostname'] = True
         appData['hostnameVerificationBypassList']['list'].append(createHostnameBypassRule(testedServerName))
         self._app.setSettings(appData)
         try:
@@ -353,11 +360,15 @@ class SslInspectorTests(NGFWTestCase):
             assert event is not None
             assert hostnameVerifyBypassDetail in event.get("ssl_inspector_detail", "")
         finally:
+            appData['verifyServerCertHostname'] = False
             appData['hostnameVerificationBypassList']['list'] = []
             self._app.setSettings(appData)
 
     def test_102_hostnameVerificationGlobalDisable(self):
         """Verify global disable adds bypass pipe to detail"""
+        appData = self._app.getSettings()
+        appData['verifyServerCertHostname'] = True
+        self._app.setSettings(appData)
         appData = self._app.getSettings()
         appData['verifyServerCertHostname'] = False
         self._app.setSettings(appData)
@@ -369,12 +380,13 @@ class SslInspectorTests(NGFWTestCase):
             assert event is not None
             assert hostnameVerifyBypassDetail in event.get("ssl_inspector_detail", "")
         finally:
-            appData['verifyServerCertHostname'] = True
+            appData['verifyServerCertHostname'] = False
             self._app.setSettings(appData)
 
     def test_103_hostnameVerificationBlindTrust(self):
         """Verify blind trust skips hostname verification without bypass pipe"""
         appData = self._app.getSettings()
+        appData['verifyServerCertHostname'] = True
         appData['serverBlindTrust'] = True
         self._app.setSettings(appData)
         try:
@@ -385,12 +397,14 @@ class SslInspectorTests(NGFWTestCase):
             assert event is not None
             assert hostnameVerifyBypassDetail not in event.get("ssl_inspector_detail", "")
         finally:
+            appData['verifyServerCertHostname'] = False
             appData['serverBlindTrust'] = False
             self._app.setSettings(appData)
 
     def test_104_hostnameVerificationWildcardBypass(self):
         """Verify wildcard bypass entry matches and adds bypass pipe"""
         appData = self._app.getSettings()
+        appData['verifyServerCertHostname'] = True
         appData['hostnameVerificationBypassList']['list'].append(createHostnameBypassRule(testedServerDomainWildcard, description="wildcard test"))
         self._app.setSettings(appData)
         try:
@@ -401,12 +415,14 @@ class SslInspectorTests(NGFWTestCase):
             assert event is not None
             assert hostnameVerifyBypassDetail in event.get("ssl_inspector_detail", "")
         finally:
+            appData['verifyServerCertHostname'] = False
             appData['hostnameVerificationBypassList']['list'] = []
             self._app.setSettings(appData)
 
     def test_105_hostnameVerificationDisabledBypassEntry(self):
         """Verify disabled bypass entry does not add bypass pipe"""
         appData = self._app.getSettings()
+        appData['verifyServerCertHostname'] = True
         appData['hostnameVerificationBypassList']['list'].append(createHostnameBypassRule(testedServerName, enabled=False, description="disabled entry"))
         self._app.setSettings(appData)
         try:
@@ -419,8 +435,41 @@ class SslInspectorTests(NGFWTestCase):
             assert event is not None
             assert hostnameVerifyBypassDetail not in event.get("ssl_inspector_detail", "")
         finally:
+            appData['verifyServerCertHostname'] = False
             appData['hostnameVerificationBypassList']['list'] = []
             self._app.setSettings(appData)
+
+    def test_106_hostnameVerificationGlobalBypassPropagation(self):
+        """Verify global bypass entries propagate across SSL Inspector instances"""
+        # verify both start with empty bypass lists
+        list1 = getHostnameBypassList(self._app)
+        list2 = getHostnameBypassList(ssl_app_2)
+        assert len(list1) == 0, "Instance 1 bypass list should be empty initially"
+        assert len(list2) == 0, "Instance 2 bypass list should be empty initially"
+
+        try:
+            # add a global entry and a non-global entry on instance 1
+            addHostnameBypassEntry(self._app, "global.example.com", isGlobal=True, description="global entry")
+            addHostnameBypassEntry(self._app, "local.example.com", isGlobal=False, description="local entry")
+
+            # verify instance 1 has both entries
+            list1 = getHostnameBypassList(self._app)
+            assert len(list1) == 2, "Instance 1 should have 2 entries, got %d" % len(list1)
+
+            # verify instance 2 has only the global entry
+            list2 = getHostnameBypassList(ssl_app_2)
+            assert len(list2) == 1, "Instance 2 should have 1 global entry, got %d" % len(list2)
+            assert list2[0]['string'] == "global.example.com"
+
+            # clear all entries on instance 1 (this removes the global entry too)
+            clearHostnameBypassList(self._app)
+
+            # verify instance 2 no longer has the global entry
+            list2 = getHostnameBypassList(ssl_app_2)
+            assert len(list2) == 0, "Instance 2 should have 0 entries after clearing, got %d" % len(list2)
+
+        finally:
+            clearHostnameBypassList(self._app)
 
     def test_551_https_with_sni_packet_split(self):
         """ Verify no exceptions with split Hello TLS packets"""
@@ -690,38 +739,6 @@ class SslInspectorTests(NGFWTestCase):
         assert any("..." in w for w in warns), (
             f"Expected safeForLog truncation marker ('...') in WARN; "
             f"got: {warns}")
-
-    def test_106_hostnameVerificationGlobalBypassPropagation(self):
-        """Verify global bypass entries propagate across SSL Inspector instances"""
-        # verify both start with empty bypass lists
-        list1 = getHostnameBypassList(self._app)
-        list2 = getHostnameBypassList(ssl_app_2)
-        assert len(list1) == 0, "Instance 1 bypass list should be empty initially"
-        assert len(list2) == 0, "Instance 2 bypass list should be empty initially"
-
-        try:
-            # add a global entry and a non-global entry on instance 1
-            addHostnameBypassEntry(self._app, "global.example.com", isGlobal=True, description="global entry")
-            addHostnameBypassEntry(self._app, "local.example.com", isGlobal=False, description="local entry")
-
-            # verify instance 1 has both entries
-            list1 = getHostnameBypassList(self._app)
-            assert len(list1) == 2, "Instance 1 should have 2 entries, got %d" % len(list1)
-
-            # verify instance 2 has only the global entry
-            list2 = getHostnameBypassList(ssl_app_2)
-            assert len(list2) == 1, "Instance 2 should have 1 global entry, got %d" % len(list2)
-            assert list2[0]['string'] == "global.example.com"
-
-            # clear all entries on instance 1 (this removes the global entry too)
-            clearHostnameBypassList(self._app)
-
-            # verify instance 2 no longer has the global entry
-            list2 = getHostnameBypassList(ssl_app_2)
-            assert len(list2) == 0, "Instance 2 should have 0 entries after clearing, got %d" % len(list2)
-
-        finally:
-            clearHostnameBypassList(self._app)
 
     @classmethod
     def final_extra_tear_down(cls):

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorApp.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorApp.java
@@ -186,13 +186,16 @@ public class SslInspectorApp extends AppBase
                     renumberRules = true;
                 }
 
-                // v3 to v4: add hostname verification settings
+                // v3 to v4: add hostname verification settings and port 25 IGNORE rule
                 if (readSettings.getVersion().intValue() < 4) {
                     logger.info("Migrating settings from v{} to v4: adding hostname verification", readSettings.getVersion());
-                    readSettings.setVerifyServerCertHostname(true);
+                    readSettings.setVerifyServerCertHostname(false);
                     readSettings.setHostnameVerificationBypassList(new LinkedList<>());
+                    readSettings.getIgnoreRules().addFirst(createDefaultRule(0, "Ignore SMTP", SslInspectorRuleCondition.ConditionType.DST_PORT, "25", null, null, null, null, SslInspectorRuleAction.ActionType.IGNORE, true));
+
                     readSettings.setVersion(4);
                     setSettings(readSettings);
+                    renumberRules = true;
                 }
 
                 if(renumberRules) {
@@ -418,35 +421,35 @@ public class SslInspectorApp extends AppBase
     }
 
     /**
-     * Reloads instance settings from disk and merges in the global
-     * hostname verification bypass entries.
+     * Merges global hostname verification bypass entries into the
+     * in-memory settings without reloading the full settings from disk.
      */
     public void loadAllGlobalSettings()
     {
-        String appID = this.getAppSettings().getId().toString();
-        String settingsFile = System.getProperty("uvm.settings.dir") + "/ssl-inspector/settings_" + appID + ".js";
-
         try {
-            SslInspectorSettings readSettings = UvmContextFactory.context().settingsManager().load(SslInspectorSettings.class, settingsFile);
-            if (readSettings == null) {
-                logger.warn("Failed to reload settings from {}", settingsFile);
+            if (this.settings == null) {
+                logger.warn("Settings not initialized, skipping global settings merge");
                 return;
-            }
-
-            if (readSettings.getHostnameVerificationBypassList() == null) {
-                readSettings.setHostnameVerificationBypassList(new LinkedList<>());
             }
 
             SslInspectorSettings globalSettings = getGlobalSettings();
             List<GenericRule> globalBypassList = globalSettings.getHostnameVerificationBypassList();
-            if (globalBypassList != null && !globalBypassList.isEmpty()) {
-                readSettings.getHostnameVerificationBypassList().addAll(0, globalBypassList);
-                logger.info("Merged {} global hostname bypass entries into instance {}", globalBypassList.size(), appID);
+
+            LinkedList<GenericRule> currentBypassList = this.settings.getHostnameVerificationBypassList();
+            if (currentBypassList == null) {
+                currentBypassList = new LinkedList<>();
+                this.settings.setHostnameVerificationBypassList(currentBypassList);
             }
 
-            this.settings = readSettings;
+            currentBypassList.removeIf(rule -> rule != null && Boolean.TRUE.equals(rule.getIsGlobal()));
+
+            if (globalBypassList != null && !globalBypassList.isEmpty()) {
+                currentBypassList.addAll(0, globalBypassList);
+                logger.info("Merged {} global hostname bypass entries into instance {}",
+                    globalBypassList.size(), this.getAppSettings().getId());
+            }
         } catch (Exception e) {
-            logger.error("Failed to load settings for instance " + appID, e);
+            logger.error("Failed to merge global hostname bypass settings for instance " + this.getAppSettings().getId(), e);
         }
     }
 
@@ -537,6 +540,7 @@ public class SslInspectorApp extends AppBase
         LinkedList<SslInspectorRule> defaultRules = new LinkedList<>();
         int ruleNumber = 1;
 
+        defaultRules.add(createDefaultRule(ruleNumber++, "Ignore SMTP", SslInspectorRuleCondition.ConditionType.DST_PORT, "25", null, null, null, null, SslInspectorRuleAction.ActionType.IGNORE, true));
         defaultRules.add(createDefaultRule(ruleNumber++, "Ignore Microsoft Update", SslInspectorRuleCondition.ConditionType.SSL_INSPECTOR_SUBJECT_DN, "*update.microsoft*", null, null, null, null, SslInspectorRuleAction.ActionType.IGNORE, true));
         defaultRules.add(createDefaultRule(ruleNumber++, "Ignore GotoMeeting", SslInspectorRuleCondition.ConditionType.SSL_INSPECTOR_SUBJECT_DN, "*citrix*", null, null, null, null, SslInspectorRuleAction.ActionType.IGNORE, true));
         defaultRules.add(createDefaultRule(ruleNumber++, "Ignore Dropbox", SslInspectorRuleCondition.ConditionType.SSL_INSPECTOR_SUBJECT_DN, "*dropbox*", null, null, null, null, SslInspectorRuleAction.ActionType.IGNORE, true));

--- a/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorSettings.java
+++ b/ssl-inspector/src/com/untangle/app/ssl_inspector/SslInspectorSettings.java
@@ -55,7 +55,7 @@ public class SslInspectorSettings implements Serializable, JSONString
         processEncryptedWebTraffic = true;
         blockInvalidTraffic = false;
         serverBlindTrust = false;
-        verifyServerCertHostname = true;
+        verifyServerCertHostname = false;
         hostnameVerificationBypassList = new LinkedList<>();
         javaxDebug = false;
         enabled = true;


### PR DESCRIPTION
## Summary

Preserve pre-UNT-33 SSL Inspector traffic behavior on upgrade by defaulting hostname verification to disabled and adding a default IGNORE rule for port 25 SMTP. Also fixes `loadAllGlobalSettings()` to surgically merge only the global bypass list instead of reloading the entire settings object from disk.

## Motivation

PR #1250 (Mythos UNT-33, commit 5500bbc) added hostname verification and removed the hardcoded port 25 SMTP blind trust bypass. On customer upgrade, these changes immediately alter traffic processing: upstream servers with mismatched certificate hostnames are rejected, and SMTP to servers with self-signed/expired certificates fails. This PR ensures upgrades are non-disruptive by matching pre-UNT-33 behavior out of the box. Customers can opt in to hostname verification manually.

Ticket: NGFW-15946

## Changes

### Backend — Default Behavior (SslInspectorSettings.java, SslInspectorApp.java)
- Change `verifyServerCertHostname` constructor default from `true` to `false`
- Change v3→v4 migration to set `verifyServerCertHostname = false` instead of `true`
- Add "Ignore SMTP" rule (`DST_PORT = 25`, `IGNORE`, enabled) via `addFirst` in v3→v4 migration to preserve port 25 blind trust behavior
- Add same "Ignore SMTP" rule to `generateDefaultRules()` for fresh installs

### Backend — Global Settings Sync Fix (SslInspectorApp.java)
- Rewrite `loadAllGlobalSettings()` to merge only the global hostname bypass entries into the in-memory bypass list instead of reloading the full settings object from disk
  - Removes stale global entries via `removeIf(isGlobal)` before merging fresh ones
  - Eliminates unnecessary per-instance disk I/O during `syncAllInstances()`
  - Prevents overwriting unrelated in-memory settings fields (`processEncryptedMailTraffic`, `serverBlindTrust`, ignore rules, etc.)
- Add null-safety: guard against `this.settings == null` (startup race between instances), null list elements, and wrap in try-catch to prevent one instance's failure from breaking the sync loop

### Tests (test_ssl_inspector.py)
- Update test_100 through test_105 to explicitly enable `verifyServerCertHostname = True` before testing, since the default is now `false`
- Update all `finally` blocks to restore `verifyServerCertHostname = False` (new default)
- test_100 now asserts the default is `False` before enabling
- test_106 (global bypass propagation) unchanged — tests list content, not verification state
- Move test_106 to run sequentially after test_105 (was previously placed after SNI tests)

## Testing

1. **Upgrade scenario**: Verify upgrading from settings version ≤ 3 does not change any traffic blocking decisions
2. **Port 25 SMTP**: Confirm SMTP to servers with self-signed/expired certificates continues working after upgrade
3. **Hostname verification off by default**: Verify no sessions are rejected due to hostname mismatch after upgrade
4. **Opt-in verification**: Enable "Enforce Hostname Match" in UI, verify hostname-mismatched upstream certs are rejected
5. **Global bypass propagation**: Add `isGlobal=true` bypass entry on one instance, verify it appears on SSL Inspector instances in other policy racks
6. **Run automated tests**: for hostname verification tests

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
