### PR TITLE
ngfw-15972 Fixed Threat Classification for metrics and Block Page

### DIFF
--- a/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionApp.java
+++ b/threat-prevention/src/com/untangle/app/threat-prevention/ThreatPreventionApp.java
@@ -321,8 +321,7 @@ public class ThreatPreventionApp extends AppBase
         if(reputation == 0){
             this.incrementMetric(STAT_THREAT_NO_REPUTATION);
         }else{
-            reputation = reputation - (reputation % 20) + 20;
-            switch(reputation){
+            switch(getReputationBand(reputation)){
                 case 100:
                     this.incrementMetric(STAT_THREAT_TRUSTWORTHY);
                     break;
@@ -340,6 +339,19 @@ public class ThreatPreventionApp extends AppBase
                     break;
             }
         }
+    }
+
+    /**
+     * Get the upper bound of the BrightCloud reputation band for a score.
+     * Scores at a band boundary belong to that band, rather than the next
+     * band. For example, both 20 and values 1 through 20 map to 20.
+     *
+     * @param reputation integer reputation score
+     * @return upper bound of the reputation band
+     */
+    private int getReputationBand(int reputation)
+    {
+        return reputation > 0 ? ((reputation - 1) / 20 + 1) * 20 : 0;
     }
 
     /**
@@ -465,7 +477,7 @@ public class ThreatPreventionApp extends AppBase
      */
     String getThreatFromReputation(Integer reputation)
     {
-        return ReputationThreatMap.get(reputation > 0 ? ( reputation - (reputation % 20) + 20 ) : 0);
+        return ReputationThreatMap.get(reputation == null ? 0 : getReputationBand(reputation));
     }
 
     /**


### PR DESCRIPTION
## Summary

  Fix BrightCloud reputation classification for Threat Prevention metrics and block-page messages.

  ## Motivation

  Reputation scores at exact band boundaries (20, 40, 60, 80, 100) were incorrectly rounded into the next band. Score 100 was not classified at
  all.

  ## Changes

  - Added shared BrightCloud reputation-band calculation.
  - Corrected incrementThreatCount() metric classification.
  - Corrected getThreatFromReputation() block-page labels.
  - Added null handling so missing reputation is treated as No reputation.
  - Preserved existing reputation decision and threshold logic.

  ## Expected Mapping

  - 1–20: High Risk
  - 21–40: Suspicious
  - 41–60: Moderate Risk
  - 61–80: Low Risk
  - 81–100: Trustworthy