### PR TITLE
NGFW-15965: use /bin/systemctl instead of /usr/bin/systemctl for Bull…

### DIFF
--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnAppImpl.java
@@ -1090,13 +1090,13 @@ public class OpenVpnAppImpl extends AppBase
             if (found == true) {
                 if (enabled == false) {
                     logger.info("Stopping client OpenVPN process for disabled openvpn@{}.service", serverName);
-                    UvmContextFactory.context().execManager().execCommand("/usr/bin/systemctl", List.of("stop", "openvpn@" + serverName + ".service"));
+                    UvmContextFactory.context().execManager().execCommand("/bin/systemctl", List.of("stop", "openvpn@" + serverName + ".service"));
                 }
                 continue;
             }
 
             logger.info("Stopping client OpenVPN process for removed openvpn@{}.service", serverName);
-            UvmContextFactory.context().execManager().execCommand("/usr/bin/systemctl", List.of("stop", "openvpn@" + serverName + ".service"));
+            UvmContextFactory.context().execManager().execCommand("/bin/systemctl", List.of("stop", "openvpn@" + serverName + ".service"));
 
             // no matching server so get rid of the config file and keys
             logger.info("Cleanup removing: {}", target);

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnManager.java
@@ -111,7 +111,7 @@ public class OpenVpnManager
         for (OpenVpnRemoteServer server : app.getSettings().getRemoteServers()) {
             if (!server.getEnabled()) continue;
             logger.debug("Starting client OpenVPN process for openvpn@{}.service", server.getName());
-            UvmContextFactory.context().execManager().execCommand("/usr/bin/systemctl", List.of("start", "openvpn@" + server.getName() + ".service"));
+            UvmContextFactory.context().execManager().execCommand("/bin/systemctl", List.of("start", "openvpn@" + server.getName() + ".service"));
         }
 
         insertIptablesRules();
@@ -130,7 +130,7 @@ public class OpenVpnManager
 
         for (OpenVpnRemoteServer server : app.getSettings().getRemoteServers()) {
             logger.debug("Stopping client OpenVPN process for openvpn@{}.service", server.getName());
-            UvmContextFactory.context().execManager().execCommand("/usr/bin/systemctl", List.of("stop", "openvpn@" + server.getName() + ".service"));
+            UvmContextFactory.context().execManager().execCommand("/bin/systemctl", List.of("stop", "openvpn@" + server.getName() + ".service"));
         }
 
         insertIptablesRules(); // remove since openvpn is not running

--- a/openvpn/src/com/untangle/app/openvpn/OpenVpnMonitor.java
+++ b/openvpn/src/com/untangle/app/openvpn/OpenVpnMonitor.java
@@ -550,7 +550,7 @@ class OpenVpnMonitor implements Runnable
 
             } catch (Exception exn) {
                 logger.warn("OpenVPN process for {} not found. {}. Restarting...", server.getName(), exn.getMessage());
-                UvmContextFactory.context().execManager().execCommand("/usr/bin/systemctl", List.of("restart", "openvpn@" + server.getName() + ".service"));
+                UvmContextFactory.context().execManager().execCommand("/bin/systemctl", List.of("restart", "openvpn@" + server.getName() + ".service"));
             }
             if (reader == null) {
                 continue;

--- a/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
+++ b/uvm/hier/usr/share/untangle/bin/ut-exec-safe-launcher
@@ -27,7 +27,7 @@ ALLOWED_EXECUTABLES = {
     "/usr/share/untangle/bin/openvpn-generate-client-exec",
     "/usr/share/untangle/bin/openvpn-generate-client-ovpn",
     "/usr/share/untangle/bin/openvpn-generate-client-onc",
-    "/usr/bin/systemctl",
+    "/bin/systemctl",
     "/usr/share/untangle/bin/ut-update-hosts-file",
     "/usr/sbin/usermod",
     "/usr/share/untangle/bin/ut-snmp.sh",

--- a/uvm/impl/com/untangle/uvm/DaemonManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/DaemonManagerImpl.java
@@ -387,7 +387,7 @@ public class DaemonManagerImpl extends TimerTask implements DaemonManager
                 reader = UvmContextFactory.context().execManager().execEvil(command);
             } else {
                 reader = UvmContextFactory.context().execManager().execEvil(
-                    new String[] { "/usr/bin/systemctl", command, daemonName });
+                    new String[] { "/bin/systemctl", command, daemonName });
             }
             reader.waitFor();
         } catch (Exception exn) {
@@ -437,7 +437,7 @@ public class DaemonManagerImpl extends TimerTask implements DaemonManager
         } else {
             cmdLabel = "systemctl " + command + " " + daemonName;
             output = UvmContextFactory.context().execManager().execCommand(
-                "/usr/bin/systemctl", List.of(command, daemonName)
+                "/bin/systemctl", List.of(command, daemonName)
             ).getOutput();
         }
         if (log) {

--- a/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
+++ b/uvm/impl/com/untangle/uvm/LocalDirectoryImpl.java
@@ -151,7 +151,7 @@ public class LocalDirectoryImpl implements LocalDirectory
         // by the "net ads" call we made above.
         if (result.getResult() != null && result.getResult() == 0) {
             UvmContextFactory.context().execManager().execCommand(
-                "/usr/bin/systemctl", List.of("restart", "winbind.service"));
+                "/bin/systemctl", List.of("restart", "winbind.service"));
         }
 
         return result;

--- a/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/SystemManagerImpl.java
@@ -1625,7 +1625,7 @@ can look deeper. - mahotz
             List.of("a+r", certBase + ".crt"));
         UvmContextFactory.context().execManager().execCommand("/bin/chmod",
             List.of("a+r", certBase + ".key"));
-        UvmContextFactory.context().execManager().execCommand("/usr/bin/systemctl",
+        UvmContextFactory.context().execManager().execCommand("/bin/systemctl",
             List.of("restart", "freeradius.service"));
     }
 


### PR DESCRIPTION


On Bullseye systems without usrmerge, the systemd package installs systemctl only to /bin/systemctl. The NGFW-15673/15675/15743 RCE hardening commits migrated shell-form exec("systemctl ...") to argv-form with hardcoded /usr/bin/systemctl, which fails on these devices. This breaks Reports (PostgreSQL never starts, all events silently dropped) and can also affect OpenVPN, winbind, and freeradius daemon control.

/bin/systemctl is the canonical Bullseye path and resolves correctly on Bookworm/Trixie (where /bin is symlinked to /usr/bin via usrmerge).