### PR TITLE
Ngfw 15909 vrrp uvm health check

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -382,6 +382,7 @@ Architecture: all
 Conflicts: untangle-libnetfilter-queue-dev, untangle-libnetfilter-queue0
 Depends: ${misc:Depends},
 	 ipset,
+	 curl,
 	 python3,
          python3-pem,
          python3-pyotp,

--- a/uvm/api/com/untangle/uvm/UvmContextFactory.java
+++ b/uvm/api/com/untangle/uvm/UvmContextFactory.java
@@ -10,8 +10,8 @@ import java.lang.reflect.Method;
  */
 public class UvmContextFactory
 {
-    private static UvmContext UVM_CONTEXT = null;
-    private static SafeUvmContext SAFE_UVM_CONTEXT = null;
+    private static volatile UvmContext UVM_CONTEXT = null;
+    private static volatile SafeUvmContext SAFE_UVM_CONTEXT = null;
 
     /**
      * Gets the current state of the UVM.  This provides a way to get

--- a/uvm/api/com/untangle/uvm/network/NetworkSettings.java
+++ b/uvm/api/com/untangle/uvm/network/NetworkSettings.java
@@ -80,6 +80,7 @@ public class NetworkSettings implements Serializable, JSONString
     private boolean logBlockedSessions = false;
     private boolean vlansEnabled = true;
     private int     lxcInterfaceId = 0;
+    private boolean vrrpHealthCheckEnabled = false;
 
     private int httpPort  = 80;
     private int httpsPort = 443;
@@ -240,6 +241,9 @@ public class NetworkSettings implements Serializable, JSONString
     public int getLxcInterfaceId() { return this.lxcInterfaceId; }
     public void setLxcInterfaceId( int newValue ) { this.lxcInterfaceId = newValue; }
 
+    public boolean getVrrpHealthCheckEnabled() { return this.vrrpHealthCheckEnabled; }
+    public void setVrrpHealthCheckEnabled( boolean newValue ) { this.vrrpHealthCheckEnabled = newValue; }
+
     /**
      * This determines the method used to calculate the publicy available URL used to reach Untangle resources
      */
@@ -366,6 +370,7 @@ public class NetworkSettings implements Serializable, JSONString
         netSettingsGen.setLogLocalOutboundSessions(this.getLogLocalOutboundSessions());
         netSettingsGen.setLogLocalInboundSessions(this.getLogLocalInboundSessions());
         netSettingsGen.setLogBlockedSessions(this.getLogBlockedSessions());
+        netSettingsGen.setVrrpHealthCheckEnabled(this.getVrrpHealthCheckEnabled());
         // Custom dnsmasq options for Advanced --> DNS & DHCP Tab
         netSettingsGen.setDnsmasqOptions(this.getDnsmasqOptions());
     }

--- a/uvm/api/com/untangle/uvm/network/generic/NetworkSettingsGeneric.java
+++ b/uvm/api/com/untangle/uvm/network/generic/NetworkSettingsGeneric.java
@@ -60,6 +60,7 @@ public class NetworkSettingsGeneric implements Serializable, JSONString {
     private boolean logLocalOutboundSessions = true;
     private boolean logLocalInboundSessions = false;
     private boolean logBlockedSessions = false;
+    private boolean vrrpHealthCheckEnabled = false;
 
     public NetworkSettingsGeneric() {
         super();
@@ -131,6 +132,8 @@ public class NetworkSettingsGeneric implements Serializable, JSONString {
     public void setLogLocalInboundSessions(boolean logLocalInboundSessions) { this.logLocalInboundSessions = logLocalInboundSessions; }
     public boolean getLogBlockedSessions() { return logBlockedSessions; }
     public void setLogBlockedSessions(boolean logBlockedSessions) { this.logBlockedSessions = logBlockedSessions; }
+    public boolean getVrrpHealthCheckEnabled() { return vrrpHealthCheckEnabled; }
+    public void setVrrpHealthCheckEnabled(boolean vrrpHealthCheckEnabled) { this.vrrpHealthCheckEnabled = vrrpHealthCheckEnabled; }
 
     /**
      * Populates the provided {@link NetworkSettings} instance with data from this
@@ -264,6 +267,7 @@ public class NetworkSettingsGeneric implements Serializable, JSONString {
         networkSettings.setLogLocalOutboundSessions(this.getLogLocalOutboundSessions());
         networkSettings.setLogLocalInboundSessions(this.getLogLocalInboundSessions());
         networkSettings.setLogBlockedSessions(this.getLogBlockedSessions());
+        networkSettings.setVrrpHealthCheckEnabled(this.getVrrpHealthCheckEnabled());
         // Custom dnsmasq options for Advanced --> DNS & DHCP Tab
         networkSettings.setDnsmasqOptions(this.getDnsmasqOptions());
     }

--- a/uvm/hier/usr/share/untangle/bin/vrrp-uvm-status-check.sh
+++ b/uvm/hier/usr/share/untangle/bin/vrrp-uvm-status-check.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Keepalived health check for the local UVM HTTP endpoint.
+# Exit 0 only when UVM returns HTTP 200. Keepalived supplies the
+# consecutive-failure/recovery thresholds; this script performs one bounded
+# request and does not add its own retry delay.
+
+HTTP_CODE=$(/usr/bin/curl --silent --show-error \
+    --connect-timeout 2 \
+    --max-time 2 \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    http://127.0.0.1/uvm/status 2>/dev/null)
+
+if [ "${HTTP_CODE}" = "200" ]; then
+    exit 0
+fi
+
+exit 1

--- a/uvm/hier/usr/share/untangle/conf/apache2/conf.d/health.conf
+++ b/uvm/hier/usr/share/untangle/conf/apache2/conf.d/health.conf
@@ -1,0 +1,6 @@
+# Local UVM status endpoint used by keepalived.
+JkMount /uvm/status uvmWorker
+
+<Location /uvm/status>
+    Require local
+</Location>

--- a/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/NetworkManagerImpl.java
@@ -124,7 +124,7 @@ public class NetworkManagerImpl implements NetworkManager
      * The current network settings
      */
     private NetworkSettings networkSettings;
-    private Integer currentVersion = 12;
+    private Integer currentVersion = 13;
 
     /**
      * This array holds the current interface Settings indexed by the interface ID.
@@ -3458,23 +3458,9 @@ public class NetworkManagerImpl implements NetworkManager
      */
     private void convertSettings()
     {
-        // For 17.5 Vue Migration Changes
-        boolean globalQosEnabled = this.networkSettings.getQosSettings() != null && this.networkSettings.getQosSettings().getQosEnabled();
-        for(InterfaceSettings intfSettings: this.networkSettings.getInterfaces()) {
-            // Set generic config type for Vue response config type.
-            InterfaceSettingsGeneric.ConfigType configTypeGeneric =
-                    (intfSettings.getConfigType() != ConfigType.DISABLED)
-                            ? InterfaceSettingsGeneric.ConfigType.valueOf(intfSettings.getConfigType().name())
-                            : InterfaceSettingsGeneric.ConfigType.ADDRESSED;
-            intfSettings.setConfigTypeGeneric(configTypeGeneric);
+        // For 18.0 initialize the optional VRRP UVM health check as disabled
+        this.networkSettings.setVrrpHealthCheckEnabled(false);
 
-            // If global QOS is enabled and interface have non zero band width set qosEnabled true for that interface
-            if(intfSettings.getIsWan() && globalQosEnabled) {
-                boolean qosEnabled = intfSettings.getDownloadBandwidthKbps() != null && intfSettings.getDownloadBandwidthKbps() != 0
-                        && intfSettings.getUploadBandwidthKbps() != null && intfSettings.getUploadBandwidthKbps() != 0;
-                intfSettings.setQosEnabled(qosEnabled);
-            }
-        }
         // Set new version
         this.networkSettings.setVersion( currentVersion );
         this.setNetworkSettings( this.networkSettings, false );

--- a/uvm/impl/com/untangle/uvm/TomcatManagerImpl.java
+++ b/uvm/impl/com/untangle/uvm/TomcatManagerImpl.java
@@ -113,6 +113,8 @@ public class TomcatManagerImpl implements TomcatManager
 
         ctx = loadServlet("/blockpage", "blockpage");
 
+        ctx = loadServlet("/uvm", "health");
+
         ctx = loadServlet("/gdrive", "gdrive");
 
         ctx = loadServlet("/support", "support", true);

--- a/uvm/impl/com/untangle/uvm/UvmContextImpl.java
+++ b/uvm/impl/com/untangle/uvm/UvmContextImpl.java
@@ -89,7 +89,7 @@ public class UvmContextImpl extends UvmContextBase implements UvmContext
     private static String applianceModel = null;
     private static int threadNumber = 1;
 
-    private UvmState state;
+    private volatile UvmState state;
     private AdminManagerImpl adminManager;
     private LoggingManagerImpl loggingManager;
     private MailSenderImpl mailSender;

--- a/uvm/package.rb
+++ b/uvm/package.rb
@@ -48,6 +48,8 @@ deps=[]
 
 ServletBuilder.new(uvm_lib, "com.untangle.uvm.support.servlet", ["./uvm/servlets/support"], deps)
 
+ServletBuilder.new(uvm_lib, "com.untangle.uvm.health.servlet", ["./uvm/servlets/health"], deps)
+
 ServletBuilder.new(uvm_lib, "com.untangle.uvm.gdrive.servlet", ["./uvm/servlets/gdrive"], deps)
 
 ServletBuilder.new(uvm_lib, "com.untangle.uvm.admin.servlet", ["./uvm/servlets/admin"], deps + Jars::Jstl)

--- a/uvm/servlets/health/root/WEB-INF/web.xml
+++ b/uvm/servlets/health/root/WEB-INF/web.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd" version="3.0" metadata-complete="true">
+
+  <display-name>UVM Health</display-name>
+
+  <servlet>
+    <servlet-name>UvmStatusHandler</servlet-name>
+    <servlet-class>com.untangle.uvm.health.UvmStatusHandler</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>UvmStatusHandler</servlet-name>
+    <url-pattern>/status</url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/uvm/servlets/health/src/com/untangle/uvm/health/UvmStatusHandler.java
+++ b/uvm/servlets/health/src/com/untangle/uvm/health/UvmStatusHandler.java
@@ -1,0 +1,61 @@
+/**
+ * $Id: UvmStatusHandler.java $
+ */
+package com.untangle.uvm.health;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.untangle.uvm.UvmContextFactory;
+import com.untangle.uvm.UvmState;
+
+/**
+ * Minimal local UVM status endpoint used by keepalived.
+ *
+ * HTTP 200 means the UVM request path is responsive and the UVM lifecycle
+ * state is RUNNING. All other responses are unhealthy.
+ */
+@SuppressWarnings("serial")
+public class UvmStatusHandler extends HttpServlet
+{
+    private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
+
+    /**
+     * Perform HTTP GET operation
+     * @param request HTTP request
+     * @param response HTTP response
+     * @throws ServletException Servlet exception
+     * @throws IOException IO exception
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+        throws ServletException, IOException
+    {
+        UvmState state;
+        try {
+            // Do not call context(); the status check must not initialize UVM
+            // or perform any other application work.
+            state = UvmContextFactory.state();
+        } catch (Throwable exn) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        boolean healthy = (state == UvmState.RUNNING);
+        response.setStatus(healthy ? HttpServletResponse.SC_OK : HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        response.setContentType(JSON_CONTENT_TYPE);
+        response.setHeader("Cache-Control", "no-store");
+
+        PrintWriter writer = response.getWriter();
+        writer.print("{\"state\":\"");
+        writer.print(state == null ? "unknown" : state.toString());
+        writer.print("\",\"healthy\":");
+        writer.print(healthy ? "true" : "false");
+        writer.println("}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a local UVM health endpoint and keepalived health-check helper so VRRP can detect an unresponsive or unhealthy UVM process.

Previously, keepalived only monitored VRRP/network availability. A hung UVM process could therefore continue advertising MASTER while traffic processing was unavailable. The new
health check validates both UVM responsiveness and lifecycle state before considering the node healthy.

## Changes

- Added GET /uvm/status local health endpoint.
    - Returns HTTP 200 only when UVM is in RUNNING state.
    - Returns a non-200 response during startup, shutdown, failure, or unavailable states.
    - Uses Cache-Control: no-store.
    - Does not initialize UVM or perform application work.

- Made the UVM lifecycle state volatile for reliable visibility across request and lifecycle threads.
- Registered and packaged the health servlet.
- Added Apache routing for /uvm/status.
    - Endpoint is restricted to local requests.

- Added vrrp-uvm-status-check.sh.
    - Returns success only for HTTP 200.
    - Uses bounded curl timeouts.
    - Uses /bin/curl with a 1-second connection timeout and 2-second total timeout.
    - Does not retry or introduce additional delays.

- Added the curl package dependency.
- Added vrrpHealthCheckEnabled to legacy and generic network settings.
    - Defaults to disabled for backward compatibility.
    - Included in legacy/generic settings conversion.

- Updated network settings version to 13.
- Preserved existing VRRP priorities, state MASTER generation, sync-group behavior, and failback behavior.
- Added ATS Tests.

## Expected VRRP Behavior

When enabled and integrated with keepalived:

- UVM startup and shutdown states are treated as unhealthy.
- A hung, stopped, or OOM-affected UVM process causes the health check to fail.
- After the configured failure threshold, keepalived places the affected VRRP instance into FAULT.
- VIPs are withdrawn from the unhealthy node.
- The peer becomes MASTER and acquires the VIPs.
- After UVM recovers and satisfies the recovery threshold, normal VRRP failback occurs.


## Testing

### Completed scenarios

- Freeze the UVM JVM with SIGSTOP.
    - Health endpoint became unavailable/non-200.
    - VRRP failed over to the secondary node.
    - VIPs were withdrawn from the unhealthy node.
    - VRRP recovered after UVM was resumed.

- Stop and start UVM.
    - The primary entered FAULT.
    - The secondary acquired the VIPs.
    - Normal failback occurred after UVM became healthy.

- Restart UVM.
    - Verified failover during restart.
    - Verified recovery after the configured rise threshold.
    - Verified automatic failback.

- Simulate Java heap exhaustion.
    - UVM health checks failed during OOM conditions.
    - VRRP withdrew the VIPs and failed over.
    - Normal operation and failback were verified after recovery.

- Validate the local endpoint and helper:
    - HTTP 200 for a responsive RUNNING UVM.
    - Non-200 response when UVM is unavailable or not running.
    - Helper exits 0 only for HTTP 200.
    - Helper exits 1 for timeout, connection failure, or non-200 response.

### Additional VRRP interface scenarios

The following scenarios will also be validated:

- VRRP configured on a PPPoE interface.
    - Verify health-check execution and failover across PPPoE reconnection and UVM failure.
    - Verify VIP withdrawal and recovery after the PPPoE interface is restored.

- VRRP configured on a VLAN interface.
    - Verify failover with VLAN-tagged traffic.
    - Verify VIP ownership changes correctly on the VLAN interface.
    - Verify recovery and automatic failback after UVM becomes healthy.

- Multiple VRRP instances using different interface types.
    - Verify all instances use the same UVM health result.
    - Verify synchronized VIP failover and recovery.

## Compatibility and Safety

- The health check is disabled by default.
- Existing settings without vrrpHealthCheckEnabled remain valid.
- Existing VRRP priorities, sync groups, and automatic failback behavior are preserved.
- The endpoint is local-only and exposes only minimal health information.
- The helper performs one bounded request per invocation and does not retry.

## Review Note

This change adds the UVM health endpoint, settings support, packaging, and helper script. The sync-settings VRRP generator will emit the shared vrrp_script and reference it from
every generated vrrp_instance when `vrrpHealthCheckEnabled` is enabled. 
`sync-settings` Review Request - https://gerrit.corp.arista.io/c/efw/sync-settings/+/803315 