### PR TITLE
ngfw-15990 Get all interface status fix

### DIFF
--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -48,6 +48,7 @@ import com.untangle.uvm.util.ObjectMatcher;
 import com.untangle.uvm.util.StringUtil;
 
 import org.apache.commons.lang3.SerializationUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jabsorb.serializer.UnmarshallException;
@@ -690,11 +691,6 @@ public class NetworkManagerImpl implements NetworkManager
      */
     private void populateTransferStats(InterfaceStatusGeneric status, InterfaceSettings intf) {
         try {
-            if (!isValidRuntimeInterface(intf.getSymbolicDev())) {
-                logger.warn("Skipping transfer statistics for invalid interface {}", intf.getSymbolicDev());
-                return;
-            }
-
             String intfTransfer = getStatus(StatusCommands.INTERFACE_TRANSFER, intf.getSymbolicDev());
             if (intfTransfer == null || intfTransfer.trim().isEmpty()) return;
             String[] stats = intfTransfer.trim().split("\\s+");
@@ -749,11 +745,6 @@ public class NetworkManagerImpl implements NetworkManager
      */
     private void populateIpAddresses(InterfaceStatusGeneric status, InterfaceSettings intf) {
         try {
-            if (!isValidRuntimeInterface(intf.getSymbolicDev())) {
-                logger.warn("Skipping IP addresses for invalid interface {}", intf.getSymbolicDev());
-                return;
-            }
-
             String ipStatus = getStatus(StatusCommands.INTERFACE_IP_ADDRESSES, intf.getSymbolicDev());
             if (ipStatus == null || ipStatus.trim().isEmpty()) return;
             String[] tokens = ipStatus.trim().split("\\s+");
@@ -871,31 +862,15 @@ public class NetworkManagerImpl implements NetworkManager
         }
     }
 
-    /** 
-     * Safely parses integer, returns 0 if invalid. 
-     * @param str String
-     * @return int 
+    /**
+     * Converts a string to a long, returning zero when the input is null,
+     * malformed, or outside the valid long range.
+     *
+     * @param str the string to convert
+     * @return the converted long value, or {@code 0L} when conversion fails
      */
     private long parseLongSafe(String str) {
-        if (str == null || !str.matches("-?\\d+")) return 0;
-        try {
-            return Long.parseLong(str);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
-    }
-
-    /**
-     * Checks whether a configured device is currently safe to pass to the
-     * interface status script. The check is repeated by getStatus(), since a
-     * device can disappear between this check and command execution.
-     * 
-     * @param device the configured device name (e.g., eth0, eth1.12, wlan0)
-     * @return true if the device is valid, false otherwise
-     */
-    private boolean isValidRuntimeInterface(String device) {
-        if (device == null || !device.matches(INTERFACE_NAME_PATTERN)) return false;
-        return device.startsWith("ppp") || Files.exists(Paths.get("/sys/class/net", device));
+        return NumberUtils.toLong(str, 0L);
     }
 
     /**

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -627,9 +627,15 @@ public class NetworkManagerImpl implements NetworkManager
      * @return List of InterfaceStatusGeneric
      */
     public List<InterfaceStatusGeneric> getAllInterfacesStatusV2() {
-        List<DeviceStatus> deviceStatusList = getDeviceStatus();
+        if (networkSettings == null || networkSettings.getInterfaces() == null) {
+            logger.warn("Unable to get interface status: network settings are unavailable");
+            return new LinkedList<>();
+        }
+
+        List<DeviceStatus> deviceStatusList = getDeviceStatusOrEmpty();
 
         return networkSettings.getInterfaces().stream()
+                .filter(Objects::nonNull)
                 .map(intf -> buildInterfaceStatus(intf.resolveDeviceName(), intf, deviceStatusList))
                 .collect(Collectors.toCollection(LinkedList::new));
     }
@@ -640,9 +646,14 @@ public class NetworkManagerImpl implements NetworkManager
      * @return InterfaceStatusGeneric for the device, or null if not found
      */
     public InterfaceStatusGeneric getInterfaceStatusV2(String device) {
-        List<DeviceStatus> deviceStatusList = getDeviceStatus();
+        if (networkSettings == null || networkSettings.getInterfaces() == null || device == null) {
+            return null;
+        }
+
+        List<DeviceStatus> deviceStatusList = getDeviceStatusOrEmpty();
 
         return networkSettings.getInterfaces().stream()
+                .filter(Objects::nonNull)
                 .filter(intf -> device.equals(intf.resolveDeviceName()))
                 .findFirst()
                 .map(intf -> buildInterfaceStatus(device, intf, deviceStatusList))
@@ -663,7 +674,7 @@ public class NetworkManagerImpl implements NetworkManager
         status.setWan(intf.getIsWan());
         status.setInterfaceId(intf.getInterfaceId());
         populateTransferStats(status, intf);
-        populateMacVendor(status);
+        populateMacVendor(status, intf);
         populateIpAddresses(status, intf);
         populateConnectionStatus(status, intf, deviceStatusList);
         populateGatewayAndDns(status, intf);
@@ -678,41 +689,56 @@ public class NetworkManagerImpl implements NetworkManager
      * @param intf InterfaceSettings
      */
     private void populateTransferStats(InterfaceStatusGeneric status, InterfaceSettings intf) {
-        String intfTransfer = getStatus(StatusCommands.INTERFACE_TRANSFER, intf.getSymbolicDev());
-        String[] stats = intfTransfer.trim().split("\\s+");
+        try {
+            if (!isValidRuntimeInterface(intf.getSymbolicDev())) {
+                logger.warn("Skipping transfer statistics for invalid interface {}", intf.getSymbolicDev());
+                return;
+            }
 
-        if (stats.length < 12) return;
+            String intfTransfer = getStatus(StatusCommands.INTERFACE_TRANSFER, intf.getSymbolicDev());
+            if (intfTransfer == null || intfTransfer.trim().isEmpty()) return;
+            String[] stats = intfTransfer.trim().split("\\s+");
 
-        status.setMacAddress(stats[1]);
-        status.setRxbytes(parseLongSafe(stats[2]));
-        status.setRxpkts(parseLongSafe(stats[3]));
-        status.setRxerr(parseLongSafe(stats[4]));
-        status.setRxdrop(parseLongSafe(stats[5]));
-        status.setTxbytes(parseLongSafe(stats[8]));
-        status.setTxpkts(parseLongSafe(stats[9]));
-        status.setTxerr(parseLongSafe(stats[10]));
-        status.setTxdrop(parseLongSafe(stats[11]));
+            if (stats.length < 12) return;
+
+            status.setMacAddress(stats[1]);
+            status.setRxbytes(parseLongSafe(stats[2]));
+            status.setRxpkts(parseLongSafe(stats[3]));
+            status.setRxerr(parseLongSafe(stats[4]));
+            status.setRxdrop(parseLongSafe(stats[5]));
+            status.setTxbytes(parseLongSafe(stats[8]));
+            status.setTxpkts(parseLongSafe(stats[9]));
+            status.setTxerr(parseLongSafe(stats[10]));
+            status.setTxdrop(parseLongSafe(stats[11]));
+        } catch (Exception e) {
+            logger.warn("Unable to populate transfer statistics for interface {}", intf.getInterfaceId(), e);
+        }
     }
 
     /** 
      * Adds vendor name based on MAC address to the InterfaceStatusGeneric object. 
      * @param status InterfaceStatusGeneric
+     * @param intf InterfaceSettings
      */
-    private void populateMacVendor(InterfaceStatusGeneric status) {
-        String vendor = null;
-        if(status.getMacAddress() != null) {
-            if (cachedMacAddrVendorList.containsKey(status.getMacAddress())) {
-                vendor = cachedMacAddrVendorList.get(status.getMacAddress());
-            } else {
-                vendor = UvmContextFactory.context()
-                            .deviceTable()
-                            .getMacVendorFromMacAddress(status.getMacAddress());
-                if (!StringUtil.isEmpty(vendor)) {
-                    cachedMacAddrVendorList.put(status.getMacAddress(), vendor);
+    private void populateMacVendor(InterfaceStatusGeneric status, InterfaceSettings intf) {
+        try {
+            String vendor = null;
+            if(status.getMacAddress() != null) {
+                if (cachedMacAddrVendorList.containsKey(status.getMacAddress())) {
+                    vendor = cachedMacAddrVendorList.get(status.getMacAddress());
+                } else {
+                    vendor = UvmContextFactory.context()
+                                .deviceTable()
+                                .getMacVendorFromMacAddress(status.getMacAddress());
+                    if (!StringUtil.isEmpty(vendor)) {
+                        cachedMacAddrVendorList.put(status.getMacAddress(), vendor);
+                    }
                 }
             }
+            status.setMacVendor(vendor);
+        } catch (Exception e) {
+            logger.warn("Unable to populate MAC vendor for interface {}", intf.getInterfaceId(), e);
         }
-        status.setMacVendor(vendor);
     }
 
     /** 
@@ -722,23 +748,33 @@ public class NetworkManagerImpl implements NetworkManager
      * @param intf InterfaceSettings
      */
     private void populateIpAddresses(InterfaceStatusGeneric status, InterfaceSettings intf) {
-        String ipStatus = getStatus(StatusCommands.INTERFACE_IP_ADDRESSES, intf.getSymbolicDev());
-        String[] tokens = ipStatus.trim().split("\\s+");
-
-        String nextType = "";
-        for (String token : tokens) {
-            if (INET.equals(nextType)) {
-                if(status.getIp4Addr() == null)
-                    status.setIp4Addr(new LinkedList<>());
-                status.getIp4Addr().add(token);
-            } else if (INET6.equals(nextType)) {
-                if(status.getIp6Addr() == null)
-                    status.setIp6Addr(new LinkedList<>());
-                status.getIp6Addr().add(token);
+        try {
+            if (!isValidRuntimeInterface(intf.getSymbolicDev())) {
+                logger.warn("Skipping IP addresses for invalid interface {}", intf.getSymbolicDev());
+                return;
             }
-            nextType = "";
-            if (INET.equals(token)) nextType = INET;
-            else if (INET6.equals(token)) nextType = INET6;
+
+            String ipStatus = getStatus(StatusCommands.INTERFACE_IP_ADDRESSES, intf.getSymbolicDev());
+            if (ipStatus == null || ipStatus.trim().isEmpty()) return;
+            String[] tokens = ipStatus.trim().split("\\s+");
+
+            String nextType = "";
+            for (String token : tokens) {
+                if (INET.equals(nextType)) {
+                    if(status.getIp4Addr() == null)
+                        status.setIp4Addr(new LinkedList<>());
+                    status.getIp4Addr().add(token);
+                } else if (INET6.equals(nextType)) {
+                    if(status.getIp6Addr() == null)
+                        status.setIp6Addr(new LinkedList<>());
+                    status.getIp6Addr().add(token);
+                }
+                nextType = "";
+                if (INET.equals(token)) nextType = INET;
+                else if (INET6.equals(token)) nextType = INET6;
+            }
+        } catch (Exception e) {
+            logger.warn("Unable to populate IP addresses for interface {}", intf.getInterfaceId(), e);
         }
     }
 
@@ -749,21 +785,26 @@ public class NetworkManagerImpl implements NetworkManager
      * @param deviceStatusList List<DeviceStatus>
      */
     private void populateConnectionStatus(InterfaceStatusGeneric status, InterfaceSettings intf, List<DeviceStatus> deviceStatusList) {
-        for (DeviceStatus ds : deviceStatusList) {
-            if (ds.getDeviceName().equals(intf.getPhysicalDev())) {
-                boolean isConnected = ConnectedStatus.CONNECTED.equals(ds.getConnected());
-                DuplexStatus duplex = ds.getDuplex();
+        try {
+            if (deviceStatusList == null || intf.getPhysicalDev() == null) return;
+            for (DeviceStatus ds : deviceStatusList) {
+                if (ds != null && intf.getPhysicalDev().equals(ds.getDeviceName())) {
+                    boolean isConnected = ConnectedStatus.CONNECTED.equals(ds.getConnected());
+                    DuplexStatus duplex = ds.getDuplex();
 
-                status.setConnected(isConnected);
-                status.setOffline(!isConnected);
-                status.setEthSpeed(ds.getMbit());
+                    status.setConnected(isConnected);
+                    status.setOffline(!isConnected);
+                    status.setEthSpeed(ds.getMbit());
 
-                if (duplex == DuplexStatus.FULL_DUPLEX) status.setEthDuplex("full");
-                else if(duplex == DuplexStatus.HALF_DUPLEX) status.setEthDuplex("half");
-                else status.setEthDuplex(DuplexStatus.UNKNOWN.toString().toLowerCase());
-                
-                return;
+                    if (duplex == DuplexStatus.FULL_DUPLEX) status.setEthDuplex("full");
+                    else if(duplex == DuplexStatus.HALF_DUPLEX) status.setEthDuplex("half");
+                    else status.setEthDuplex(DuplexStatus.UNKNOWN.toString().toLowerCase());
+
+                    return;
+                }
             }
+        } catch (Exception e) {
+            logger.warn("Unable to populate connection status for interface {}", intf.getInterfaceId(), e);
         }
     }
 
@@ -773,18 +814,23 @@ public class NetworkManagerImpl implements NetworkManager
      * @param intf InterfaceSettings
      */
     private void populateGatewayAndDns(InterfaceStatusGeneric status, InterfaceSettings intf) {
-        InterfaceStatus intfStatus = getInterfaceStatus(intf.getInterfaceId());
-        List<InetAddress> dns = Stream.of(intfStatus.getV4Dns1(), intfStatus.getV4Dns2())
-                                .filter(Objects::nonNull)
-                                .collect(Collectors.toList());
-        if (!dns.isEmpty()) {
-            if (status.getDnsServers() == null)
-                status.setDnsServers(new LinkedList<>());
-            status.getDnsServers().addAll(dns);
+        try {
+            InterfaceStatus intfStatus = getInterfaceStatus(intf.getInterfaceId());
+            if (intfStatus == null) return;
+            List<InetAddress> dns = Stream.of(intfStatus.getV4Dns1(), intfStatus.getV4Dns2())
+                                    .filter(Objects::nonNull)
+                                    .collect(Collectors.toList());
+            if (!dns.isEmpty()) {
+                if (status.getDnsServers() == null)
+                    status.setDnsServers(new LinkedList<>());
+                status.getDnsServers().addAll(dns);
+            }
+            status.setV4Address(intfStatus.getV4Address());
+            status.setIp4Gateway(intfStatus.getV4Gateway());
+            status.setIp6Gateway(intfStatus.getV6Gateway());
+        } catch (Exception e) {
+            logger.warn("Unable to populate gateway and DNS for interface {}", intf.getInterfaceId(), e);
         }
-        status.setV4Address(intfStatus.getV4Address());
-        status.setIp4Gateway(intfStatus.getV4Gateway());
-        status.setIp6Gateway(intfStatus.getV6Gateway());
     }
 
     /** Populates IPv4/IPv6 address source (dhcp/static/pppoe
@@ -792,32 +838,36 @@ public class NetworkManagerImpl implements NetworkManager
     * @param intf InterfaceSettings
     */
     private void populateAddressSources(InterfaceStatusGeneric status, InterfaceSettings intf) {
-        if (intf.getConfigType() != ConfigType.ADDRESSED) return;
+        try {
+            if (intf.getConfigType() != ConfigType.ADDRESSED) return;
 
-        // Ensure lists are initialized
-        if(status.getAddressSource() == null)
-            status.setAddressSource(new LinkedList<>());
-        if(status.getIp6addressSource() == null && intf.getV6ConfigType() != V6ConfigType.DISABLED)
-            status.setIp6addressSource(new LinkedList<>());
-        
-        // Handle IPv4 address source
-        V4ConfigType v4Type = intf.getV4ConfigType();
-        switch (v4Type) {
-            case AUTO: 
-                status.getAddressSource().add(DHCP); break;
-            case PPPOE: 
-            case STATIC: {
-                status.getAddressSource().add(v4Type.name().toLowerCase()); break;
+            // Ensure lists are initialized
+            if(status.getAddressSource() == null)
+                status.setAddressSource(new LinkedList<>());
+            if(status.getIp6addressSource() == null && intf.getV6ConfigType() != V6ConfigType.DISABLED)
+                status.setIp6addressSource(new LinkedList<>());
+
+            // Handle IPv4 address source
+            V4ConfigType v4Type = intf.getV4ConfigType();
+            if (v4Type != null) switch (v4Type) {
+                case AUTO:
+                    status.getAddressSource().add(DHCP); break;
+                case PPPOE:
+                case STATIC: {
+                    status.getAddressSource().add(v4Type.name().toLowerCase()); break;
+                }
             }
-        }
 
-        // Handle IPv6 address source
-        V6ConfigType v6Type = intf.getV6ConfigType();
-        switch (v6Type) {
-            case AUTO: 
-                status.getIp6addressSource().add(DHCPV6); break;
-            case STATIC: 
-                status.getIp6addressSource().add(v6Type.name().toLowerCase()); break;
+            // Handle IPv6 address source
+            V6ConfigType v6Type = intf.getV6ConfigType();
+            if (v6Type != null) switch (v6Type) {
+                case AUTO:
+                    status.getIp6addressSource().add(DHCPV6); break;
+                case STATIC:
+                    status.getIp6addressSource().add(v6Type.name().toLowerCase()); break;
+            }
+        } catch (Exception e) {
+            logger.warn("Unable to populate address sources for interface {}", intf.getInterfaceId(), e);
         }
     }
 
@@ -827,7 +877,44 @@ public class NetworkManagerImpl implements NetworkManager
      * @return int 
      */
     private long parseLongSafe(String str) {
-        return str.matches("-?\\d+") ? Long.parseLong(str) : 0;
+        if (str == null || !str.matches("-?\\d+")) return 0;
+        try {
+            return Long.parseLong(str);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Checks whether a configured device is currently safe to pass to the
+     * interface status script. The check is repeated by getStatus(), since a
+     * device can disappear between this check and command execution.
+     * 
+     * @param device the configured device name (e.g., eth0, eth1.12, wlan0)
+     * @return true if the device is valid, false otherwise
+     */
+    private boolean isValidRuntimeInterface(String device) {
+        if (device == null || !device.matches(INTERFACE_NAME_PATTERN)) return false;
+        return device.startsWith("ppp") || Files.exists(Paths.get("/sys/class/net", device));
+    }
+
+    /**
+     * Gets device statuses for interface status responses.
+     *
+     * Device status is optional data for the V2 response. If it cannot be
+     * retrieved or parsed, return an empty list so the remaining interface
+     * status fields can still be returned.
+     *
+     * @return device statuses, or an empty list when unavailable
+     */
+    private List<DeviceStatus> getDeviceStatusOrEmpty() {
+        try {
+            List<DeviceStatus> statuses = getDeviceStatus();
+            return statuses != null ? statuses : Collections.emptyList();
+        } catch (Exception e) {
+            logger.warn("Unable to retrieve device status", e);
+            return Collections.emptyList();
+        }
     }
 
     /**


### PR DESCRIPTION
# Fix interface status API failure for removed adapters

## Summary

Prevent getAllInterfacesStatusV2() and getInterfaceStatusV2() from failing when an interface exists in the saved configuration but has been removed from the VM.

## Problem

When a configured adapter such as eth2 is disabled or removed, its stale configuration remains in NGFW. Interface status collection passes the missing device to getStatus(), which throws:

java.lang.RuntimeException: Invalid interface name

This caused the complete interface status API response to fail.

## Changes

  - Add independent exception handling to each status-population method.
  - Return partial status data when an individual status source is unavailable.
  - Continue processing other interfaces when one interface is invalid or unavailable.
  - Handle null or malformed device status safely.
  - Protect numeric parsing from invalid or overflowing values.
  - Harden getInterfaceStatusV2() for null and unavailable data.

## Expected Behavior

If a configured interface is missing at runtime:

  - The API does not throw an unhandled exception.
  - Available interfaces continue to return complete status data.
  - The missing interface returns a partial/default status response.
  - The unavailable interface and failed status sources are logged.